### PR TITLE
Passed props should override defaults

### DIFF
--- a/src/image.jsx
+++ b/src/image.jsx
@@ -10,7 +10,7 @@ class Image extends Base {
       display: this.props.display || ""
     };
     return (
-      <img src={this.props.src} style={assign({}, styles, this.context.styles.components.image, this.getStyles())}/>
+      <img src={this.props.src} style={assign({}, this.context.styles.components.image, this.getStyles(), styles)}/>
     );
   }
 }


### PR DESCRIPTION
The way it is now if you try to set the `display` property of an `Image` it is overwritten by the defaults.

This PR moves the styles from props to the end of the assign call they will always override the defaults.