### PR TITLE
Correct typo in imports

### DIFF
--- a/src/spectacle.jsx
+++ b/src/spectacle.jsx
@@ -9,7 +9,7 @@ import Fit from './fit';
 import Heading from './heading';
 import Image from './image';
 import Layout from './layout';
-import Link from './Link';
+import Link from './link';
 import ListItem from './list-item';
 import List from './list';
 import Quote from './quote';


### PR DESCRIPTION
This typo makes the import not work on my machine

Some versions of what I use:
```
node v0.10.25
npm 1.3.10
webpack 1.10.1
```