### PR TITLE
Adds Surge as a development dependency for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "webpack": "^1.10.0",
     "webpack-dev-server": "^1.10.0",
     "yeticss": "^6.0.7"
+  },
+  "devDependencies": {
+    "surge": "latest"
   }
 }


### PR DESCRIPTION
If you don’t already have Surge installed with `npm install -g surge`, the `npm run deploy` command will fail. This fixes the issue by adding `surge` as a `devDependency` in the `package.json`.