### PR TITLE
Fix hot loading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,4 +16,8 @@ webpackConfig.module.loaders[0] = {
   ]
 }
 
+if (process.argv[1].indexOf('webpack-dev-server') !== -1) {
+  webpackConfig.module.loaders[0].loaders.unshift('react-hot')
+}
+
 module.exports = webpackConfig;


### PR DESCRIPTION
Hot loading was broken in [this commit](https://github.com/FormidableLabs/spectacle/commit/12831ca2bfdced87ec8d00a7b3292bf3f796db4a)

`hjs-webpack` enables hotloading when running with `webpack-dev-server` [here](https://github.com/HenrikJoreteg/hjs-webpack/blob/a8d771bd99870706e7f0e20a69aea89c6c836d92/index.js#L106)

This PR will always leave hot loading on.
If you'd like I can only turn on hot loading when running with `webpack-dev-server` the same way that `hjs-webpack` does it by wrapping in an if `isDev` where ...
`var isDev = process.argv[1].indexOf('webpack-dev-server') !== -1`

Lemme know and I'll update the PR...