### PR TITLE
add support for page up & page down

### DIFF
--- a/src/deck.jsx
+++ b/src/deck.jsx
@@ -49,10 +49,12 @@ class Deck extends React.Component {
   }
   _handleKeyPress(e) {
     const event = window.event ? window.event : e;
-    if (event.keyCode === 37) {
+    // left, page down
+    if (event.keyCode === 37 || event.keyCode === 33) {
       this._prevSlide();
     }
-    if (event.keyCode === 39) {
+    // right, page up
+    if (event.keyCode === 39 || event.keyCode === 34) {
       this._nextSlide();
     }
   }


### PR DESCRIPTION
Just gave a talk with one of those presenter remotes and it used page up and page down to move through the slides.

I threw this in before the talk and it went great :smile: 

The same presenter remote worked fine with [reveal.js](https://github.com/hakimel/reveal.js/blob/eff2265bbd6d892ae2316edff748754b4b0c4798/js/reveal.js#L3808-L3811) so i'm assuming its standard.