### PR TITLE
Change keys for Presenter and Overview

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ Check it out:
 
 ![http://i.imgur.com/H7o2qHI.gif](http://i.imgur.com/H7o2qHI.gif_)
 
-You can toggle the presenter or overview mode by pressing respectively `p` and `o`.
+You can toggle the presenter or overview mode by pressing respectively `alt+p` and `alt+o`.
 
 ## PDF Export
 

--- a/src/deck.jsx
+++ b/src/deck.jsx
@@ -58,10 +58,10 @@ class Deck extends React.Component {
     if (event.keyCode === 39 || event.keyCode === 34) {
       this._nextSlide();
     }
-    if (event.keyCode === 79 && !event.ctrlKey && !event.metaKey) { // o
+    if ((event.altKey && event.keyCode === 79) && !event.ctrlKey && !event.metaKey) { // o
       this._toggleOverviewMode();
     }
-    if (event.keyCode === 80 && !event.ctrlKey && !event.metaKey) { // o
+    if ((event.altKey && event.keyCode === 80) && !event.ctrlKey && !event.metaKey) { // p
       this._togglePresenterMode();
     }
   }


### PR DESCRIPTION
The o key and p key currently drive the overview and presenter views.

This poses a problem when building an interactive component with a textbox or textarea within a slide. If the o or p key is pressed while in a text input, the slideshow will go into that mode, which may be unexpected behavior to a lot of people.

This pull request requires the alt key to be pressed in conjunction with the p key and the
o to trigger the overview and presenter views.