### PR TITLE
Use relative em units

### DIFF
--- a/themes/default/index.js
+++ b/themes/default/index.js
@@ -115,7 +115,7 @@ module.exports = {
       paddingLeft: 40,
       display: "block",
       color: colors.primary,
-      fontSize: "4.9em",
+      fontSize: "4.9rem",
       lineHeight: 1,
       fontWeight: "bold"
     },
@@ -123,8 +123,8 @@ module.exports = {
       color: colors.tertiary,
       display: "block",
       clear: "left",
-      fontSize: "2em",
-      marginTop: "1em"
+      fontSize: "2rem",
+      marginTop: "1rem"
     },
     content: {
       margin: "0 auto",
@@ -133,7 +133,7 @@ module.exports = {
     codePane: {
       pre: {
         margin: "auto",
-        fontSize: "1em",
+        fontSize: "1rem",
         fontWeight: "normal",
         fontFamily: fonts.tertiary,
         minWidth: "100%",
@@ -147,9 +147,9 @@ module.exports = {
     },
     code: {
       color: "black",
-      fontSize: "2.66em",
+      fontSize: "2.66rem",
       fontFamily: fonts.tertiary,
-      margin: "0.25em auto",
+      margin: "0.25rem auto",
       backgroundColor: "rgba(0,0,0,0.15)",
       padding: "0 10px",
       borderRadius: 3
@@ -157,7 +157,7 @@ module.exports = {
     heading: {
       h1: {
         color: colors.tertiary,
-        fontSize: "7.05em",
+        fontSize: "7.05rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
@@ -166,7 +166,7 @@ module.exports = {
       },
       h2: {
         color: colors.secondary,
-        fontSize: "5.88em",
+        fontSize: "5.88rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
@@ -174,46 +174,46 @@ module.exports = {
       },
       h3: {
         color: "black",
-        fontSize: "4.9em",
+        fontSize: "4.9rem",
         fontFamily: fonts.secondary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h4: {
         color: "black",
-        fontSize: "3.82em",
+        fontSize: "3.82rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h5: {
         color: "black",
-        fontSize: "3.19em",
+        fontSize: "3.19rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h6: {
         color: "black",
-        fontSize: "2.66em",
+        fontSize: "2.66rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       }
     },
     image: {
       display: "block",
-      margin: "0.5em auto"
+      margin: "0.5rem auto"
     },
     link: {
       textDecoration: "none"
     },
     listItem: {
-      fontSize: "2.66em"
+      fontSize: "2.66rem"
     },
     list: {
       textAlign: "left",
@@ -225,9 +225,9 @@ module.exports = {
     },
     text: {
       color: "black",
-      fontSize: "2.66em",
+      fontSize: "2.66rem",
       fontFamily: fonts.primary,
-      margin: "0.25em auto"
+      margin: "0.25rem auto"
     }
   }
 };

--- a/themes/default/print.js
+++ b/themes/default/print.js
@@ -42,7 +42,7 @@ module.exports = {
       paddingLeft: 40,
       display: "block",
       color: "black",
-      fontSize: "4.9em",
+      fontSize: "4.9rem",
       lineHeight: 1,
       fontWeight: "bold"
     },
@@ -50,8 +50,8 @@ module.exports = {
       color: "black",
       display: "block",
       clear: "left",
-      fontSize: "2em",
-      marginTop: "1em"
+      fontSize: "2rem",
+      marginTop: "1rem"
     },
     content: {
       margin: "auto",
@@ -61,7 +61,7 @@ module.exports = {
       pre: {
         maxWidth: 800,
         margin: "auto",
-        fontSize: "1em",
+        fontSize: "1rem",
         fontWeight: "normal",
         fontFamily: fonts.tertiary
       },
@@ -73,9 +73,9 @@ module.exports = {
     },
     code: {
       color: "black",
-      fontSize: "2.66em",
+      fontSize: "2.66rem",
       fontFamily: fonts.tertiary,
-      margin: "0.25em auto",
+      margin: "0.25rem auto",
       backgroundColor: "rgba(0,0,0,0.15)",
       padding: "0 10px",
       borderRadius: 3
@@ -83,7 +83,7 @@ module.exports = {
     heading: {
       h1: {
         color: "black",
-        fontSize: "7.05em",
+        fontSize: "7.05rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
@@ -91,7 +91,7 @@ module.exports = {
       },
       h2: {
         color: "black",
-        fontSize: "5.88em",
+        fontSize: "5.88rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
@@ -99,46 +99,46 @@ module.exports = {
       },
       h3: {
         color: "black",
-        fontSize: "4.9em",
+        fontSize: "4.9rem",
         fontFamily: fonts.secondary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h4: {
         color: "black",
-        fontSize: "3.82em",
+        fontSize: "3.82rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h5: {
         color: "black",
-        fontSize: "3.19em",
+        fontSize: "3.19rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       },
       h6: {
         color: "black",
-        fontSize: "2.66em",
+        fontSize: "2.66rem",
         fontFamily: fonts.primary,
         lineHeight: 1,
         fontWeight: "bold",
-        margin: "0.5em auto"
+        margin: "0.5rem auto"
       }
     },
     image: {
       display: "block",
-      margin: "0.5em auto"
+      margin: "0.5rem auto"
     },
     link: {
       textDecoration: "none"
     },
     listItem: {
-      fontSize: "2.66em"
+      fontSize: "2.66rem"
     },
     list: {
       textAlign: "left",
@@ -150,9 +150,9 @@ module.exports = {
     },
     text: {
       color: "black",
-      fontSize: "2.66em",
+      fontSize: "2.66rem",
       fontFamily: fonts.primary,
-      margin: "0.25em auto"
+      margin: "0.25rem auto"
     }
   }
 };


### PR DESCRIPTION
This PR replaces `em` with `rem`. This fixes the font styling of inline code (#88) and nested lists (#75).