### PR TITLE
Add presenter query param to presenter link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ To present:
 
 - Run `npm start`
 - Open two browser windows on two different screens
-- On your screen visit [http://localhost:3000/#/?presenter](http://localhost:3000/#/)
+- On your screen visit [http://localhost:3000/#/?presenter](http://localhost:3000/#/?presenter)
 - On the presentation screen visit [http://localhost:3000/#/](http://localhost:3000/#/)
 - Give an amazingly stylish presentation
 


### PR DESCRIPTION
Quick fix on the link link to http://localhost:3000/#/?presenter – didn't have the query param in the `href`, now it does. :smile: 