### PR TITLE
Fix import statement for lodash/lang/isUndefined

### DIFF
--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from "react";
 import highlight from "highlight.js";
 import { getStyles } from "../utils/base";
 import Radium from "radium";
-import isUndefined from "lodash/lang/isundefined";
+import { isUndefined } from "lodash";
 
 @Radium
 export default class CodePane extends Component {

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import mdast from "mdast";
 import mdastReact from "mdast-react";
-import isUndefined from "lodash/lang/isundefined";
+import { isUndefined } from "lodash";
 
 import BlockQuote from "./block-quote";
 import CodePane from "./code-pane";


### PR DESCRIPTION
When running `npm start` I got an error that `lodash/lang/isundefined` could not be resolved (used in `code-pane.js` and `markdown.js`).
I'm not sure why it couldn't resolve it (the path seems to be right), but this PR fixes it.