### PR TITLE
styleBase + propTypesBase

### DIFF
--- a/src/components/block-quote.js
+++ b/src/components/block-quote.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class BlockQuote extends Component {
@@ -13,10 +13,10 @@ export default class BlockQuote extends Component {
   }
 }
 
-BlockQuote.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+BlockQuote.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 BlockQuote.contextTypes = {
   styles: PropTypes.object

--- a/src/components/block-quote.js
+++ b/src/components/block-quote.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class BlockQuote extends Component {
   render() {
     return (
-      <blockquote style={[this.context.styles.components.blockquote, getStyles.call(this), this.props.style]}>
+      <blockquote style={[this.context.styles.components.blockquote, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </blockquote>
     );

--- a/src/components/cite.js
+++ b/src/components/cite.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Cite extends Component {
   render() {
     return (
-      <cite style={[this.context.styles.components.cite, getStyles.call(this), this.props.style]}>
+      <cite style={[this.context.styles.components.cite, styleBase(this.props, this.context), this.props.style]}>
         - {this.props.children}
       </cite>
     );

--- a/src/components/cite.js
+++ b/src/components/cite.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Cite extends Component {
@@ -13,10 +13,10 @@ export default class Cite extends Component {
   }
 }
 
-Cite.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+Cite.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 Cite.contextTypes = {
   styles: PropTypes.object

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
 import { isUndefined } from "lodash";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 const format = (str) => {
   return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -36,12 +36,12 @@ CodePane.contextTypes = {
   styles: PropTypes.object
 };
 
-CodePane.propTypes = {
+CodePane.propTypes = Object.assign({}, propTypesBase, {
   lang: PropTypes.string,
   source: PropTypes.string,
   style: PropTypes.object,
   children: PropTypes.node
-};
+});
 
 CodePane.defaultProps = {
   lang: "markup",

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
 import { isUndefined } from "lodash";
+import { styleBase } from "../utils/base";
 
 const format = (str) => {
   return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -21,7 +21,7 @@ export default class CodePane extends Component {
   }
   render() {
     return (
-      <pre style={[this.context.styles.components.codePane.pre, getStyles.call(this), this.props.style]}>
+      <pre style={[this.context.styles.components.codePane.pre, styleBase(this.props, this.context), this.props.style]}>
         <code
           className={`language-${this.props.lang}`}
           style={this.context.styles.components.codePane.code}

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Code extends Component {
   render() {
     return (
-      <code style={[this.context.styles.components.code, getStyles.call(this), this.props.style]}>
+      <code style={[this.context.styles.components.code, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </code>
     );

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Code extends Component {
@@ -13,10 +13,10 @@ export default class Code extends Component {
   }
 }
 
-Code.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+Code.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 Code.contextTypes = {
   styles: PropTypes.object

--- a/src/components/fill.js
+++ b/src/components/fill.js
@@ -16,6 +16,6 @@ export default class Fill extends Component {
 }
 
 Fill.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
+  style: PropTypes.object,
+  children: PropTypes.node
 };

--- a/src/components/fit.js
+++ b/src/components/fit.js
@@ -16,6 +16,6 @@ export default class Fit extends Component {
 }
 
 Fit.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
+  style: PropTypes.object,
+  children: PropTypes.node
 };

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -1,6 +1,6 @@
 import React, { Component, createElement, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Heading extends Component {
@@ -66,7 +66,7 @@ export default class Heading extends Component {
           ref="container"
           style={[
             this.context.styles.components.heading[`h${size}`],
-            getStyles.call(this), styles.container
+            styleBase(this.props, this.context), styles.container
           ]}
         >
           <span ref="text" style={[styles.text, style]}>
@@ -75,7 +75,7 @@ export default class Heading extends Component {
         </div>
       ) : (
         createElement(Tag, {
-          style: [this.context.styles.components.heading[`h${size}`], getStyles.call(this), styles.nonFit, style]
+          style: [this.context.styles.components.heading[`h${size}`], styleBase(this.props, this.context), styles.nonFit, style]
         }, children)
       )
     );

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -1,6 +1,6 @@
 import React, { Component, createElement, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Heading extends Component {
@@ -87,13 +87,13 @@ Heading.defaultProps = {
   lineHeight: 1
 };
 
-Heading.propTypes = {
-  children: PropTypes.node,
+Heading.propTypes = Object.assign({}, propTypesBase, {
   fit: PropTypes.bool,
+  lineHeight: PropTypes.number,
   size: PropTypes.number,
   style: PropTypes.object,
-  lineHeight: PropTypes.number
-};
+  children: PropTypes.node
+});
 
 Heading.contextTypes = {
   styles: PropTypes.object

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Image extends Component {
@@ -24,7 +24,7 @@ export default class Image extends Component {
   }
 }
 
-Image.propTypes = {
+Image.propTypes = Object.assign({}, propTypesBase, {
   width: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
@@ -36,7 +36,7 @@ Image.propTypes = {
   display: PropTypes.string,
   src: PropTypes.string,
   style: PropTypes.object
-};
+});
 
 Image.contextTypes = {
   styles: PropTypes.object

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Image extends Component {
@@ -15,7 +15,7 @@ export default class Image extends Component {
         src={this.props.src}
         style={[
           this.context.styles.components.image,
-          getStyles.call(this),
+          styleBase(this.props, this.context),
           styles,
           this.props.style
         ]}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -16,6 +16,6 @@ export default class Layout extends Component {
 }
 
 Layout.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
+  style: PropTypes.object,
+  children: PropTypes.node
 };

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Link extends Component {
@@ -13,12 +13,12 @@ export default class Link extends Component {
   }
 }
 
-Link.propTypes = {
-  children: PropTypes.node,
+Link.propTypes = Object.assign({}, propTypesBase, {
   href: PropTypes.string,
   target: PropTypes.string,
-  style: PropTypes.object
-};
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 Link.contextTypes = {
   styles: PropTypes.object

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Link extends Component {
   render() {
     return (
-      <a href={this.props.href} target={this.props.target} style={[this.context.styles.components.link, getStyles.call(this), this.props.style]}>
+      <a href={this.props.href} target={this.props.target} style={[this.context.styles.components.link, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </a>
     );

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class ListItem extends Component {
   render() {
     return (
-      <li style={[this.context.styles.components.listItem, getStyles.call(this), this.props.style]}>
+      <li style={[this.context.styles.components.listItem, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </li>
     );

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class ListItem extends Component {
@@ -13,10 +13,10 @@ export default class ListItem extends Component {
   }
 }
 
-ListItem.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+ListItem.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 ListItem.contextTypes = {
   styles: PropTypes.object

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import { styleBase } from "../utils/base";
 import Radium from "radium";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class List extends Component {
@@ -13,10 +13,10 @@ export default class List extends Component {
   }
 }
 
-List.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+List.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 List.contextTypes = {
   styles: PropTypes.object

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
+import { styleBase } from "../utils/base";
 import Radium from "radium";
 
 @Radium
 export default class List extends Component {
   render() {
     return (
-      <ul style={[this.context.styles.components.list, getStyles.call(this), this.props.style]}>
+      <ul style={[this.context.styles.components.list, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </ul>
     );

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -81,9 +81,9 @@ export default class Markdown extends React.Component {
 }
 
 Markdown.propTypes = {
-  children: PropTypes.node,
   source: PropTypes.string,
-  mdastConfig: PropTypes.object
+  mdastConfig: PropTypes.object,
+  children: PropTypes.node
 };
 
 Markdown.defaultProps = {

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 const animations = {
   pacmanTopFrames: Radium.keyframes({
@@ -104,11 +104,11 @@ export default class Progress extends Component {
 
 }
 
-Progress.propTypes = {
+Progress.propTypes = Object.assign({}, propTypesBase, {
   items: PropTypes.array,
   currentSlide: PropTypes.number,
   type: PropTypes.oneOf(["pacman", "bar", "number", "none"])
-};
+});
 
 Progress.contextTypes = {
   styles: PropTypes.object

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 const animations = {
   pacmanTopFrames: Radium.keyframes({
@@ -65,7 +65,7 @@ export default class Progress extends Component {
         return false;
     }
     return (
-      <div style={[getStyles.call(this)]}>
+      <div style={[styleBase(this.props, this.context)]}>
         <div style={[style.container]}>
           {markup}
         </div>

--- a/src/components/quote.js
+++ b/src/components/quote.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Quote extends Component {
@@ -13,10 +13,10 @@ export default class Quote extends Component {
   }
 }
 
-Quote.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object
-};
+Quote.propTypes = Object.assign({}, propTypesBase, {
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 Quote.contextTypes = {
   styles: PropTypes.object

--- a/src/components/quote.js
+++ b/src/components/quote.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Quote extends Component {
   render() {
     return (
-      <span style={[this.context.styles.components.quote, getStyles.call(this), this.props.style]}>
+      <span style={[this.context.styles.components.quote, styleBase(this.props, this.context), this.props.style]}>
         {this.props.children}
       </span>
     );

--- a/src/components/s.js
+++ b/src/components/s.js
@@ -27,12 +27,12 @@ export default class S extends Component {
 }
 
 S.propTypes = {
-  children: PropTypes.node,
-  style: PropTypes.object,
   type: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.array
-  ])
+  ]),
+  style: PropTypes.object,
+  children: PropTypes.node
 };
 
 S.contextTypes = {

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import tweenState from "react-tween-state";
-import { styleBase } from "../utils/base";
+import { styleBase /* , propTypesBase */ } from "../utils/base";
 import Transitions from "./transitions";
 import radium from "radium";
 import { addFragment } from "../actions";
@@ -14,18 +14,23 @@ const Slide = React.createClass({
       presenterStyle: {}
     };
   },
+  // TODO: Object.assign({}, propTypesBase, { ... })
   propTypes: {
     align: PropTypes.string,
+    transition: PropTypes.array,
+    transitionDuration: PropTypes.number,
+    notes: PropTypes.string,
+    id: PropTypes.string,
+    // TODO: elsewhere margin can be either number OR string
+    margin: PropTypes.number,
     dispatch: PropTypes.func,
     hash: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     presenterStyle: PropTypes.object,
     maxHeight: PropTypes.number,
     maxWidth: PropTypes.number,
-    margin: PropTypes.number,
-    children: PropTypes.node,
-    notes: PropTypes.string,
     slideIndex: PropTypes.number,
-    lastSlide: PropTypes.number
+    lastSlide: PropTypes.number,
+    children: PropTypes.node
   },
   contextTypes: {
     styles: PropTypes.object,

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import tweenState from "react-tween-state";
-import { getStyles } from "../utils/base";
+import { styleBase } from "../utils/base";
 import Transitions from "./transitions";
 import radium from "radium";
 import { addFragment } from "../actions";
@@ -118,7 +118,7 @@ const Slide = React.createClass({
         ref="slide"
         style={[
           styles.outer,
-          getStyles.call(this),
+          styleBase(this.props, this.context),
           this.getTransitionStyles(),
           printStyles,
           presenterStyle

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import { getStyles } from "../utils/base";
 import Radium from "radium";
+import { styleBase } from "../utils/base";
 
 @Radium
 export default class Text extends Component {
@@ -63,7 +63,7 @@ export default class Text extends Component {
       fit ? (
         <div
           ref="container"
-          style={[this.context.styles.components.text, getStyles.call(this), styles.container]}
+          style={[this.context.styles.components.text, styleBase(this.props, this.context), styles.container]}
         >
           <span
             ref="text"
@@ -73,7 +73,7 @@ export default class Text extends Component {
           </span>
         </div>
       ) : (
-        <p style={[this.context.styles.components.text, getStyles.call(this), styles.nonFit, style]}>
+        <p style={[this.context.styles.components.text, styleBase(this.props, this.context), styles.nonFit, style]}>
           {this.props.children}
         </p>
       )

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import Radium from "radium";
-import { styleBase } from "../utils/base";
+import { styleBase, propTypesBase } from "../utils/base";
 
 @Radium
 export default class Text extends Component {
@@ -85,12 +85,12 @@ Text.defaultProps = {
   lineHeight: 1
 };
 
-Text.propTypes = {
+Text.propTypes = Object.assign({}, propTypesBase, {
   fit: PropTypes.bool,
-  children: PropTypes.node,
   lineHeight: PropTypes.number,
-  style: PropTypes.object
-};
+  style: PropTypes.object,
+  children: PropTypes.node
+});
 
 Text.contextTypes = {
   styles: PropTypes.object

--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -1,80 +1,80 @@
 /*eslint max-statements:0,complexity:0,no-invalid-this:0*/
 
-export const getStyles = function getStyles() {
-  const {
-    italic,
-    bold,
-    caps,
-    margin,
-    padding,
-    textColor,
-    textFont,
-    textSize,
-    textAlign,
-    bgColor,
-    bgImage,
-    bgDarken
-  } = this.props;
-
-  const styles = {};
+// render() { return (<tag style={[..., styleBase(this.props, this.context), ...]}></tag>); }
+export const styleBase = function styleBase({
+  italic,
+  bold,
+  caps,
+  margin,
+  padding,
+  textColor,
+  textFont,
+  textSize,
+  textAlign,
+  bgColor,
+  bgImage,
+  bgDarken
+}, {
+  styles
+}) {
+  const style = {};
   if (typeof italic === "boolean") {
-    styles.fontStyle = italic ? "italic" : "normal";
+    style.fontStyle = italic ? "italic" : "normal";
   }
   if (typeof bold === "boolean") {
-    styles.fontWeight = bold ? "bold" : "normal";
+    style.fontWeight = bold ? "bold" : "normal";
   }
   if (typeof caps === "boolean") {
-    styles.textTransform = caps ? "uppercase" : "none";
+    style.textTransform = caps ? "uppercase" : "none";
   }
   if (margin) {
-    styles.margin = margin;
+    style.margin = margin;
   }
   if (padding) {
-    styles.padding = padding;
+    style.padding = padding;
   }
   if (textColor) {
     let color = "";
-    if (!this.context.styles.colors.hasOwnProperty(textColor)) {
+    if (!styles.colors.hasOwnProperty(textColor)) {
       color = textColor;
     } else {
-      color = this.context.styles.colors[textColor];
+      color = styles.colors[textColor];
     }
-    styles.color = color;
+    style.color = color;
   }
   if (textFont) {
     let font = "";
-    if (!this.context.styles.fonts.hasOwnProperty(textFont)) {
+    if (!styles.fonts.hasOwnProperty(textFont)) {
       font = textFont;
     } else {
-      font = this.context.styles.fonts[textFont];
+      font = styles.fonts[textFont];
     }
-    styles.fontFamily = font;
+    style.fontFamily = font;
   }
   if (textSize) {
-    styles.fontSize = textSize;
+    style.fontSize = textSize;
   }
   if (textAlign) {
-    styles.textAlign = textAlign;
+    style.textAlign = textAlign;
   }
   if (bgColor) {
     let color = "";
-    if (!this.context.styles.colors.hasOwnProperty(bgColor)) {
+    if (!styles.colors.hasOwnProperty(bgColor)) {
       color = bgColor;
     } else {
-      color = this.context.styles.colors[bgColor];
+      color = styles.colors[bgColor];
     }
-    styles.backgroundColor = color;
+    style.backgroundColor = color;
   }
   if (bgImage) {
     if (bgDarken) {
-      styles.backgroundImage =
+      style.backgroundImage =
       `linear-gradient( rgba(0, 0, 0, ${bgDarken}), rgba(0, 0, 0, ${bgDarken}) ), url(${bgImage})`;
     } else {
-      styles.backgroundImage = `url(${bgImage})`;
+      style.backgroundImage = `url(${bgImage})`;
     }
-    styles.backgroundSize = "cover";
-    styles.backgroundPosition = "center center";
+    style.backgroundSize = "cover";
+    style.backgroundPosition = "center center";
   }
-  return styles;
+  return style;
 };
-

--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -1,4 +1,5 @@
 /*eslint max-statements:0,complexity:0,no-invalid-this:0*/
+import { PropTypes } from "react";
 
 // render() { return (<tag style={[..., styleBase(this.props, this.context), ...]}></tag>); }
 export const styleBase = function styleBase({
@@ -77,4 +78,25 @@ export const styleBase = function styleBase({
     style.backgroundPosition = "center center";
   }
   return style;
+};
+
+export const propTypesBase = {
+  italic: PropTypes.bool,
+  bold: PropTypes.bool,
+  caps: PropTypes.bool,
+  margin: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
+  padding: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
+  textColor: PropTypes.string,
+  textFont: PropTypes.string,
+  textSize: PropTypes.string,
+  textAlign: PropTypes.string,
+  bgColor: PropTypes.string,
+  bgImage: PropTypes.string,
+  bgDarken: PropTypes.number
 };


### PR DESCRIPTION
Follow up on #108 and supersede #115
1. styleBase(this.props, this.context) eliminates coupling to this of component for simpler testing
2. propTypesBase so components can check base style props

Suggested order to merge Component.propTypes using Object.assign:
1. propTypesBase
2. props specific to component (for example, src for Image)
3. style
4. children

TODO in slide.js review how it uses base style props, especially the apparent restriction on margin to be a single number (instead of number or string as everywhere else). Need to review progress.js too.
