### PR TITLE
Remove redux-logger import

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,5 @@
 import { createStore, applyMiddleware } from "redux";
 import reducer from "../reducers";
-import createLogger from "redux-logger";
 
 const configureStore = () => {
   const createStoreWithMiddleware = applyMiddleware()(createStore);


### PR DESCRIPTION
createLogger was imported but not used. Fixes the error:
"Module not found: Error: Cannot resolve module 'redux-logger'"