### PR TITLE
Remove references to react-router

### DIFF
--- a/assets/deck.example
+++ b/assets/deck.example
@@ -20,7 +20,6 @@ return (
       <List>
         <ListItem>Inline style based theme system</ListItem>
         <ListItem>Autofit Text</ListItem>
-        <ListItem>react-router navigation</ListItem>
         <ListItem>PDF Export</ListItem>
       </List>
     </Slide>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-addons-transition-group": "^0.14.3",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.0",
-    "react-router": "^1.0.0",
     "react-tween-state": "0.1.3",
     "redux": "^3.0.4",
     "redux-actions": "^0.8.0",

--- a/presentation/index.js
+++ b/presentation/index.js
@@ -127,7 +127,6 @@ You can write inline images, [Markdown Links](http://commonmark.org), paragraph 
               <Appear><ListItem>Inline style based theme system</ListItem></Appear>
               <Appear><ListItem>Autofit text</ListItem></Appear>
               <Appear><ListItem>Flexbox layout system</ListItem></Appear>
-              <Appear><ListItem>React-Router navigation</ListItem></Appear>
               <Appear><ListItem>PDF export</ListItem></Appear>
               <Appear><ListItem>And...</ListItem></Appear>
             </List>


### PR DESCRIPTION
`react-router` was removed in `1.0.0` but there are still references to it in `package.json` and the example slides. This pull request deletes references to `react-router`.