### PR TITLE
exclude dist from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 node_modules
 src
-dist
 *.log


### PR DESCRIPTION
to be able to use spectacle via npmcdn.com