### PR TITLE
add missing semicolon

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,7 +81,7 @@ To present:
 
 - Run `npm start`
 - Open two browser windows on two different screens
-- On your screen visit [http://localhost:3000/#/?presenter](http://localhost:3000/#/?presenter)
+- On your screen visit [http://localhost:3000/#/?presenter](http://localhost:3000/#/?presenter) or [http://localhost:3000/?presenter](http://localhost:3000/?presenter)
 - On the presentation screen visit [http://localhost:3000/#/](http://localhost:3000/#/)
 - Give an amazingly stylish presentation
 

--- a/src/components/spectacle.js
+++ b/src/components/spectacle.js
@@ -11,7 +11,7 @@ export default class Spectacle extends Component {
   static propTypes = {
     children: PropTypes.node,
     theme: PropTypes.object
-  }
+  };
 
   render() {
     return (


### PR DESCRIPTION
if windows, "npm start" fail !

```

ERROR in ./src/components/spectacle.js
Module build failed: SyntaxError: C:/ami44/spectacle/src/components/spectacle.js: A semicolon is required after a class property (14:3)
  12 |     children: PropTypes.node,
  13 |     theme: PropTypes.object
> 14 |   }
     |    ^
  15 |
  16 |   render() {
  17 |     return (
    at Parser.pp.raise (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:1413:13)
    at Parser.pp.parseClassProperty (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:2565:10)
    at Parser.<anonymous> (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:3774:20)
    at Parser.parseClassProperty (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:3774:20)
    at Parser.pp.parseClassBody (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:2470:34)
    at Parser.pp.parseClass (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:2413:8)
    at Parser.pp.parseExport (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:2630:19)
    at Parser.<anonymous> (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:3625:20)
    at Parser.parseExport (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:3625:20)
    at Parser.pp.parseStatement (C:\ami44\spectacle\node_modules\babel-core\node_modules\babylon\index.js:1916:90)
 @ ./src/index.js 80:17-50
```