### PR TITLE
Allow notes to be JSX elements

### DIFF
--- a/src/components/presenter.js
+++ b/src/components/presenter.js
@@ -80,7 +80,10 @@ export default class Presenter extends Component {
   _renderNotes() {
     const child = this.props.slides[this.props.slide];
     if (!child.props.notes) { return false; }
-    return <div dangerouslySetInnerHTML={{__html: child.props.notes}} />;
+    if (typeof child.props.notes === 'string') {
+      return <div dangerouslySetInnerHTML={{__html: child.props.notes}} />;  
+    }
+    return <div>{child.props.notes}</div>;
   }
   render() {
     const styles = {

--- a/src/components/presenter.js
+++ b/src/components/presenter.js
@@ -80,7 +80,7 @@ export default class Presenter extends Component {
   _renderNotes() {
     const child = this.props.slides[this.props.slide];
     if (!child.props.notes) { return false; }
-    if (typeof child.props.notes === 'string') {
+    if (typeof child.props.notes === "string") {
       return <div dangerouslySetInnerHTML={{__html: child.props.notes}} />;  
     }
     return <div>{child.props.notes}</div>;


### PR DESCRIPTION
I didn’t update the proptype for this since I’m using the github editor since that is a professional developer tool for professional developers like me.