### PR TITLE
Remove `#` from links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,8 +84,8 @@ To present:
 
 - Run `npm start`
 - Open two browser windows on two different screens
-- On your screen visit [http://localhost:3000/#/?presenter](http://localhost:3000/#/?presenter)
-- On the presentation screen visit [http://localhost:3000/#/](http://localhost:3000/#/)
+- On your screen visit [http://localhost:3000/?presenter](http://localhost:3000/?presenter)
+- On the presentation screen visit [http://localhost:3000/](http://localhost:3000/)
 - Give an amazingly stylish presentation
 
 _Note: Any windows/tabs in the same browser that are running Spectacle will sync to one another, even if you don't want to use presentation mode_
@@ -119,14 +119,14 @@ Fullscreen can be toggled via browser options, or by **hovering over the bottom 
 Exporting a totally sweet looking PDF from your totally sweet looking Spectacle presentation is absurdly easy.
 
 - Run `npm start`
-- Append your URL with `?export` (e.g. [http://localhost:3000/#/?export](http://localhost:3000/#/?export) or [http://localhost:3000/?export](http://localhost:3000/?export))
+- Append your URL with `?export` ([http://localhost:3000/?export](http://localhost:3000/?export))
 - Bring up the print dialog `(ctrl or cmd + p)`
 - Check "Background Graphics" to on if you are about that life
 - Change destination to "Save as PDF", as shown below:
 
 ![http://i.imgur.com/t6GL5Oc.png](http://i.imgur.com/t6GL5Oc.png)
 
-If you want to print your slides, and want a printer friendly version, simply repeat the above process but instead print from [http://localhost:3000/#/?export&print](http://localhost:3000/#/?export&print)
+If you want to print your slides, and want a printer friendly version, simply repeat the above process but instead print from [http://localhost:3000/?export&print](http://localhost:3000/?export&print)
 
 <a name="basic-concepts"></a>
 ## Basic Concepts


### PR DESCRIPTION
I cloned the boilerplate and clicked the links in this README; did not have the intended effect. This commit updates the links so that the boilerplate works.