### PR TITLE
Fix alignment typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -238,7 +238,7 @@ The slide tag represents each slide in the presentation. Giving a slide tag an `
 
 |Name|PropType|Description|
 |---|---|---|
-|align| React.PropTypes.string | Accepts a space delimited value for positioning interior content. The first value can be `flex-start` (left), `center` (middle), or `flex-end` (bottom). The second value can be `flex-start` (top) , `center` (middle), or `flex-end` (bottom). You would provide this prop like `align="center middle"`, which is it's default.
+|align| React.PropTypes.string | Accepts a space delimited value for positioning interior content. The first value can be `flex-start` (left), `center` (middle), or `flex-end` (bottom). The second value can be `flex-start` (top) , `center` (middle), or `flex-end` (bottom). You would provide this prop like `align="center center"`, which is its default.
 |transition|React.PropTypes.array|Accepts `slide`, `zoom`, `fade` or `spin`, and can be combined. Sets the slide transition. **Note: If you use the 'scale' transition, fitted text won't work in Safari.**|
 |transitionDuration| React.PropTypes.number| Accepts integer value in milliseconds for slide transition duration.
 |notes| React.PropTypes.string| Text which will appear in the presenter mode. Can be HTML.


### PR DESCRIPTION
The readme [states](https://github.com/FormidableLabs/spectacle#slide-base) that a slide's `align` property takes two values, both of which can either by `flex-start` or `center` or `flex-end`, but then states that the default is `align="center middle"`, which should actually be `align="center center"` I think, so that change has been made. Also changed `it's` to `its` on line 241 (the same line).

Spectacle is awesome, by the way, thanks for making this :+1: 