### PR TITLE
update history to v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "history": "1.13.1",
+    "history": "^2.1.1",
     "lodash": "3.10.1",
     "mdast": "^2.1.0",
     "mdast-react": "git://github.com/jjt/mdast-react.git#2ea3bcd",


### PR DESCRIPTION
It seems the history module at v1.13.1 doesn't properly build on install in a cross-platform way.

This resolves windows installation problems & a related CI problem with the spectacle editor.