### PR TITLE
Add Link Target Documentation in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ ReactJS based Presentation Library
     - [Table, TableRow, TableHeaderItem and TableItem (Base)](#table-tablerow-tableheaderitem-and-tableitem-base)
     - [Text (Base)](#text-base)
   - [Base Props](#base-props)
-- [Third Party Extensions](#third-party) 
+- [Third Party Extensions](#third-party)
 
 <!-- /MarkdownTOC -->
 
@@ -346,6 +346,7 @@ The link tag is used to render `<a>` tags. It accepts an `href` prop:
 |Name|PropType|Description|
 |---|---|---|
 |href|React.PropTypes.string| String of url for `href` attribute |
+|target|React.PropTypes.string| Set the `target` attribute |
 
 <a name="list--listitem-base"></a>
 #### List & ListItem (Base)


### PR DESCRIPTION
I checked the Link Component, and it supports passing in the `target` attribute in as a `prop` but it wasn't documented.

Also the deleted space I believe was my editor. I can put the space back if you need, let me know!

Thanks!