### PR TITLE
Fix generation of new react component class during render of context wrapper

### DIFF
--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -1,25 +1,29 @@
-import React, { Component, PropTypes } from "react";
+import { Component, PropTypes } from "react";
 
-const context = (component, params) => {
-  return class Context extends Component {
-    static displayName = "ContextWrapper";
-    static childContextTypes = {
-      styles: PropTypes.object,
-      history: PropTypes.object,
-      store: PropTypes.object
-    };
-    getChildContext() {
-      const { history, styles, store } = params;
-      return {
-        history,
-        styles,
-        store
-      };
-    }
-    render() {
-      return React.cloneElement(component);
-    }
+class Context extends Component {
+  static displayName = "Context";
+  static propTypes = {
+    children: PropTypes.node,
+    styles: PropTypes.object,
+    history: PropTypes.object,
+    store: PropTypes.object
   };
-};
+  static childContextTypes = {
+    styles: PropTypes.object,
+    history: PropTypes.object,
+    store: PropTypes.object
+  };
+  getChildContext() {
+    const { history, styles, store } = this.props;
+    return {
+      history,
+      styles,
+      store
+    };
+  }
+  render() {
+    return this.props.children;
+  }
+}
 
-export default context;
+export default Context;

--- a/src/utils/controller.js
+++ b/src/utils/controller.js
@@ -2,8 +2,8 @@ import React, { Component, PropTypes } from "react";
 
 import createHashHistory from "history/lib/createHashHistory";
 
-import context from "../utils/context";
 import theme from "../themes/default";
+import Context from "./context";
 import { updateRoute } from "../actions";
 
 const history = createHashHistory();
@@ -14,7 +14,7 @@ export default class Controller extends Component {
     children: PropTypes.node,
     store: PropTypes.object,
     history: PropTypes.object
-  };
+  }
   constructor(props) {
     super(props);
     this.state = {
@@ -40,13 +40,15 @@ export default class Controller extends Component {
   }
   render() {
     const styles = this.props.theme ? this.props.theme : theme();
-    const Context = context(React.Children.only(this.props.children), {
-      history: this.history,
-      styles: this.state.print ? styles.print : styles.screen,
-      print: styles.print,
-      store: this.props.store
-    });
-    return <Context />;
+    return (
+      <Context
+        store={this.props.store}
+        history={this.history}
+        styles={this.state.print ? styles.print : styles.screen}
+      >
+        {this.props.children}
+      </Context>
+    );
   }
 }
 


### PR DESCRIPTION
Previously, a unique react component class was generated for every `render()` of `controller.js`. This caused the entire slide deck DOM to be replaced during every transition. 

/cc @kenwheeler 