### PR TITLE
Allow arrow keys up and down to control transition

### DIFF
--- a/src/components/deck.js
+++ b/src/components/deck.js
@@ -88,9 +88,9 @@ export default class Deck extends Component {
   _handleEvent(e) {
     const event = window.event ? window.event : e;
 
-    if (event.keyCode === 37 || event.keyCode === 33 || (event.keyCode === 32 && event.shiftKey)) {
+    if (event.keyCode === 40 || event.keyCode === 37 || event.keyCode === 33 || (event.keyCode === 32 && event.shiftKey)) {
       this._prevSlide();
-    } else if (event.keyCode === 39 || event.keyCode === 34 || (event.keyCode === 32 && !event.shiftKey)) {
+    } else if (event.keyCode === 38 || event.keyCode === 39 || event.keyCode === 34 || (event.keyCode === 32 && !event.shiftKey)) {
       this._nextSlide();
     } else if ((event.altKey && event.keyCode === 79) && !event.ctrlKey && !event.metaKey) { // o
       this._toggleOverviewMode();


### PR DESCRIPTION
It works better for pointing device that support only up and down keys.