### PR TITLE
Don't set documentElement fontSize when slide viewerScaleMode is true

### DIFF
--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -134,7 +134,9 @@ const Slide = React.createClass({
       }
     };
 
-    document.documentElement.style.fontSize = `${16 * this.state.zoom}px`;
+    if (!this.props.viewerScaleMode) {
+      document.documentElement.style.fontSize = `${16 * this.state.zoom}px`;
+    }
 
     return (
       <div className="spectacle-slide"


### PR DESCRIPTION
Global mutation of documentElement style was breaking the site containing the spectacle presentation. If I'm understanding the slide's `viewerScaleMode` prop correctly, then when it's true, setting the documentElement's fontSize won't make a difference anyway.
