### PR TITLE
updating the basic concepts header from h2 to h1

### DIFF
--- a/docs/api/basic-concepts.md
+++ b/docs/api/basic-concepts.md
@@ -1,5 +1,5 @@
 <a name="basic-concepts"></a>
-## Basic Concepts
+# Basic Concepts
 
 <a name="main-file"></a>
 ### Main file


### PR DESCRIPTION
updating the header on the basic concepts page for the docs from an H2 to an H1 for better syntax and stylistic purposes