### PR TITLE
Add support for ordered list in `List`component

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -354,8 +354,26 @@ The link tag is used to render `<a>` tags. It accepts an `href` prop:
 <a name="list--listitem-base"></a>
 #### List & ListItem (Base)
 
+|Name|PropType|Description|
+|---|---|---|
+|ordered|React.PropTypes.bool| Render as `<ol>`-tag|
+|reversed|React.PropTypes.bool| Set the `reversed` attribute |
+|start|React.PropTypes.bool| Set the `start` attribute, Default: 1 |
+|type|React.PropTypes.bool| Set the `type` attribute. Default: "1" |
+
 These tags create lists. Use them as follows:
 
+Ordered lists:
+```jsx
+<List ordered start={2} type="A">
+	<ListItem>Item 1</ListItem>
+	<ListItem>Item 2</ListItem>
+	<ListItem>Item 3</ListItem>
+	<ListItem>Item 4</ListItem>
+</List>
+```
+
+Unordered lists:
 ```jsx
 <List>
 	<ListItem>Item 1</ListItem>

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -5,18 +5,31 @@ import Radium from "radium";
 @Radium
 export default class List extends Component {
   render() {
-    return (
+    return this.props.ordered ? (
+      <ol reversed={this.props.reversed} start={this.props.start} type={this.props.type} className={this.props.className} style={[this.context.styles.components.list, getStyles.call(this), this.props.style]}>
+        {this.props.children}
+      </ol>) : (
       <ul className={this.props.className} style={[this.context.styles.components.list, getStyles.call(this), this.props.style]}>
         {this.props.children}
-      </ul>
-    );
+      </ul>);
   }
 }
 
 List.propTypes = {
   children: PropTypes.node,
   style: PropTypes.object,
-  className: PropTypes.string
+  className: PropTypes.string,
+  ordered: PropTypes.bool,
+  reversed: PropTypes.bool,
+  start: PropTypes.number,
+  type: PropTypes.string
+};
+
+List.defaultProps = {
+  ordered: false,
+  reversed: false,
+  start: 1,
+  type: "1"
 };
 
 List.contextTypes = {


### PR DESCRIPTION
This PR adds ordered list functionality to the `List` component, in order to enable functionality as described [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol). Supported props in ordered lists are:

* reversed
* start (index to start numbering)
* type (lettered, numbered, Roman numerals...)

## Usage
```jsx
// Capital letter list starting from 2
<List ordered start={2} type="A">
  <ListItem></ListItem>
</List>
```
