### PR TITLE
Accept arrays of `Slide` in `Deck`

### DIFF
--- a/src/components/deck.js
+++ b/src/components/deck.js
@@ -163,13 +163,14 @@ export default class Deck extends Component {
     this.setState({
       lastSlide: slide
     });
+    const children = Children.toArray(this.props.children);
     if (this._checkFragments(this.props.route.slide, true) || this.props.route.params.indexOf("overview") !== -1) {
-      if (slide < this.props.children.length - 1) {
+      if (slide < children.length - 1) {
         this.context.history.replace(`/${this._getHash(slide + 1) + this._getSuffix()}`);
         localStorage.setItem("spectacle-slide",
           JSON.stringify({slide: this._getHash(slide + 1), forward: true, time: Date.now()}));
       }
-    } else if (slide < this.props.children.length) {
+    } else if (slide < children.length) {
       localStorage.setItem("spectacle-slide",
         JSON.stringify({slide: this._getHash(slide), forward: true, time: Date.now()}));
     }


### PR DESCRIPTION
Currently we cannot pass arrays of `<Slide>`s to `<Deck>`, such as

```js
<Spectacle theme={theme}>
  <Deck transition={["zoom", "slide"]} transitionDuration={200} progress="bar">
    {mds.map(md => <Markdown source={md}/>)}
  </Deck>
</Spectacle>
```

It would be great if we could!

## Problem
`<Deck>` treats `this.props.children` directly.
`this.props.children` may include arrays as the element like:
`[<Slide/>, [<Slide/>, <Slide/>], <Slide/>]`

So `this.props.children.length` returns `3` while it actually has `4` slides.

## Solution

However, in some methods `Deck` treats children with `React.Children`.

```js
import { Children } from 'react';

assert.deepEqual(this.props.children, [<Slide/>, [<Slide/>, <Slide/>], <Slide/>]);
this.props.children.length; // 3;

const children = Children.toArray(this.props.children); // [<Slide/>, <Slide/>, <Slide/>, <Slide/>]
children.length // 4
```

I fixed `Deck` to treat children via `React.Children` so that we can pass arrays of `<Slide>`s.



