### PR TITLE
Fix invalid DOM nesting in <Table>

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -7,7 +7,9 @@ export default class Table extends Component {
   render() {
     return (
       <table className={this.props.className} style={[this.context.styles.components.table, getStyles.call(this), this.props.style]}>
-        {this.props.children}
+        <tbody>
+          {this.props.children}
+        </tbody>
       </table>
     );
   }


### PR DESCRIPTION
Any `<table>` HTML element must have a `<tbody>`. React is also nagging:

![screen shot 2016-10-28 at 14 59 57](https://cloud.githubusercontent.com/assets/985701/19807229/81ca4a1a-9d1f-11e6-82ef-a7aa39898c04.png)

This patch adds a `<tbody>` to the `<Table>` component.
