### PR TITLE
Add Typeface tag and Google Font support to themes.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,7 @@ ReactJS based Presentation Library
     - [S (Base)](#s-base)
     - [Table, TableRow, TableHeaderItem and TableItem (Base)](#table-tablerow-tableheaderitem-and-tableitem-base)
     - [Text (Base)](#text-base)
+    - [Typeface](#typeface)
   - [Base Props](#base-props)
 - [Third Party Extensions](#third-party)
 
@@ -87,7 +88,7 @@ To present:
 
 - Run `npm start`
 - Open two browser windows on two different screens
-- On your screen visit [http://localhost:3000/](http://localhost:3000/). You will be redirected to a URL containing the slide id. 
+- On your screen visit [http://localhost:3000/](http://localhost:3000/). You will be redirected to a URL containing the slide id.
 - Add `presenter&` immediately after the questionmark, e.g.: [http://localhost:3000/#/?presenter&_k=wbyhif](http://localhost:3000/#/?presenter&_k=wbyhif)
 - On the presentation screen visit [http://localhost:3000/](http://localhost:3000/)
 - Give an amazingly stylish presentation
@@ -194,13 +195,15 @@ You will want to edit `index.html` to include any web fonts or additional CSS th
 <a name="createthemecolors-fonts"></a>
 #### createTheme(colors, fonts)
 
-Spectacle's functional theme system allows you to pass in color and font variables that you can use on your elements. See the example below:
+Spectacle's functional theme system allows you to pass in color and font variables that you can use on your elements. The fonts configuration object can take a string for a system font or an object that specifies it‘s a Google Font. If you use a Google Font you can provide a styles array for loading different weights and variations. Google Font tags will be automatically created. See the example below:
 
 ```jsx
 const theme = createTheme({
-  primary: "red"
+  primary: "red",
+  secondary: "blue"
 }, {
-  primary: "Helvetica"
+  primary: "Helvetica",
+  secondary: { name: "Droid Serif", googleFont: true, styles: [ "400", "700i" ] }
 });
 ```
 
@@ -445,6 +448,30 @@ Every component above that has `(Base)` after it has been extended from a common
 | bgColor | React.PropTypes.string | Set `backgroundColor` value|
 | bgImage | React.PropTypes.string | Set `backgroundImage` value|
 | bgDarken | React.PropTypes.number | Float value from 0.0 to 1.0 specifying how much to darken the bgImage image|
+
+<a name="typeface"></a>
+#### Typeface
+
+The `Typeface` tag is used to apply a specific font to text content. It can either use a font that exists on the system or load a font from the Google Fonts library. `Typeface` requires either `font` or `googleFont` to be defined.
+
+| Name | PropType | Description |
+| ---- | -------- | ----------- |
+| font | React.PropTypes.string | Use a font from the local system |
+| googleFont | React.PropTypes.string | Use a font from the Google Fonts library |
+| weight | React.PropTypes.number | Numeric weight value for the font. Default: `400`. |
+| italic | React.PropTypes.boolean | Use an italics variant of the font if it exists. Default: `false`. |
+
+```jsx
+<Typeface googleFont="Roboto Slab" weight={600}>
+  <Text>This text is using bold Roboto Slab from Google Fonts.</Text>
+</Typeface>
+```
+
+```jsx
+<Typeface font="SF Text" weight={400} italic={true}>
+  <Text>This text is using the San Francisco Text font from the system.</Text>
+</Typeface>
+```
 
 <a name="third-party"></a>
 ## Third Party Extensions

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-cli": "^6.16.0",
     "babel-core": "^6.18.0",
     "babel-eslint": "^7.0.0",
-    "babel-jest": "^16.0.0",
+    "babel-jest": "^17.0.2",
     "babel-loader": "^6.2.5",
     "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-plugin-transform-decorators-legacy": "^1.2.0",
@@ -61,12 +61,12 @@
     "eslint-plugin-react": "^6.4.1",
     "express": "^4.13.3",
     "file-loader": "^0.9.0",
-    "jest": "^16.0.2",
+    "jest": "^17.0.2",
     "node-libs-browser": "^0.5.3",
     "raw-loader": "^0.5.1",
-    "react": "^15.3.2",
-    "react-addons-test-utils": "^15.3.2",
-    "react-dom": "^15.3.2",
+    "react": "^15.4.0",
+    "react-addons-test-utils": "^15.4.0",
+    "react-dom": "^15.4.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.2.0",
@@ -77,8 +77,5 @@
     "webpack": "^2.1.0-beta.25",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.13.0"
-  },
-  "jest": {
-    "clearMocks": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-addons-transition-group": "^15.3.2",
     "react-history": "^0.15.1",
     "react-redux": "^4.0.0",
+    "react-typography": "^0.15.0",
     "redux": "^3.0.4",
     "redux-actions": "^0.12.0",
     "tween-functions": "1.1.0",

--- a/src/components/__snapshots__/deck.test.js.snap
+++ b/src/components/__snapshots__/deck.test.js.snap
@@ -18,6 +18,11 @@ exports[`<Deck /> should render correctly. 1`] = `
         "slide": 0,
       }
     }
+    style={
+      Object {
+        "globalStyleSet": Array [],
+      }
+    }
     transition={
       Array [
         "zoom",
@@ -86,12 +91,10 @@ exports[`<Deck /> should render correctly. 1`] = `
               "width": "100%",
             }
           }>
-          <div
-            data-radium={true}
+          <MockSlide
             dispatch={[Function]}
             export={false}
             hash={0}
-            id={1}
             lastSlide={0}
             print={false}
             slideIndex={0}
@@ -101,21 +104,19 @@ exports[`<Deck /> should render correctly. 1`] = `
                 "slide",
               ]
             }
-            transitionDuration={500} />
+            transitionDuration={500}>
+            <div>
+              Slide Content
+            </div>
+          </MockSlide>
         </div>
       </ReactTransitionGroup>
       <Progress
         currentSlide={0}
         items={
           Array [
-            <div
-              id={1}>
-              Slide 1
-          </div>,
-            <div
-              id={2}>
-              Slide 2
-          </div>,
+            <MockSlide />,
+            <MockSlide />,
           ]
         }
         type="pacman">
@@ -227,6 +228,11 @@ exports[`<Deck /> should render the export configuration when specified. 1`] = `
         "slide": 0,
       }
     }
+    style={
+      Object {
+        "globalStyleSet": Array [],
+      }
+    }
     transitionDuration={500}>
     <div
       className="spectacle-deck"
@@ -257,14 +263,8 @@ exports[`<Deck /> should render the export configuration when specified. 1`] = `
         }
         slides={
           Array [
-            <div
-              id={1}>
-              Slide 1
-          </div>,
-            <div
-              id={2}>
-              Slide 2
-          </div>,
+            <MockSlide />,
+            <MockSlide />,
           ]
         }>
         <div
@@ -276,24 +276,26 @@ exports[`<Deck /> should render the export configuration when specified. 1`] = `
               "width": "100%",
             }
           }>
-          <div
+          <MockSlide
             export={true}
-            id={1}
             print={false}
             slideIndex={0}
             transition={Array []}
             transitionDuration={0}>
-            Slide 1
-          </div>
-          <div
+            <div>
+              Slide Content
+            </div>
+          </MockSlide>
+          <MockSlide
             export={true}
-            id={2}
             print={false}
             slideIndex={1}
             transition={Array []}
             transitionDuration={0}>
-            Slide 2
-          </div>
+            <div>
+              Slide Content
+            </div>
+          </MockSlide>
         </div>
       </Export>
       <Style
@@ -335,6 +337,11 @@ exports[`<Deck /> should render the overview configuration when specified. 1`] =
         "slide": 0,
       }
     }
+    style={
+      Object {
+        "globalStyleSet": Array [],
+      }
+    }
     transitionDuration={500}>
     <div
       className="spectacle-deck"
@@ -366,14 +373,8 @@ exports[`<Deck /> should render the overview configuration when specified. 1`] =
         slide={0}
         slides={
           Array [
-            <div
-              id={1}>
-              Slide 1
-          </div>,
-            <div
-              id={2}>
-              Slide 2
-          </div>,
+            <MockSlide />,
+            <MockSlide />,
           ]
         }>
         <div
@@ -401,16 +402,17 @@ exports[`<Deck /> should render the overview configuration when specified. 1`] =
                 "width": NaN,
               }
             }>
-            <div
+            <MockSlide
               appearOff={true}
               export={false}
-              id={1}
               print={false}
               slideIndex={0}
               transition={Array []}
               transitionDuration={0}>
-              Slide 1
-            </div>
+              <div>
+                Slide Content
+              </div>
+            </MockSlide>
           </div>
           <div
             data-radium={true}
@@ -427,16 +429,17 @@ exports[`<Deck /> should render the overview configuration when specified. 1`] =
                 "width": NaN,
               }
             }>
-            <div
+            <MockSlide
               appearOff={true}
               export={false}
-              id={2}
               print={false}
               slideIndex={1}
               transition={Array []}
               transitionDuration={0}>
-              Slide 2
-            </div>
+              <div>
+                Slide Content
+              </div>
+            </MockSlide>
           </div>
         </div>
       </Overview>

--- a/src/components/__snapshots__/typeface.test.js.snap
+++ b/src/components/__snapshots__/typeface.test.js.snap
@@ -1,0 +1,63 @@
+exports[`<Typeface /> should render the children when using a Google font. 1`] = `
+<Typeface
+  googleFont="Roboto Slab"
+  italic={true}
+  weight={700}>
+  <div>
+    <GoogleFont
+      typography={
+        Object {
+          "options": Object {
+            "googleFonts": Array [
+              Object {
+                "name": "Roboto Slab",
+                "styles": Array [
+                  "700i",
+                ],
+              },
+            ],
+          },
+          "title": "Roboto Slab",
+        }
+      }>
+      <link
+        href="//fonts.googleapis.com/css?family=Roboto+Slab:700i"
+        rel="stylesheet"
+        type="text/css" />
+    </GoogleFont>
+    <MockComponent>
+      <div
+        style={
+          Object {
+            "fontFamily": "Roboto Slab",
+            "fontStyle": "italic",
+            "fontWeight": 700,
+          }
+        }>
+        Hello!
+      </div>
+    </MockComponent>
+  </div>
+</Typeface>
+`;
+
+exports[`<Typeface /> should render the children when using a system font. 1`] = `
+<Typeface
+  font="SF UI Text"
+  weight={400}>
+  <div>
+    <MockComponent>
+      <div
+        style={
+          Object {
+            "fontFamily": "SF UI Text",
+            "fontStyle": "normal",
+            "fontWeight": 400,
+          }
+        }>
+        Hello!
+      </div>
+    </MockComponent>
+  </div>
+</Typeface>
+`;

--- a/src/components/block-quote.js
+++ b/src/components/block-quote.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class BlockQuote extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <blockquote className={this.props.className} style={[this.context.styles.components.blockquote, getStyles.call(this), this.props.style]}>
+      <blockquote className={this.props.className} style={[this.context.styles.components.blockquote, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </blockquote>
     );
@@ -21,5 +22,6 @@ BlockQuote.propTypes = {
 
 BlockQuote.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/cite.js
+++ b/src/components/cite.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class Cite extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <cite className={this.props.className} style={[this.context.styles.components.cite, getStyles.call(this), this.props.style]}>
+      <cite className={this.props.className} style={[this.context.styles.components.cite, getStyles.call(this), this.props.style, typefaceStyle]}>
         - {this.props.children}
       </cite>
     );
@@ -21,5 +22,6 @@ Cite.propTypes = {
 
 Cite.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/deck.js
+++ b/src/components/deck.js
@@ -8,6 +8,7 @@ import filter from "lodash/filter";
 import size from "lodash/size";
 import { connect } from "react-redux";
 import { setGlobalStyle, updateFragment } from "../actions";
+import Typeface from "./typeface";
 
 import Presenter from "./presenter";
 import Export from "./export";
@@ -409,6 +410,15 @@ export default class Deck extends Component {
       this.props.route.params.indexOf("overview") === -1 &&
       this.props.route.params.indexOf("presenter") === -1;
 
+    const { googleFonts = {} } = this.context.styles;
+    const googleFontsElements = Object.keys(googleFonts).map((key, index) => (
+      <Typeface
+        googleFont={googleFonts[key].name}
+        styles={googleFonts[key].styles}
+        key={`gFont-${index}`}
+      />
+    ));
+
     return (
       <div
         className="spectacle-deck"
@@ -424,6 +434,7 @@ export default class Deck extends Component {
               onNext={this._nextSlide.bind(this)}
             />}
 
+        {googleFontsElements}
         {componentToRender}
 
         {

--- a/src/components/deck.test.js
+++ b/src/components/deck.test.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import { mount } from "enzyme";
 import { mountToJson } from "enzyme-to-json";
 import Deck from "./deck";
@@ -19,6 +19,9 @@ const _mockContext = function (slide, routeParams) {
         route: {
           params: routeParams,
           slide
+        },
+        style: {
+          globalStyleSet: []
         }
       }),
       dispatch: () => {},
@@ -26,6 +29,12 @@ const _mockContext = function (slide, routeParams) {
     }
   };
 };
+
+class MockSlide extends Component {
+  render() {
+    return (<div>Slide Content</div>);
+  }
+}
 
 const _mockChildContext = function () {
   return { styles: () => {} };
@@ -35,8 +44,8 @@ describe("<Deck />", () => {
   test("should render correctly.", () => {
     const wrapper = mount((
       <Deck transition={["zoom", "slide"]} transitionDuration={500}>
-        <div id={1}>Slide 1</div>
-        <div id={2}>Slide 2</div>
+        <MockSlide />
+        <MockSlide />
       </Deck>
     ), { context: _mockContext(0, []), childContextTypes: _mockChildContext() });
     expect(mountToJson(wrapper)).toMatchSnapshot();
@@ -45,8 +54,8 @@ describe("<Deck />", () => {
   test("should render the export configuration when specified.", () => {
     const wrapper = mount((
       <Deck>
-        <div id={1}>Slide 1</div>
-        <div id={2}>Slide 2</div>
+        <MockSlide />
+        <MockSlide />
       </Deck>
     ), { context: _mockContext(0, [ "export" ]), childContextTypes: _mockChildContext() });
     expect(mountToJson(wrapper)).toMatchSnapshot();
@@ -55,8 +64,8 @@ describe("<Deck />", () => {
   test("should render the overview configuration when specified.", () => {
     const wrapper = mount((
       <Deck>
-        <div id={1}>Slide 1</div>
-        <div id={2}>Slide 2</div>
+        <MockSlide />
+        <MockSlide />
       </Deck>
     ), { context: _mockContext(0, [ "overview" ]), childContextTypes: _mockChildContext() });
     expect(mountToJson(wrapper)).toMatchSnapshot();

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -60,6 +60,7 @@ export default class Heading extends Component {
         lineHeight
       }
     };
+    const typefaceStyle = this.context.typeface || {};
     return (
       fit ? (
         <div
@@ -70,14 +71,14 @@ export default class Heading extends Component {
             getStyles.call(this), styles.container
           ]}
         >
-          <span ref={(t) => { this.textRef = t; }} style={[styles.text, style]}>
+          <span ref={(t) => { this.textRef = t; }} style={[styles.text, style, typefaceStyle]}>
             {children}
           </span>
         </div>
       ) : (
         createElement(Tag, {
           className: this.props.className,
-          style: [this.context.styles.components.heading[`h${size}`], getStyles.call(this), styles.nonFit, style]
+          style: [this.context.styles.components.heading[`h${size}`], getStyles.call(this), styles.nonFit, style, typefaceStyle]
         }, children)
       )
     );
@@ -100,5 +101,6 @@ Heading.propTypes = {
 
 Heading.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class Link extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <a className={this.props.className} href={this.props.href} target={this.props.target} style={[this.context.styles.components.link, getStyles.call(this), this.props.style]}>
+      <a className={this.props.className} href={this.props.href} target={this.props.target} style={[this.context.styles.components.link, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </a>
     );
@@ -23,5 +24,6 @@ Link.propTypes = {
 
 Link.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class ListItem extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <li className={this.props.className} style={[this.context.styles.components.listItem, getStyles.call(this), this.props.style]}>
+      <li className={this.props.className} style={[this.context.styles.components.listItem, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </li>
     );
@@ -21,5 +22,6 @@ ListItem.propTypes = {
 
 ListItem.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/quote.js
+++ b/src/components/quote.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class Quote extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <span className={this.props.className} style={[this.context.styles.components.quote, getStyles.call(this), this.props.style]}>
+      <span className={this.props.className} style={[this.context.styles.components.quote, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </span>
     );
@@ -21,5 +22,6 @@ Quote.propTypes = {
 
 Quote.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/table-header-item.js
+++ b/src/components/table-header-item.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class TableHeaderItem extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <td className={this.props.className} style={[this.context.styles.components.tableHeaderItem, getStyles.call(this), this.props.style]}>
+      <td className={this.props.className} style={[this.context.styles.components.tableHeaderItem, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </td>
     );
@@ -21,5 +22,6 @@ TableHeaderItem.propTypes = {
 
 TableHeaderItem.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/table-item.js
+++ b/src/components/table-item.js
@@ -5,8 +5,9 @@ import Radium from "radium";
 @Radium
 export default class TableItem extends Component {
   render() {
+    const typefaceStyle = this.context.typeface || {};
     return (
-      <td className={this.props.className} style={[this.context.styles.components.tableItem, getStyles.call(this), this.props.style]}>
+      <td className={this.props.className} style={[this.context.styles.components.tableItem, getStyles.call(this), this.props.style, typefaceStyle]}>
         {this.props.children}
       </td>
     );
@@ -21,5 +22,6 @@ TableItem.propTypes = {
 
 TableItem.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -59,6 +59,7 @@ export default class Text extends Component {
         lineHeight
       }
     };
+    const typefaceStyle = this.context.typeface || {};
     return (
       fit ? (
         <div
@@ -68,13 +69,13 @@ export default class Text extends Component {
         >
           <span
             ref={(t) => { this.textRef = t; }}
-            style={[styles.text, style]}
+            style={[styles.text, style, typefaceStyle]}
           >
             {children}
           </span>
         </div>
       ) : (
-        <p className={this.props.className} style={[this.context.styles.components.text, getStyles.call(this), styles.nonFit, style]}>
+        <p className={this.props.className} style={[this.context.styles.components.text, getStyles.call(this), styles.nonFit, style, typefaceStyle]}>
           {children}
         </p>
       )
@@ -96,5 +97,6 @@ Text.propTypes = {
 
 Text.contextTypes = {
   styles: PropTypes.object,
-  store: PropTypes.object
+  store: PropTypes.object,
+  typeface: PropTypes.object
 };

--- a/src/components/transitionable.test.js
+++ b/src/components/transitionable.test.js
@@ -21,7 +21,7 @@ describe("@renderTransition", () => {
 
 describe("@Transitionable", () => {
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it("should add ReactCSSTransitionGroup lifecycle functions to the decorated class.", () => {

--- a/src/components/typeface.js
+++ b/src/components/typeface.js
@@ -1,0 +1,57 @@
+import React, { Component, PropTypes } from "react";
+import { GoogleFont } from "react-typography";
+
+class Typeface extends Component {
+  getChildContext() {
+    return {
+      typeface: {
+        fontFamily: this.props.googleFont || this.props.font || "",
+        fontWeight: this.props.weight,
+        fontStyle: this.props.italic ? "italic" : "normal"
+      }
+    };
+  }
+
+  render() {
+    const { children, googleFont, weight = 400, italic = false, styles } = this.props;
+    if (typeof googleFont !== "undefined" && googleFont.length > 0) {
+      const styleSuffix = italic ? "i" : "";
+      const config = {
+        title: `${googleFont}`,
+        options: {
+          googleFonts: [
+            {
+              name: googleFont,
+              styles: styles || [ `${weight}${styleSuffix}` ]
+            }
+          ]
+        }
+      };
+      return (
+        <div>
+          <GoogleFont typography={config} />
+          { children }
+        </div>
+      );
+    } else {
+      return (
+        <div>{ children }</div>
+      );
+    }
+  }
+}
+
+Typeface.propTypes = {
+  children: PropTypes.node,
+  font: PropTypes.string,
+  googleFont: PropTypes.string,
+  italic: PropTypes.bool,
+  styles: PropTypes.array,
+  weight: PropTypes.number
+};
+
+Typeface.childContextTypes = {
+  typeface: PropTypes.object
+};
+
+export default Typeface;

--- a/src/components/typeface.test.js
+++ b/src/components/typeface.test.js
@@ -1,0 +1,51 @@
+import React, { Component, PropTypes } from "react";
+import { mount } from "enzyme";
+import { mountToJson } from "enzyme-to-json";
+import Typeface from "./typeface";
+
+class MockComponent extends Component {
+  static propTypes = {
+    children: PropTypes.node
+  };
+
+  static contextTypes = {
+    typeface: PropTypes.object
+  };
+
+  render() {
+    return (
+      <div
+        style={this.context.typeface}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+describe("<Typeface />", () => {
+  test("should render the children when using a system font.", () => {
+    const wrapper = mount(
+      <Typeface
+        font="SF UI Text"
+        weight={400}
+      >
+        <MockComponent>Hello!</MockComponent>
+      </Typeface>
+    );
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+
+  test("should render the children when using a Google font.", () => {
+    const wrapper = mount(
+      <Typeface
+        googleFont="Roboto Slab"
+        weight={700}
+        italic
+      >
+        <MockComponent>Hello!</MockComponent>
+      </Typeface>
+    );
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import TableItem from "./components/table-item";
 import TableRow from "./components/table-row";
 import Table from "./components/table";
 import Text from "./components/text";
+import Typeface from "./components/typeface";
 
 export {
   Appear,
@@ -47,5 +48,6 @@ export {
   TableItem,
   TableRow,
   Table,
-  Text
+  Text,
+  Typeface
 };

--- a/src/themes/default/screen.js
+++ b/src/themes/default/screen.js
@@ -15,10 +15,21 @@ const defaultFonts = {
 
 const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
   const colors = Object.assign({}, defaultColors, colorArgs);
-  const fonts = Object.assign({}, defaultFonts, fontArgs);
+  let normalizedFontArgs = {};
+  let googleFonts = {};
+  Object.keys(fontArgs).forEach((key) => {
+    const value = fontArgs[key];
+    const fontName = value.hasOwnProperty("name") ? value.name : value;
+    normalizedFontArgs = { ...normalizedFontArgs, [key]: fontName };
+    if (value.hasOwnProperty("googleFont") && value.googleFont) {
+      googleFonts = { ...googleFonts, [key]: value };
+    }
+  });
+  const fonts = Object.assign({}, defaultFonts, normalizedFontArgs);
   return {
     colors: colors,
     fonts: fonts,
+    googleFonts,
     global: {
       body: {
         background: colors.primary,


### PR DESCRIPTION
* Themes can now load a system font or Google Font
* Google Font style tags will be automatically created and appended to DOM
* `<Typeface />` tag can be used for specific font styling of text
* Added and documented changes and examples to README

Addresses #233 

// cc: @kenwheeler 