### PR TITLE
add webpack -loader suffixes

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -57,7 +57,7 @@ export default class Presentation extends React.Component {
           <Slide transition={["zoom", "fade"]} bgColor="primary" notes="<ul><li>talk about that</li><li>and that</li></ul>">
             <CodePane
               lang="jsx"
-              source={require("raw!../assets/deck.example")}
+              source={require("raw-loader!../assets/deck.example")}
               margin="20px auto"
             />
           </Slide>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loader: "babel",
+      loader: "babel-loader",
       query: {
         plugins: [
           [
@@ -41,11 +41,11 @@ module.exports = {
       include: __dirname
     }, {
       test: /\.css$/,
-      loaders: ["style", "raw"],
+      loaders: ["style-loader", "raw-loader"],
       include: __dirname
     }, {
       test: /\.svg$/,
-      loader: "url?limit=10000&mimetype=image/svg+xml",
+      loader: "url-loader?limit=10000&mimetype=image/svg+xml",
       include: path.join(__dirname, "example/assets")
     }, {
       test: /\.png$/,

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -28,7 +28,7 @@ module.exports = {
     loaders: [{
       test: /\.js$/,
       exclude: /node_modules/,
-      loader: "babel"
+      loader: "babel-loader"
     }, {
       test: /\.css$/,
       loader: "style-loader!css-loader"
@@ -37,7 +37,7 @@ module.exports = {
       loader: "url-loader?limit=8192"
     }, {
       test: /\.svg$/,
-      loader: "url?limit=10000&mimetype=image/svg+xml"
+      loader: "url-loader?limit=10000&mimetype=image/svg+xml"
     }]
   }
 };


### PR DESCRIPTION
On a fresh install, `npm start` returns:
```
Module not found: Error: Can't resolve 'babel' in '/_dir/spectacle'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' prefix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel'.
```
This fixes the problem.