### PR TITLE
Initial Support For Remote Control/Viewing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ ReactJS based Presentation Library
   - [Main file](#main-file)
   - [Themes](#themes)
     - [createTheme(colors, fonts)](#createthemecolors-fonts)
+  - [Remote](#remote)
 - [Tag API](#tag-api)
   - [Main Tags](#main-tags)
     - [Spectacle](#spectacle)
@@ -209,6 +210,55 @@ const theme = createTheme({
 
 The returned theme object can then be passed to the `Spectacle` tag via the `theme` prop, and will override the default styles.
 
+<a name="remote"></a>
+### Remote
+
+Spectacle supports remote control and viewing of slides. You will need to create a socket class that has the following functions and events.
+|Name|Type|Payload|Description|
+|---|---|---|---|
+|setup|Function|uri|Setup socket with passed uri. Instantiates open and message events.|
+|send|Function|message|Called to send message to remote clients/viewers.|
+|open|Event||Emitted to indicate socket is now open and ready to send messages.|
+|message|Event||Emitted to send messages to clients/viewers.|
+
+An example of a socket class.
+```jsx
+import WebSocket from "reconnecting-websocket";
+import EventEmitter from "eventemitter3";
+
+export default class Socket extends EventEmitter {
+  socket;
+  connected = false;
+
+  constructor(uri) {
+    super();
+    if (uri) {
+      this.setup(uri);
+    }
+  }
+
+  setup(uri) {
+    this.socket = new WebSocket(uri);
+    this.socket.addEventListener("open", () => {
+      this.connected = true;
+      this.emit("open");
+    });
+
+    this.socket.onmessage = (event) => {
+      this.emit("message", event);
+    };
+  }
+
+  send(payload) {
+    if (this.connected) {
+      this.socket.send(payload);
+    }
+  }
+}
+```
+
+The returned socket object can then be passed to the `Spectacle` tag via the `remote` prop.
+
 <a name="tag-api"></a>
 ## Tag API
 
@@ -226,6 +276,7 @@ The Spectacle tag is the root level tag for your presentation. It handles routin
 |---|---|---|
 |history|React.PropTypes.object|Accepts custom configuration for [history](https://github.com/ReactTraining/history)
 |theme|React.PropTypes.object|Accepts a theme object for styling your presentation|
+|remote|React.PropTypes.object|Accepts a socket class that allows remote control or remote viewing of presentation|
 
 <a name="deck"></a>
 #### Deck

--- a/README.markdown
+++ b/README.markdown
@@ -219,7 +219,7 @@ Spectacle supports remote control and viewing of slides. You will need to create
 |setup|Function|uri|Setup socket with passed uri. Instantiates open and message events.|
 |send|Function|message|Called to send message to remote clients/viewers.|
 |open|Event||Emitted to indicate socket is now open and ready to send messages.|
-|message|Event||Emitted to send messages to clients/viewers.|
+|message|Event|message|Emitted to send messages to clients/viewers.|
 
 An example of a socket class.
 ```jsx
@@ -257,7 +257,9 @@ export default class Socket extends EventEmitter {
 }
 ```
 
-The returned socket object can then be passed to the `Spectacle` tag via the `remote` prop.
+The returned socket object can then be passed to the `Deck` tag via the `remote` prop.
+
+Remote control/viewing does not work with deploying slides to surge with `npm run deploy`.
 
 <a name="tag-api"></a>
 ## Tag API

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -6,6 +6,8 @@ import {
   TableHeaderItem, TableItem, TableRow, Table, Text
 } from "../../src";
 
+import Socket from "./socket";
+
 import preloader from "../../src/utils/preloader";
 
 import createTheme from "../../src/themes/default";
@@ -28,10 +30,12 @@ const theme = createTheme({
   primary: "#ff4081"
 });
 
+const socket = new Socket(`ws://${location.host}`);
+
 export default class Presentation extends React.Component {
   render() {
     return (
-      <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
+      <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500} remote={socket}>
         <Slide transition={["zoom"]} bgColor="primary">
           <Heading size={1} fit caps lineHeight={1} textColor="black">
             Spectacle

--- a/example/src/socket.js
+++ b/example/src/socket.js
@@ -1,0 +1,32 @@
+import WebSocket from "reconnecting-websocket";
+import EventEmitter from "eventemitter3";
+
+export default class Socket extends EventEmitter {
+  socket;
+  connected = false;
+
+  constructor(uri) {
+    super();
+    if (uri) {
+      this.setup(uri);
+    }
+  }
+
+  setup(uri) {
+    this.socket = new WebSocket(uri);
+    this.socket.addEventListener("open", () => {
+      this.connected = true;
+      this.emit("open");
+    });
+
+    this.socket.onmessage = (event) => {
+      this.emit("message", event);
+    };
+  }
+
+  send(payload) {
+    if (this.connected) {
+      this.socket.send(payload);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "eventemitter3": "^2.0.2",
     "lodash": "^4.16.4",
     "mdast": "^2.1.0",
     "mdast-react": "git://github.com/jjt/mdast-react.git#2ea3bcd",
@@ -25,10 +26,12 @@
     "react-history": "^0.15.1",
     "react-redux": "^4.0.0",
     "react-typography": "^0.15.0",
+    "reconnecting-websocket": "^3.0.3",
     "redux": "^3.0.4",
     "redux-actions": "^0.12.0",
     "styled-components": "^1.1.3",
     "tween-functions": "1.1.0",
+    "uws": "^0.11.1",
     "victory-core": "^9.1.1"
   },
   "peerDependencies": {

--- a/server.js
+++ b/server.js
@@ -45,7 +45,6 @@ wss.on('connection', function connection(ws) {
   // or ws.upgradeReq.headers.cookie (see http://stackoverflow.com/a/16395220/151312)
   ws.on('message', function incoming(message) {
     const payload = JSON.parse(message);
-    // console.log('received: ', util.inspect(message, false, null));
     state = payload;
     wss.clients.forEach(function (client) {
       if (client !== ws) client.send(message);
@@ -59,11 +58,6 @@ wss.on('connection', function connection(ws) {
   ws.send(
     JSON.stringify(state)
   );
-  /**
-  state.forEach(function (op) {
-    ws.send(op);
-  });
-  **/
 });
 
 server.on('request', app);

--- a/server.js
+++ b/server.js
@@ -1,12 +1,32 @@
 /* eslint-disable */
-
+var server = require('http').createServer();
+var WebSocketServer = require('uws').Server;
+var wss = new WebSocketServer({ server: server });
+var url = require('url');
 var path = require("path");
 var express = require("express");
 var webpack = require("webpack");
 var config = require("./webpack.config");
-
+const util = require('util')
 var app = express();
 var compiler = webpack(config);
+var port = 3000;
+var host = 'localhost';
+var state = {
+  "state": {
+    "fragment": {
+      "fragments": {}
+    },
+    "route": {
+      "slide": 0,
+      "params": []
+    },
+    "style": {
+      "globalStyleSet": true
+    }
+  },
+  "type": "REMOTE_STATE"
+};
 
 app.use(require("webpack-dev-middleware")(compiler, {
     noInfo: true,
@@ -19,11 +39,42 @@ app.get("*", function(req, res) {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
-app.listen(3000, "localhost", function (err) {
-  if (err) {
-    console.log(err);
-    return;
-  }
+wss.on('connection', function connection(ws) {
+  const location = url.parse(ws.upgradeReq.url, true);
+  // you might use location.query.access_token to authenticate or share sessions
+  // or ws.upgradeReq.headers.cookie (see http://stackoverflow.com/a/16395220/151312)
+  ws.on('message', function incoming(message) {
+    const payload = JSON.parse(message);
+    // console.log('received: ', util.inspect(message, false, null));
+    state = payload;
+    wss.clients.forEach(function (client) {
+      if (client !== ws) client.send(message);
+    });
+  });
 
-  console.log("Listening at http://localhost:3000");
+  ws.on('close', function close() {
+    console.log('socket disconnected');
+  });
+
+  ws.send(
+    JSON.stringify(state)
+  );
+  /**
+  state.forEach(function (op) {
+    ws.send(op);
+  });
+  **/
 });
+
+server.on('request', app);
+server.listen(
+  port, 
+  host,
+  function (err) { 
+    if (err) {
+      console.log(err);
+      return;
+    }
+    console.log(`Listening on http://${host}:${server.address().port}`) 
+  }
+);

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,5 +4,6 @@ export const addFragment = createAction("ADD_FRAGMENT");
 export const updateFragment = createAction("UPDATE_FRAGMENT");
 
 export const updateRoute = createAction("UPDATE_ROUTE");
+export const remoteState = createAction("REMOTE_STATE");
 
 export const setGlobalStyle = createAction("SET_GLOBAL_STYLE");

--- a/src/components/deck.js
+++ b/src/components/deck.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 
 import { Provider } from "react-redux";
-import configureStore from "../store";
+import configureStore, { subscribe, setupRemote } from "../store";
 
 import Controller from "../utils/controller";
 import Manager from "./manager";
@@ -17,10 +17,20 @@ export default class Deck extends Component {
     globalStyles: PropTypes.bool,
     history: PropTypes.object,
     progress: PropTypes.oneOf(["pacman", "bar", "number", "none"]),
+    remote: PropTypes.object,
     theme: PropTypes.object,
     transition: PropTypes.array,
     transitionDuration: PropTypes.number
   };
+
+  componentWillMount() {
+    const { remote } = this.props;
+
+    if (remote) {
+      subscribe(remote);
+      setupRemote(remote);
+    }
+  }
 
   render() {
     return (

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -20,12 +20,14 @@ class Slide extends Component {
     const slide = this.slideRef;
     const frags = slide.querySelectorAll(".fragment");
     if (frags && frags.length && !this.context.overview) {
+      const lastAction = this.context.store.getState().lastAction;
       Array.prototype.slice.call(frags, 0).forEach((frag, i) => {
         frag.dataset.fid = i;
         return this.props.dispatch && this.props.dispatch(addFragment({
           slide: this.props.hash,
           id: i,
-          visible: this.props.lastSlide > this.props.slideIndex
+          visible: this.props.lastSlide > this.props.slideIndex,
+          remote: lastAction.type === "REMOTE_STATE"
         }));
       });
     }

--- a/src/reducers/fragment.js
+++ b/src/reducers/fragment.js
@@ -1,24 +1,35 @@
 import { handleActions } from "redux-actions";
+const addFragment = (state, action) => {
+  const {
+    id,
+    slide
+  } = action.payload;
+  const s = Object.assign({}, state);
+  s.fragments[slide] = s.fragments[slide] || {};
+  s.fragments[slide][id] = action.payload;
+  return s;
+};
+
+const updateFragment = (state, action) => {
+  const {
+    fragment
+  } = action.payload;
+  const s = Object.assign({}, state);
+  s.fragments[fragment.slide][fragment.id].visible = action.payload.visible;
+  return s;
+};
+
+const initState = (state, action) => {
+  const { fragment } = action.payload;
+  const s = Object.assign({}, state);
+  s.fragments = fragment.fragments;
+  return s;
+};
 
 const reducer = handleActions({
-  ADD_FRAGMENT: (state, action) => {
-    const {
-      id,
-      slide
-    } = action.payload;
-    const s = Object.assign({}, state);
-    s.fragments[slide] = s.fragments[slide] || {};
-    s.fragments[slide][id] = action.payload;
-    return s;
-  },
-  UPDATE_FRAGMENT: (state, action) => {
-    const {
-      fragment
-    } = action.payload;
-    const s = Object.assign({}, state);
-    s.fragments[fragment.slide][fragment.id].visible = action.payload.visible;
-    return s;
-  }
+  ADD_FRAGMENT: addFragment,
+  UPDATE_FRAGMENT: updateFragment,
+  REMOTE_STATE: initState
 }, { fragments: {} });
 
 export default reducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,14 @@ import { combineReducers } from "redux";
 import fragment from "./fragment";
 import route from "./route";
 import style from "./style";
-
+const lastAction = (state = null, action) => {
+  return action;
+};
 const rootReducer = combineReducers({
   fragment,
   route,
-  style
+  style,
+  lastAction
 });
 
 export default rootReducer;

--- a/src/reducers/route.js
+++ b/src/reducers/route.js
@@ -1,16 +1,27 @@
 import { handleActions } from "redux-actions";
+const updateRoute = (state, action) => {
+  const { location, slideCount } = action.payload;
+  const proposedSlideIndex = parseInt(location.pathname.replace(/\//g, ""));
+  const isWithinBounds = proposedSlideIndex < slideCount && proposedSlideIndex >= 0;
+
+  return Object.assign({}, {
+    slide: isWithinBounds ? proposedSlideIndex : 0,
+    params: location.search.replace("?", "").split("&")
+  });
+};
+
+const initState = (state, action) => {
+  const { route } = action.payload;
+
+  return Object.assign({}, {
+    slide: route.slide,
+    params: route.params
+  });
+};
 
 const reducer = handleActions({
-  UPDATE_ROUTE: (state, action) => {
-    const { location, slideCount } = action.payload;
-    const proposedSlideIndex = parseInt(location.pathname.replace(/\//g, ""));
-    const isWithinBounds = proposedSlideIndex < slideCount && proposedSlideIndex >= 0;
-
-    return Object.assign({}, {
-      slide: isWithinBounds ? proposedSlideIndex : 0,
-      params: location.search.replace("?", "").split("&")
-    });
-  }
+  UPDATE_ROUTE: updateRoute,
+  REMOTE_STATE: initState
 }, { slide: 0, params: [] });
 
 export default reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,20 @@
 import { createStore, applyMiddleware } from "redux";
 import reducer from "../reducers";
+import { setup, sendState } from "./remote";
+let store;
+
+
+export const subscribe = (remote) => {
+  store.subscribe(() => sendState(store, remote));
+};
+
+export const setupRemote = (remote) => {
+  setup(store, remote);
+};
 
 const configureStore = () => {
   const createStoreWithMiddleware = applyMiddleware()(createStore);
-  const store = createStoreWithMiddleware(reducer);
+  store = createStoreWithMiddleware(reducer);
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/src/store/remote.js
+++ b/src/store/remote.js
@@ -1,0 +1,38 @@
+import uniqueId from "lodash/uniqueId";
+import { remoteState } from "../actions";
+let connected = false;
+const uid = uniqueId();
+
+export const sendState = (store, socket) => {
+  const state = JSON.parse(JSON.stringify(store.getState()));
+  const action = store.getState().lastAction;
+  const payload = {
+    state,
+    type: "REMOTE_STATE",
+    uid
+  };
+  if (connected && action.type !== "REMOTE_STATE" && !action.payload.remote) {
+    payload.state.route.params.splice(
+      payload.state.route.params.findIndex(
+        (el) => el === "presenter"
+      ),
+      1
+    );
+    socket.send(JSON.stringify(payload));
+  }
+};
+
+export const setup = (store, socket) => {
+  socket.on("open", () => {
+    connected = true;
+  });
+
+  socket.on("message", (event) => {
+    const message = JSON.parse(event.data);
+    switch (message.type) {
+      case "REMOTE_STATE":
+        store.dispatch(remoteState(message.state));
+        break;
+    }
+  });
+};


### PR DESCRIPTION
This adds initial support for remote control of presentations. The example implementation uses websockets however any socket type could be used theoretically. 

It works by transmitting the state on a change action to any connected node. All nodes can control the presentation. However the props specifying presenter mode and overview mode are stripped from the state object prior to transmission. This prevents the node where those modes are invoked from propagating those modes to the other connected nodes.

There is a new action added "REMOTE_STATE" to support this functionality. 

In addition the last action called is stored in state. I think this should be reviewed and may not be necessary if a more correct "Redux" way could be found.

The server has been altered to support websockets and contains some new functionality to support remote control/viewing. One thing to note is that the latest state is saved on the server to allow newly connected nodes to sync to the most current state of the presentation. Right now to completely reset state one of two things must be done. Either restart the server or go back to the very beginning of a presentation.  