### PR TITLE
Reorganize presenter screen to make room for notes

### DIFF
--- a/src/components/__snapshots__/presenter.test.js.snap
+++ b/src/components/__snapshots__/presenter.test.js.snap
@@ -35,8 +35,8 @@ exports[`<Presenter /> should render correctly 1`] = `
         Object {
           "color": "white",
           "display": "block",
-          "height": "20%",
-          "padding": "20px 50px",
+          "height": "10%",
+          "padding": "10px 50px",
           "position": "absolute",
           "textAlign": "center",
           "width": "100%",
@@ -82,99 +82,106 @@ exports[`<Presenter /> should render correctly 1`] = `
       data-radium={true}
       style={
         Object {
-          "alignItems": "center",
           "display": "flex",
           "flex": 1,
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100%",
+          "padding": "10px 50px 0 50px",
         }
       }>
       <div
-        className="spectacle-presenter-main"
         data-radium={true}
         style={
           Object {
-            "border": "2px solid white",
-            "display": "inline-block",
-            "height": "60%",
-            "margin": 20,
-            "padding": 20,
-            "position": "relative",
-            "width": "50%",
+            "display": "flex",
+            "flex": "1",
+            "flexWrap": "wrap",
+            "height": "90%",
+            "justifyContent": "center",
+            "position": "absolute",
+            "top": "10%",
+            "width": "60%",
           }
         }>
-        <Slide
-          dispatch={[Function]}
-          export={false}
-          hash={1}
-          lastSlide={0}
-          presenterStyle={
+        <div
+          className="spectacle-presenter-main"
+          data-radium={true}
+          style={
             Object {
-              "position": "relative",
+              "border": "2px solid white",
+              "display": "flex",
+              "flex": "0 0 100%",
+              "height": "55%",
+              "padding": 20,
             }
-          }
-          print={false}
-          slideIndex={1}
-          transition={Array []}
-          transitionDuration={0}>
-          <div>
-            Slide Content
-          </div>
-        </Slide>
+          }>
+          <Slide
+            dispatch={[Function]}
+            export={false}
+            hash={1}
+            lastSlide={0}
+            presenterStyle={
+              Object {
+                "position": "relative",
+              }
+            }
+            print={false}
+            slideIndex={1}
+            transition={Array []}
+            transitionDuration={0}>
+            <div>
+              Slide Content
+            </div>
+          </Slide>
+        </div>
+        <div
+          className="spectacle-presenter-next"
+          data-radium={true}
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flex": "0 0 68.75%",
+              "height": "40%",
+              "justifyContent": "center",
+              "opacity": 0.4,
+            }
+          }>
+          <Slide
+            appearOff={true}
+            dispatch={[Function]}
+            export={false}
+            hash={2}
+            lastSlide={0}
+            presenterStyle={
+              Object {
+                "position": "relative",
+              }
+            }
+            print={false}
+            slideIndex={2}
+            transition={Array []}
+            transitionDuration={0}>
+            <div>
+              Slide Content
+            </div>
+          </Slide>
+        </div>
       </div>
       <div
-        className="spectacle-presenter-next"
+        className="spectacle-presenter-notes"
         data-radium={true}
         style={
           Object {
-            "border": "2px solid white",
-            "display": "inline-block",
-            "height": "50%",
-            "margin": 20,
-            "padding": 20,
-            "position": "relative",
-            "width": "40%",
+            "color": "white",
+            "display": "block",
+            "height": "90%",
+            "left": "calc(60% + 50px)",
+            "padding": "10px 30px",
+            "position": "absolute",
+            "top": "10%",
+            "width": "calc(40% - 100px)",
           }
-        }>
-        <Slide
-          appearOff={true}
-          dispatch={[Function]}
-          export={false}
-          hash={2}
-          lastSlide={0}
-          presenterStyle={
-            Object {
-              "position": "relative",
-            }
-          }
-          print={false}
-          slideIndex={2}
-          transition={Array []}
-          transitionDuration={0}>
-          <div>
-            Slide Content
-          </div>
-        </Slide>
-      </div>
+        } />
     </div>
-    <div
-      className="spectacle-presenter-notes"
-      data-radium={true}
-      style={
-        Object {
-          "bottom": "0px",
-          "color": "white",
-          "columnCount": "2",
-          "display": "block",
-          "fontSize": "0.8em",
-          "height": "20%",
-          "padding": "20px 50px",
-          "position": "absolute",
-          "textAlign": "left",
-          "width": "100%",
-        }
-      } />
   </div>
 </Presenter>
 `;
@@ -217,8 +224,8 @@ exports[`<Presenter /> should render with notes when slides have them. 1`] = `
         Object {
           "color": "white",
           "display": "block",
-          "height": "20%",
-          "padding": "20px 50px",
+          "height": "10%",
+          "padding": "10px 50px",
           "position": "absolute",
           "textAlign": "center",
           "width": "100%",
@@ -264,106 +271,113 @@ exports[`<Presenter /> should render with notes when slides have them. 1`] = `
       data-radium={true}
       style={
         Object {
-          "alignItems": "center",
           "display": "flex",
           "flex": 1,
-          "height": "100%",
-          "justifyContent": "center",
-          "width": "100%",
+          "padding": "10px 50px 0 50px",
         }
       }>
       <div
-        className="spectacle-presenter-main"
         data-radium={true}
         style={
           Object {
-            "border": "2px solid white",
-            "display": "inline-block",
-            "height": "60%",
-            "margin": 20,
-            "padding": 20,
-            "position": "relative",
-            "width": "50%",
+            "display": "flex",
+            "flex": "1",
+            "flexWrap": "wrap",
+            "height": "90%",
+            "justifyContent": "center",
+            "position": "absolute",
+            "top": "10%",
+            "width": "60%",
           }
         }>
-        <Slide
-          dispatch={[Function]}
-          export={false}
-          hash={1}
-          lastSlide={0}
-          notes="These are my slide notes!!"
-          presenterStyle={
+        <div
+          className="spectacle-presenter-main"
+          data-radium={true}
+          style={
             Object {
-              "position": "relative",
+              "border": "2px solid white",
+              "display": "flex",
+              "flex": "0 0 100%",
+              "height": "55%",
+              "padding": 20,
             }
-          }
-          print={false}
-          slideIndex={1}
-          transition={Array []}
-          transitionDuration={0}>
-          <div>
-            Slide Content
-          </div>
-        </Slide>
+          }>
+          <Slide
+            dispatch={[Function]}
+            export={false}
+            hash={1}
+            lastSlide={0}
+            notes="These are my slide notes!!"
+            presenterStyle={
+              Object {
+                "position": "relative",
+              }
+            }
+            print={false}
+            slideIndex={1}
+            transition={Array []}
+            transitionDuration={0}>
+            <div>
+              Slide Content
+            </div>
+          </Slide>
+        </div>
+        <div
+          className="spectacle-presenter-next"
+          data-radium={true}
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+              "flex": "0 0 68.75%",
+              "height": "40%",
+              "justifyContent": "center",
+              "opacity": 0.4,
+            }
+          }>
+          <Slide
+            appearOff={true}
+            dispatch={[Function]}
+            export={false}
+            hash={2}
+            lastSlide={0}
+            presenterStyle={
+              Object {
+                "position": "relative",
+              }
+            }
+            print={false}
+            slideIndex={2}
+            transition={Array []}
+            transitionDuration={0}>
+            <div>
+              Slide Content
+            </div>
+          </Slide>
+        </div>
       </div>
       <div
-        className="spectacle-presenter-next"
+        className="spectacle-presenter-notes"
         data-radium={true}
         style={
           Object {
-            "border": "2px solid white",
-            "display": "inline-block",
-            "height": "50%",
-            "margin": 20,
-            "padding": 20,
-            "position": "relative",
-            "width": "40%",
+            "color": "white",
+            "display": "block",
+            "height": "90%",
+            "left": "calc(60% + 50px)",
+            "padding": "10px 30px",
+            "position": "absolute",
+            "top": "10%",
+            "width": "calc(40% - 100px)",
           }
         }>
-        <Slide
-          appearOff={true}
-          dispatch={[Function]}
-          export={false}
-          hash={2}
-          lastSlide={0}
-          presenterStyle={
+        <div
+          dangerouslySetInnerHTML={
             Object {
-              "position": "relative",
+              "__html": "These are my slide notes!!",
             }
-          }
-          print={false}
-          slideIndex={2}
-          transition={Array []}
-          transitionDuration={0}>
-          <div>
-            Slide Content
-          </div>
-        </Slide>
+          } />
       </div>
-    </div>
-    <div
-      className="spectacle-presenter-notes"
-      data-radium={true}
-      style={
-        Object {
-          "bottom": "0px",
-          "color": "white",
-          "columnCount": "2",
-          "display": "block",
-          "fontSize": "0.8em",
-          "height": "20%",
-          "padding": "20px 50px",
-          "position": "absolute",
-          "textAlign": "left",
-          "width": "100%",
-        }
-      }>
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "These are my slide notes!!",
-          }
-        } />
     </div>
   </div>
 </Presenter>

--- a/src/components/presenter.js
+++ b/src/components/presenter.js
@@ -79,10 +79,7 @@ export default class Presenter extends Component {
       position: "relative"
     };
     const endStyle = {
-      position: "absolute",
-      top: "50%",
-      left: "50%",
-      transform: "translate(-50%, -50%)",
+      display: "flex",
       margin: 0,
       color: "white"
     };
@@ -133,9 +130,9 @@ export default class Presenter extends Component {
         display: "block",
         color: "white",
         width: "100%",
-        height: "20%",
+        height: "10%",
         textAlign: "center",
-        padding: "20px 50px"
+        padding: "10px 50px"
       },
       slideInfo: {
         position: "relative",
@@ -157,43 +154,45 @@ export default class Presenter extends Component {
         display: "inline-block",
         fontSize: 28
       },
-      preview: {
+      container: {
         display: "flex",
-        width: "100%",
-        height: "100%",
-        alignItems: "center",
-        justifyContent: "center",
-        flex: 1
+        flex: 1,
+        padding: "10px 50px 0 50px"
+      },
+      preview: {
+        position: "absolute",
+        top: "10%",
+        display: "flex",
+        width: "60%",
+        height: "90%",
+        flex: "1",
+        flexWrap: "wrap",
+        justifyContent: "center"
       },
       main: {
-        display: "inline-block",
-        width: "50%",
-        height: "60%",
+        display: "flex",
+        flex: "0 0 100%",
+        height: "55%",
         border: "2px solid white",
-        padding: 20,
-        margin: 20,
-        position: "relative"
+        padding: 20
       },
       next: {
-        display: "inline-block",
-        width: "40%",
-        height: "50%",
-        border: "2px solid white",
-        padding: 20,
-        margin: 20,
-        position: "relative"
+        display: "flex",
+        flex: "0 0 68.75%",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "40%",
+        opacity: 0.4
       },
       notes: {
         position: "absolute",
+        top: "10%",
+        left: "calc(60% + 50px)",
+        height: "90%",
+        width: "calc(40% - 100px)",
         display: "block",
-        color: "white",
-        width: "100%",
-        height: "20%",
-        bottom: "0px",
-        textAlign: "left",
-        padding: "20px 50px",
-        columnCount: "2",
-        fontSize: "0.8em"
+        padding: "10px 30px",
+        color: "white"
       }
     };
     return (
@@ -204,16 +203,18 @@ export default class Presenter extends Component {
           </h2>
           <h2 style={styles.clock}>{this.state.time}</h2>
         </div>
-        <div style={styles.preview}>
-          <div className="spectacle-presenter-main" style={[styles.main]}>
-            {this._renderMainSlide()}
+        <div style={styles.container}>
+          <div style={styles.preview}>
+            <div className="spectacle-presenter-main" style={[styles.main]}>
+              {this._renderMainSlide()}
+            </div>
+            <div className="spectacle-presenter-next" style={[styles.next]}>
+              {this._renderNextSlide()}
+            </div>
           </div>
-          <div className="spectacle-presenter-next" style={[styles.next]}>
-            {this._renderNextSlide()}
+          <div className="spectacle-presenter-notes" style={[styles.notes]}>
+            {this._renderNotes()}
           </div>
-        </div>
-        <div className="spectacle-presenter-notes" style={[styles.notes]}>
-          {this._renderNotes()}
         </div>
       </div>
     );


### PR DESCRIPTION
Addresses #214 

This reorganizes the presenter screen to make more room for slide notes:

![image](https://cloud.githubusercontent.com/assets/13814048/21552875/7338ebe4-cdb9-11e6-8ffd-fd498f172d5f.png)
