### PR TITLE
Update yarn.lock with enzyme to json 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "babel-runtime": "^6.18.0",
     "css-loader": "^0.25.0",
     "enzyme": "^2.5.1",
-    "enzyme-to-json": "^1.3.0",
+    "enzyme-to-json": "1.4.5",
     "eslint": "^3.8.0",
     "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-filenames": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,9 +2031,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-to-json@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.3.0.tgz#58b5eb2d9cc0ddd1250e900e2b8ffb775b85a32a"
+enzyme-to-json@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.4.5.tgz#698d6c209b54527aa3e28658e34b5d9f976f8016"
   dependencies:
     lodash.compact "^3.0.1"
     lodash.isplainobject "^4.0.6"


### PR DESCRIPTION
Ensured yarn and npm both install the latest version of enzyme-to-json so child text strings are properly rendered in the snapshot tests.

// cc: @kenwheeler 