### PR TITLE
Fix typo in getStyles

### DIFF
--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -52,7 +52,7 @@ const convertFontSizeToPx = function (fontSize) {
 };
 
 export const getStyles = function getStyles() {
-  if (process.env.NODE_ENV !== "producion" && typeof this.warnedAboutFontSize === "undefined") {
+  if (process.env.NODE_ENV !== "production" && typeof this.warnedAboutFontSize === "undefined") {
     this.warnedAboutFontSize = false;
   }
 


### PR DESCRIPTION
Fixes a typo when checking the `NODE_ENV` in `getStyles`.