### PR TITLE
Added feature to pass custom component to ComponentPlayground

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -359,6 +359,7 @@ This tag displays a two-pane view with a ES6 source code editor on the right and
 |code|React.PropTypes.string|The code block you want to initially supply to the component playground. If none is supplied a demo component will be displayed.|
 |previewBackgroundColor|React.PropTypes.string|The background color you want for the preview pane. Defaults to `#fff`.|
 |theme|React.PropTypes.string|Accepts `light` or `dark` for the source editor's syntax highlighting. Defaults to `light`.|
+|scope|React.PropTypes.object|Defines any outside modules or components to expose to the playground. React, Component, and render are supplied for you.|
 
 Example code blocks:
 

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -18,6 +18,7 @@ const ComponentPlaygroundContainer = styled.div`
 const ComponentPlayground = ({
   code,
   previewBackgroundColor,
+  scope = {},
   theme = "dark"
 }) => {
   const useDarkTheme = theme === "dark";
@@ -35,7 +36,7 @@ const ComponentPlayground = ({
     >
       <Playground
         codeText={(code || defaultCode).trim()}
-        scope={{ React, Component, render }}
+        scope={{ React, Component, render, ...scope }}
         noRender={false}
         theme={useDarkTheme ? "material" : "elegant"}
       />
@@ -46,6 +47,7 @@ const ComponentPlayground = ({
 ComponentPlayground.propTypes = {
   code: PropTypes.string,
   previewBackgroundColor: PropTypes.string,
+  scope: PropTypes.object,
   theme: PropTypes.string
 };
 

--- a/src/components/component-playground.test.js
+++ b/src/components/component-playground.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "enzyme";
+import { render, shallow } from "enzyme";
 import { renderToJson } from "enzyme-to-json";
 import ComponentPlayground from "./component-playground";
 
@@ -41,5 +41,18 @@ describe("<ComponentPlayground />", () => {
         previewBackgroundColor="#ff0"
       />);
     expect(renderToJson(wrapper)).toMatchSnapshot();
+  });
+
+  test("Should render custom scoped components", () => {
+    const NewComponent = () => (
+      <div><h1>Hi!</h1></div>
+    );
+    const wrapper = shallow(
+      <ComponentPlayground
+        scope={{ NewComponent }}
+      />);
+
+    const scope = wrapper.find("ReactPlayground").prop("scope");
+    expect(scope.NewComponent).toEqual(NewComponent);
   });
 });


### PR DESCRIPTION
Hi Spectacle team! 🙋 Thanks for all your hard work, I'm loving it so far! I wanted to request a feature to pass in a custom component or outside module via the scope prop to ComponentPlayground.

Here's what I did to accomplish this:
- Added scope prop to ComponentPlayground that connects to existing functionality in ReactPlayground from the `component-playground` module
- Updated README to document new prop
- Added test to cover new functionality

Now, you can pass in third-party components & change them on the fly!
![spectaclescope](https://cloud.githubusercontent.com/assets/18017067/22904489/b16ad09c-f20a-11e6-9482-2510dc5d4e50.gif)
