### PR TITLE
Changes Overview to show Slides and SlideSets as a 2D grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "component-playground": "^1.3.1",
+    "dom-scroll-into-view": "^1.2.1",
     "lodash": "^4.16.4",
     "markdown-to-react-components": "^0.2.3",
     "mdast": "^2.1.0",

--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -412,6 +412,9 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
           data-radium={true}
           style={
             Object {
+              "display": "flex",
+              "flexDirection": "row",
+              "flexWrap": "nowrap",
               "height": "100%",
               "overflow": "scroll",
               "width": "100%",
@@ -419,57 +422,87 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
           }>
           <div
             data-radium={true}
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
             style={
               Object {
-                "cursor": "pointer",
-                "float": "left",
+                "display": "flex",
+                "flexDirection": "column",
+                "flexWrap": "nowrap",
                 "height": NaN,
-                "opacity": 1,
-                "position": "relative",
                 "width": NaN,
               }
             }>
-            <MockSlide
-              appearOff={true}
-              export={false}
-              print={false}
-              slideIndex={0}
-              transition={Array []}
-              transitionDuration={0}>
-              <div>
-                Slide Content
-              </div>
-            </MockSlide>
+            <div
+              data-radium={true}
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "cursor": "pointer",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "flexWrap": "nowrap",
+                  "height": NaN,
+                  "opacity": 1,
+                  "position": "relative",
+                  "width": NaN,
+                }
+              }>
+              <MockSlide
+                appearOff={true}
+                export={false}
+                overview={true}
+                print={false}
+                slideIndex={0}
+                transition={Array []}
+                transitionDuration={0}>
+                <div>
+                  Slide Content
+                </div>
+              </MockSlide>
+            </div>
           </div>
           <div
             data-radium={true}
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
             style={
               Object {
-                "cursor": "pointer",
-                "float": "left",
+                "display": "flex",
+                "flexDirection": "column",
+                "flexWrap": "nowrap",
                 "height": NaN,
-                "opacity": 0.5,
-                "position": "relative",
                 "width": NaN,
               }
             }>
-            <MockSlide
-              appearOff={true}
-              export={false}
-              print={false}
-              slideIndex={1}
-              transition={Array []}
-              transitionDuration={0}>
-              <div>
-                Slide Content
-              </div>
-            </MockSlide>
+            <div
+              data-radium={true}
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "cursor": "pointer",
+                  "display": "flex",
+                  "flexDirection": "column",
+                  "flexWrap": "nowrap",
+                  "height": NaN,
+                  "opacity": 0.5,
+                  "position": "relative",
+                  "width": NaN,
+                }
+              }>
+              <MockSlide
+                appearOff={true}
+                export={false}
+                overview={true}
+                print={false}
+                slideIndex={1}
+                transition={Array []}
+                transitionDuration={0}>
+                <div>
+                  Slide Content
+                </div>
+              </MockSlide>
+            </div>
           </div>
         </div>
       </Overview>

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -442,7 +442,6 @@ export default class Manager extends Component {
         <TransitionGroup component="div" style={[styles.transition]}>
           {this._renderSlide()}
         </TransitionGroup>);
-
     }
 
     const showControls = !this.state.fullscreen &&

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -288,8 +288,29 @@ export default class Manager extends Component {
       this._setLocalStorageSlide(prevSlideIndex, true);
     }
   }
-  _upSlide() {}
-  _downSlide() {}
+  // If slide is in a SlideSet, go to previous in set. If not in a set, do nothing.
+  _upSlide() {
+    const slideIndex = this._getSlideIndex();
+    this.setState({ lastSlideIndex: slideIndex });
+    const reference = this.state.slideReference[slideIndex];
+    if (!isUndefined(reference.setIndex) && reference.setIndex > 0) {
+      this._navigateToSlide(slideIndex - 1, this._getSuffix());
+      this._setLocalStorageSlide(slideIndex - 1, true);
+    }
+  }
+  // If slide is in a SlideSet, go to next in set. If not in a set, do nothing.
+  _downSlide() {
+    const slideIndex = this._getSlideIndex();
+    this.setState({ lastSlideIndex: slideIndex });
+    const reference = this.state.slideReference[slideIndex];
+    if (!isUndefined(reference.setIndex)) {
+      const nextReference = this.state.slideReference[slideIndex + 1];
+      if (nextReference.rootIndex === reference.rootIndex) {
+        this._navigateToSlide(slideIndex + 1, this._getSuffix());
+        this._setLocalStorageSlide(slideIndex + 1, true);
+      }
+    }
+  }
   _getHash(slideIndex) {
     return this.state.slideReference[slideIndex].id;
   }

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -1,7 +1,9 @@
 import React, { cloneElement, Children, Component, PropTypes } from "react";
+import { findDOMNode } from "react-dom";
 import Radium from "radium";
+import scrollIntoView from "dom-scroll-into-view";
 
-const slidesPerWidth = 5;
+const slidesPerWidth = 3;
 
 @Radium
 export default class Overview extends Component {
@@ -15,6 +17,12 @@ export default class Overview extends Component {
   componentDidMount() {
     this.resizeHandler();
     window.addEventListener("resize", this.resizeHandler);
+    this._ensureActiveItemVisible();
+  }
+  componentDidUpdate(prevProps) {
+    if (this.props.slideIndex !== prevProps.slideIndex) {
+      this._ensureActiveItemVisible();
+    }
   }
   componentWillUnmount() {
     window.removeEventListener("resize", this.resizeHandler);
@@ -39,7 +47,8 @@ export default class Overview extends Component {
         display: "flex",
         flexDirection: "column",
         flexWrap: "nowrap",
-        width: screen / slidesPerWidth
+        width: screen / slidesPerWidth,
+        height: (screen / slidesPerWidth) * 0.7 * columnSlides.length
       };
       return (
         <div key={`col${rootIndex}`} style={[style]}>
@@ -77,11 +86,25 @@ export default class Overview extends Component {
         appearOff: true
       });
       return (
-        <div key={index} style={[style]} onClick={this._slideClicked.bind(this, index)}>
+        <div
+          ref={index === slideIndex ? (d) => { this.activeSlideRef = d; } : null}
+          key={index}
+          style={[style]}
+          onClick={this._slideClicked.bind(this, index)}
+        >
           {el}
         </div>
       );
     });
+  }
+  _ensureActiveItemVisible() {
+    if (this.activeSlideRef) {
+      scrollIntoView(
+        findDOMNode(this.activeSlideRef),
+        findDOMNode(this.overviewRef),
+        { onlyScrollIfNeeded: true, alignWithLeft: false, alightWithTop: false }
+      );
+    }
   }
   resizeHandler() {
     this.setState({
@@ -91,6 +114,8 @@ export default class Overview extends Component {
   render() {
     const styles = {
       overview: {
+        height: "100%",
+        width: "100%",
         display: "flex",
         flexDirection: "row",
         flexWrap: "nowrap",

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -1,6 +1,7 @@
-import React, { cloneElement, Component, PropTypes } from "react";
+import React, { cloneElement, Children, Component, PropTypes } from "react";
 import Radium from "radium";
-import { getSlideByIndex } from "../utils/slides";
+
+const slidesPerWidth = 5;
 
 @Radium
 export default class Overview extends Component {
@@ -24,31 +25,53 @@ export default class Overview extends Component {
   _getHash(slideIndex) {
     return this.props.slideReference[slideIndex].id;
   }
-  _renderSlides() {
+  _renderSlideColumns() {
+    const screen = this.state.overviewWidth;
+    let startIndex = 0;
+    let nextStartIndex = 0;
+    return this.props.slides.map((slide, rootIndex) => {
+      startIndex = nextStartIndex;
+      const columnSlides = slide.props.hasSlideChildren ?
+        Children.toArray(slide.props.children) :
+        [ slide ];
+      nextStartIndex += columnSlides.length;
+      const style = {
+        display: "flex",
+        flexDirection: "column",
+        flexWrap: "nowrap",
+        width: screen / slidesPerWidth
+      };
+      return (
+        <div key={`col${rootIndex}`} style={[style]}>
+          {this._renderSlides(columnSlides, startIndex)}
+        </div>
+      );
+    });
+  }
+  _renderSlides(columnSlides, startIndex) {
     const slideIndex = this.props.slideIndex;
     const screen = this.state.overviewWidth;
-    return this.props.slideReference.map((reference, index) => {
+    return columnSlides.map((slide, colSlideIndex) => {
+      const index = startIndex + colSlideIndex;
       const style = {
+        display: "flex",
+        flexDirection: "column",
+        flexWrap: "nowrap",
+        width: screen / slidesPerWidth,
+        height: (screen / slidesPerWidth) * 0.7,
         position: "relative",
-        width: screen / 3,
-        height: (screen / 3) * 0.7,
-        float: "left",
         opacity: index === slideIndex ? 1 : 0.5,
         cursor: "pointer",
         ":hover": {
           opacity: 1
         }
       };
-      const slide = getSlideByIndex(
-        this.props.slides,
-        this.props.slideReference,
-        index
-      );
       const el = cloneElement(slide, {
         key: index,
         slideIndex: index,
         export: this.props.route.params.indexOf("export") !== -1,
         print: this.props.route.params.indexOf("print") !== -1,
+        overview: true,
         transition: [],
         transitionDuration: 0,
         appearOff: true
@@ -68,14 +91,15 @@ export default class Overview extends Component {
   render() {
     const styles = {
       overview: {
-        height: "100%",
-        width: "100%",
+        display: "flex",
+        flexDirection: "row",
+        flexWrap: "nowrap",
         overflow: "scroll"
       }
     };
     return (
       <div className="spectacle-overview" ref={(o) => { this.overviewRef = o; }} style={[styles.overview]}>
-        {this._renderSlides()}
+        {this._renderSlideColumns()}
       </div>
     );
   }

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -19,7 +19,7 @@ class Slide extends Component {
     this.setZoom();
     const slide = this.slideRef;
     const frags = slide.querySelectorAll(".fragment");
-    if (frags && frags.length && !this.context.overview) {
+    if (frags && frags.length && !this.props.overview) {
       Array.prototype.slice.call(frags, 0).forEach((frag, i) => {
         frag.dataset.fid = i;
         return this.props.dispatch && this.props.dispatch(addFragment({
@@ -95,11 +95,15 @@ class Slide extends Component {
     };
 
     const overViewStyles = {
+      outer: {
+        backgroundImage: "none"
+      },
       inner: {
         flexDirection: "column"
       },
       content: {
-        width: "100%"
+        width: "100%",
+        fontSize: "2px"
       }
     };
 
@@ -128,16 +132,17 @@ class Slide extends Component {
           styles.outer,
           getStyles.call(this),
           printStyles,
-          presenterStyle
+          presenterStyle,
+          this.props.overview && overViewStyles.outer
         ]}
       >
-        <div style={[styles.inner, this.context.overview && overViewStyles.inner]}>
+        <div style={[styles.inner, this.props.overview && overViewStyles.inner]}>
           <div ref={(c) => { this.contentRef = c; }}
             className={`${contentClass} spectacle-content`}
             style={[
               styles.content,
               this.context.styles.components.content,
-              this.context.overview && overViewStyles.content
+              this.props.overview && overViewStyles.content
             ]}
           >
             {children}
@@ -167,6 +172,7 @@ Slide.propTypes = {
   maxHeight: PropTypes.number,
   maxWidth: PropTypes.number,
   notes: PropTypes.any,
+  overview: PropTypes.bool,
   presenterStyle: PropTypes.object,
   print: PropTypes.bool,
   slideIndex: PropTypes.number,
@@ -178,7 +184,6 @@ Slide.contextTypes = {
   styles: PropTypes.object,
   export: PropTypes.bool,
   print: PropTypes.object,
-  overview: PropTypes.bool,
   store: PropTypes.object
 };
 

--- a/src/utils/keycodes.js
+++ b/src/utils/keycodes.js
@@ -1,0 +1,11 @@
+export const codes = {
+  space: 32,
+  pageUp: 33,
+  pageDown: 34,
+  left: 37,
+  up: 38,
+  right: 39,
+  down: 40,
+  o: 79,
+  p: 80
+};


### PR DESCRIPTION
This updates the overview view to show `SlideSet`s as vertical stacks and allow an up/down/left/right keyboard navigation to navigate slides in a grid (see below).

* on normal presentation and presenter views, keyboard navigation is unaffected. Left/right go forward-next in 1D series
* on overview, left/right/up/down navigates a 2D grid of slides. If you use space/shift+space you'll advance as you would in the presenter view. If you use arrow keys, you will navigate the grid.

Overview if most slides are simple siblings:
![image](https://cloud.githubusercontent.com/assets/3869/22909309/35d3b054-f208-11e6-9cae-f1066f93b72b.png)

Overview with `SlideSet` organization:
![image](https://cloud.githubusercontent.com/assets/3869/22909338/58fe747e-f208-11e6-9678-af25c51c924c.png)

Related to #57