### PR TITLE
Allow using S without a type.

### DIFF
--- a/src/components/__snapshots__/s.test.js.snap
+++ b/src/components/__snapshots__/s.test.js.snap
@@ -1,3 +1,18 @@
+exports[`<S /> should allow custom styling 1`] = `
+<S
+  textColor="magenta">
+  <span
+    data-radium={true}
+    style={
+      Object {
+        "color": "#ff00ff",
+      }
+    }>
+    This text is magenta!
+  </span>
+</S>
+`;
+
 exports[`<S /> should bold text when specified 1`] = `
 <S
   type="bold">

--- a/src/components/s.js
+++ b/src/components/s.js
@@ -8,17 +8,19 @@ export default class S extends Component {
   render() {
     const { type, style, children } = this.props;
     let styles = {};
-    if (type.indexOf("strikethrough") !== -1) {
-      styles = { ...styles, textDecoration: "line-through" };
-    }
-    if (type.indexOf("underline") !== -1) {
-      styles = { ...styles, textDecoration: "underline" };
-    }
-    if (type.indexOf("bold") !== -1) {
-      styles = { ...styles, fontWeight: "bold" };
-    }
-    if (type.indexOf("italic") !== -1) {
-      styles = { ...styles, fontStyle: "italic" };
+    if (typeof type !== "undefined") {
+      if (type.indexOf("strikethrough") !== -1) {
+        styles = { ...styles, textDecoration: "line-through" };
+      }
+      if (type.indexOf("underline") !== -1) {
+        styles = { ...styles, textDecoration: "underline" };
+      }
+      if (type.indexOf("bold") !== -1) {
+        styles = { ...styles, fontWeight: "bold" };
+      }
+      if (type.indexOf("italic") !== -1) {
+        styles = { ...styles, fontStyle: "italic" };
+      }
     }
     return (
       <span className={this.props.className} style={[styles, this.context.styles.components.s[type], getStyles.call(this), style]}>

--- a/src/components/s.test.js
+++ b/src/components/s.test.js
@@ -35,4 +35,22 @@ describe("<S />", () => {
     const wrapper = mount(<S type="italic">This text is italicized!</S>, { context });
     expect(mountToJson(wrapper)).toMatchSnapshot();
   });
+
+  test("should not require a type", () => {
+    const context = { styles: { components: { s: {} } } };
+    expect(() => {
+      const wrapper = mount(<S>This text is normal.</S>, { context });
+    }).not.toThrow();
+  });
+
+  test("should allow custom styling", () => {
+    const context = { styles: {
+      colors: {
+        magenta: "#ff00ff"
+      },
+      components: { s: {} }
+    } };
+    const wrapper = mount(<S textColor="magenta">This text is magenta!</S>, { context });
+    expect(mountToJson(wrapper)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Sorry for submitting a PR without any prior discussion; this is an issue that hits me every time I come at Spectacle again after a month of not writing talks.

Previously, S required a type, even when used only for Base properties like `textColor`. Setting text to `""` or `"normal"` was a workaround; this change removes the requirement altogether.