### PR TITLE
Fix markdown.js codepane bug.

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -28,10 +28,13 @@ const _S = (type) => {
 const _CombineBlockQuote = ({ children }) => <BlockQuote><Quote>{children}</Quote></BlockQuote>;
 _CombineBlockQuote.propTypes = { children: PropTypes.node };
 
+const _CodePane = ({ language, code }) => <CodePane lang={language} source={code}/>;
+_CodePane.propTypes = { code: PropTypes.string, language: PropTypes.string };
+
 markdownToReact.configure({
   a: Link,
   blockquote: _CombineBlockQuote,
-  code: CodePane,
+  code: _CodePane,
   del: _S("strikethrough"),
   em: _S("italic"),
   h1: _Heading(1),


### PR DESCRIPTION
This pull request fixes CodePane render bug when using markdown syntax.

### Sample presentation code 

Note : I attached `Presentation` class without import clause. You can paste and run this code at example/index.js.

``` javascript
export default class Presentation extends React.Component {
  render() {
    return (
      <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
        <Slide transition={["zoom"]} bgColor="white">
          <Markdown>
              {`
  ## CodePane
---

  \`\`\`
  console.log("Hello world!");
  \`\`\`
            `}
          </Markdown>
        </Slide>
      </Deck>
    );
  }
}
```


At current master branch )

![image](https://cloud.githubusercontent.com/assets/4811664/25224512/8e36d206-25f9-11e7-8d3e-0d988a4d5242.png)

After fixes branch )

![image](https://cloud.githubusercontent.com/assets/4811664/25226237/33de8e92-25ff-11e7-811e-38e7752e42b9.png)


This happens because CodePane needs source with `props.source` or `children`, but marked.js (markdown renderer) returns `code` property to implement them.

I fix additional function by changing property `code` to `source`, so we don't modify `CodePane` nor `marked.js` source.