### PR TITLE
Fix preloader to accept an array or object

### DIFF
--- a/src/utils/preloader.js
+++ b/src/utils/preloader.js
@@ -1,9 +1,10 @@
-const preload = (imageArray) => {
-  const images = [];
-  for (let i = 0; i < imageArray.length; i++) {
-    images[i] = new Image();
-    images[i].src = imageArray[i];
-  }
+import forEach from "lodash/forEach";
+
+const preload = (imageCollection) => {
+  forEach(imageCollection, (src) => {
+    const image = new Image();
+    image.src = src;
+  });
 };
 
 export default preload;


### PR DESCRIPTION
In `example/src/index.js`, we are using `preload` like this:

```js
const images = {
  city: require("../assets/city.jpg"),
  kat: require("../assets/kat.png"),
  logo: require("../assets/formidable-logo.svg"),
  markdown: require("../assets/markdown.png")
};

preloader(images);
```

...which is not an array, so images were not actually being preloaded. This updates `preload` to work with both arrays and objects.