### PR TITLE
Add default transition prop

### DIFF
--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -28,6 +28,7 @@ export default class Manager extends Component {
   static displayName = "Manager";
 
   static defaultProps = {
+    transition: [],
     transitionDuration: 500,
     progress: "pacman",
     controls: true,


### PR DESCRIPTION
Addresses #299 and #159 

Adds a default transition prop to prevent transition is undefined error when neither `Deck` or `Slide` have transition props