### PR TITLE
Fix direction of slide transition

### DIFF
--- a/src/components/transitionable.js
+++ b/src/components/transitionable.js
@@ -35,9 +35,9 @@ const Transitionable = function (target) {
     },
 
     transitionDirection() {
-      const { slideIndex, lastSlide } = this.props;
+      const { slideIndex, lastSlideIndex } = this.props;
       const slide = this.context.store.getState().route.slide || 0;
-      return this.state.reverse ? slideIndex > slide : slideIndex > lastSlide;
+      return this.state.reverse ? slideIndex > slide : slideIndex > lastSlideIndex;
     },
 
     getTransitionStyles() {


### PR DESCRIPTION
Defect since introduction of SlideSet in 49b191723591f8aa4f18004a3268256298cde720 in January.

The wrong transition direction is especially visible on forward "slide" transitions.