### PR TITLE
add warning re: deployment to GitHub Pages and dist dir path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,8 @@ Building the dist version of the project is as easy as running `npm run build`
 
 If you want to deploy the slideshow to surge, run `npm run deploy`
 
+<span role="img" aria-label="Warning Sign">⚠️</span> If you are deploying the dist version to [GitHub Pages](https://pages.github.com/ 'GitHub Pages'), note that the built bundle uses an absolute path to the `/dist/` directory while GitHub Pages requires the relative `./dist/` to find any embedded assets and/or images. A very hacky way to fix this is to edit one place in the produced bundle, as shown [in this GitHub issue](https://github.com/FormidableLabs/spectacle/issues/326#issue-233283633 'GitHub: spectacle issue #633').
+
 <a name="presenting"></a>
 ## Presenting
 

--- a/README.markdown
+++ b/README.markdown
@@ -79,7 +79,7 @@ Building the dist version of the project is as easy as running `npm run build`
 
 If you want to deploy the slideshow to surge, run `npm run deploy`
 
-<span role="img" aria-label="Warning Sign">⚠️</span> If you are deploying the dist version to [GitHub Pages](https://pages.github.com/ 'GitHub Pages'), note that the built bundle uses an absolute path to the `/dist/` directory while GitHub Pages requires the relative `./dist/` to find any embedded assets and/or images. A very hacky way to fix this is to edit one place in the produced bundle, as shown [in this GitHub issue](https://github.com/FormidableLabs/spectacle/issues/326#issue-233283633 'GitHub: spectacle issue #633').
+<span role="img" aria-label="Warning Sign">⚠️</span> If you are deploying the dist version to [GitHub Pages](https://pages.github.com/ 'GitHub Pages'), note that the built bundle uses an absolute path to the `/dist/` directory while GitHub Pages requires the relative `./dist/` to find any embedded assets and/or images. A very hacky way to fix this is to edit one place in the produced bundle, as shown [in this GitHub issue](https://github.com/FormidableLabs/spectacle/issues/326#issue-233283633 'GitHub: spectacle issue #326').
 
 <a name="presenting"></a>
 ## Presenting


### PR DESCRIPTION
What it says on the tin. Just a documentation change as discussed in #326.

What your strategy around updating https://formidable.com/open-source/spectacle/docs/? Do you want a PR against spectacle-docs as well?