### PR TITLE
Fix issue #329

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -333,7 +333,6 @@ Markdown generated tags aren't prop configurable, and instead render with your t
 |Name|PropType|Description|
 |---|---|---|
 |source|PropTypes.string| Markdown source |
-|mdastConfig| PropTypes.object | Mdast configuration object |
 
 <a name="element-tags"></a>
 ### Element Tags

--- a/src/components/__snapshots__/markdown-slides.test.js.snap
+++ b/src/components/__snapshots__/markdown-slides.test.js.snap
@@ -13,7 +13,6 @@ exports[`MarkdownSlides should render correctly when using function syntax 1`] =
     >
       
       ## Slide A Title
-      
     </Markdown>
   </Slide>
   <Slide
@@ -25,7 +24,6 @@ exports[`MarkdownSlides should render correctly when using function syntax 1`] =
     <Markdown
       style={Object {}}
     >
-      
       ## Slide B Title
           
     </Markdown>
@@ -45,7 +43,6 @@ exports[`MarkdownSlides should render correctly when using tagged template liter
       style={Object {}}
     >
       ## Slide 1 Title
-      
     </Markdown>
   </Slide>
   <Slide
@@ -57,7 +54,6 @@ exports[`MarkdownSlides should render correctly when using tagged template liter
     <Markdown
       style={Object {}}
     >
-      
       ## Slide 2 Title
     </Markdown>
   </Slide>
@@ -77,7 +73,6 @@ exports[`MarkdownSlides should render correctly when using tagged template liter
     >
       ## Slide 1 Title
       This text is **bold**.
-      
     </Markdown>
   </Slide>
   <Slide
@@ -89,7 +84,6 @@ exports[`MarkdownSlides should render correctly when using tagged template liter
     <Markdown
       style={Object {}}
     >
-      
       ## Slide 2 Title
     </Markdown>
   </Slide>

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -70,7 +70,8 @@ const compile = marksy({
 export default class Markdown extends Component {
   static propTypes = {
     children: PropTypes.node,
-    style: PropTypes.object,
+    source: PropTypes.string,
+    style: PropTypes.object
   };
 
   static defaultProps = {
@@ -78,7 +79,14 @@ export default class Markdown extends Component {
   };
 
   render() {
-    const { style, children } = this.props;
+    const { style, children, source } = this.props;
+    if (source) {
+      return (
+        <div style={style}>
+          {compile(source).tree}
+        </div>
+      );
+    }
     return (
       <div style={style}>
         {compile(children).tree}


### PR DESCRIPTION
This pr fixes issue about #329.

In README, Markdown tag has property 'source'. But, It has no usage on codes. 
So Markdown class will pass 'null' or 'undefined' value to marked.js, `str.replace` method makes exception in conclusion.

I think this commit makes bugs. (Changes markdown passing logic?)
https://github.com/FormidableLabs/spectacle/commit/fe8607de3ed12e58bc0705a2351f5152dd1de4e0#diff-600386b6077350650f252d685cbe2565

And, I found that `mdastConfig` property has removed on that commit, So I removed it from README.md together.