### PR TITLE
Allow presenter notes to scroll

### DIFF
--- a/src/components/presenter-components.js
+++ b/src/components/presenter-components.js
@@ -67,6 +67,7 @@ export const Notes = styled.div`
   position: absolute;
   top: 10%;
   width: (40% - 100px);
+  overflow: auto;
 `;
 
 export const SlideInfo = styled.h2`


### PR DESCRIPTION
Currently, if the content cant fit on the screen you won't be able to see it because the notes don't scroll.

This fixes that