### PR TITLE
Pass child css through to element wrapped in Appear tag

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -82,6 +82,26 @@ export default class Presentation extends React.Component {
             </Heading>
           </Appear>
         </Slide>
+        <Slide transition={["fade"]}>
+          <Layout>
+            <Fill width="100%">
+              <Image src={images.city.replace("/", "")} style={{width: '100%'}} />
+            </Fill>
+            <Appear fid="1" transitionDuration={500}>
+              <Fill width="100%" style={{position: 'absolute', top:40, height: 575, display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
+                <Heading size={3} caps fit textColor="primary">
+                  Overlay Text
+                </Heading>
+                <Heading size={3} caps fit textColor="primary">
+                  <Image src={images.logo} style={{position: 'relative', width: 920}} />
+                </Heading>
+                <Heading size={3} caps fit textColor="primary">
+                  and Images
+                </Heading>
+              </Fill>
+            </Appear>
+          </Layout>
+        </Slide>
         <Slide transition={["zoom", "fade"]} bgColor="primary">
           <Heading caps fit>Flexible Layouts</Heading>
           <Layout>

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -50,7 +50,7 @@ class Appear extends Component {
         {({ opacity }) =>
           React.cloneElement(child, {
             className: 'fragment',
-            style: { opacity },
+            style: { ...child.props.style, opacity },
             ref: f => {
               this.fragmentRef = f;
             },


### PR DESCRIPTION
Fixed a bug where css was lost when applied to an element contained inside an <Appear /> tag.
Also added an example to show how one can use this new ability to layer fragments on top of each other with css. 