### PR TITLE
Fix large image slide cut-offs in presentation mode.

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -58,7 +58,7 @@ export default class Presentation extends React.Component {
           <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
         </Slide>
         <Slide id="wait-what" transition={['slide']} bgColor="black" notes="You can even put notes on your slide. How awesome is that?">
-          <Image src={images.kat.replace('/', '')} margin="0px auto 40px" height="293px"/>
+          <Image src={images.kat.replace('/', '')} margin="0px auto 40px" />
           <Heading size={2} caps fit textColor="primary" textFont="primary">
             Wait what?
           </Heading>

--- a/src/components/__snapshots__/image.test.js.snap
+++ b/src/components/__snapshots__/image.test.js.snap
@@ -14,6 +14,8 @@ exports[`<Image /> should render correctly. 1`] = `
       Object {
         "display": "inline-block",
         "height": 1440,
+        "maxHeight": "100%",
+        "maxWidth": "100%",
         "width": 2560,
       }
     }

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -9,6 +9,8 @@ export default class Image extends Component {
     const styles = {
       width: this.props.width || '',
       height: this.props.height || '',
+      maxWidth: '100%',
+      maxHeight: '100%',
       display: this.props.display || ''
     };
     return (


### PR DESCRIPTION
- Add max height & width to image element
- Updated Tests
- Builds off of PR #357
- Fixes #365 

### Screenshots of Change
- With large image:
  * [Before](https://d28fz8geg24kjr.cloudfront.net/spectacle-large-before.png)
  * [After](https://d28fz8geg24kjr.cloudfront.net/spectacle-large-after.png)
- Small Image:
  * [Before](https://d28fz8geg24kjr.cloudfront.net/spectacle-kat-before.png)
  * [After](https://d28fz8geg24kjr.cloudfront.net/spectacle-kat-after.png)