### PR TITLE
Added .example loader to webpack config files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,10 @@ module.exports = {
         loader: 'url-loader?mimetype=image/jpg',
         include: path.join(__dirname, 'example/assets'),
       },
+      {
+        test: /\.example$/,
+        loader: 'raw-loader'
+      }
     ],
   },
 };

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -39,6 +39,9 @@ module.exports = {
     }, {
       test: /\.svg$/,
       loader: 'url-loader?limit=10000&mimetype=image/svg+xml'
+    }, {
+      test: /\.example$/,
+      loader: 'raw-loader'
     }]
   }
 };

--- a/webpack.config.umd.js
+++ b/webpack.config.umd.js
@@ -58,6 +58,9 @@ module.exports = {
     }, {
       test: /\.svg$/,
       loader: 'url-loader?limit=10000&mimetype=image/svg+xml'
+    }, {
+      test: /\.example$/,
+      loader: 'raw-loader'
     }]
   }
 };


### PR DESCRIPTION
## Why?

>  I prefer putting my code samples in external .example files and requiring them using raw-loader as shown in the demo - https://github.com/FormidableLabs/spectacle#codepane-base

While in the example `source={require('raw-loader!../assets/deck.example')}` works just fine, we get a linter error when working with create-react-app by default. It can be hidden with /* eslint-disable */ ... /* eslint-enable */ but I don't think that's the best solution.

```
Line 24:  Unexpected '!' in 'raw-loader!./assets/hello.example'. Do not use import syntax to configure webpack loaders  import/no-webpack-loader-syntax
```

Since you are recommending `.example` file as source code example files, I thought it would be interesting to have `.example` files to be loaded with the `raw-loader` by deault.