### PR TITLE
Fix React warnings for uppercase HTML heading elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ export default class extends Component {
 
 Here is where you can use the library's tags to compose your presentation. While you can use any JSX syntax here, building your presentation with the supplied tags allows for theming to work properly.
 
-The bare minimum you need to start is a`Deck` element and a `Slide` element. Each `Slide` element represents a slide inside of your slideshow.
+The bare minimum you need to start is a `Deck` element and a `Slide` element. Each `Slide` element represents a slide inside of your slideshow.
 
 <a name="themes"></a>
 ### Themes

--- a/src/components/__snapshots__/heading.test.js.snap
+++ b/src/components/__snapshots__/heading.test.js.snap
@@ -5,7 +5,7 @@ exports[`<Heading /> should render correctly. 1`] = `
   lineHeight={1}
   size={2}
 >
-  <H2
+  <h2
     className={undefined}
     data-radium={true}
     style={
@@ -16,7 +16,7 @@ exports[`<Heading /> should render correctly. 1`] = `
     }
   >
     Hi There!
-  </H2>
+  </h2>
 </Heading>
 `;
 

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -41,7 +41,7 @@ export default class Heading extends Component {
   }
   render() {
     const { size, lineHeight, fit, style, children } = this.props;
-    const Tag = `H${size}`;
+    const Tag = `h${size}`;
     const styles = {
       container: {
         display: 'block',


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/3484188/31626532-b2c8fe20-b26f-11e7-9a58-ecd6fa6cc3a4.png)

Also tested really quick in a fresh CRA / spectacle-scripts repo and the headings still rendered correctly.

Also a minor README spacing fix.