### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Slide Content
 **Function Usage**
 
 ```jsx
-import slidesMarkdown from "raw!markdown.md";
+import slidesMarkdown from "raw-loader!markdown.md";
 
 <Deck ...>
   {MarkdownSlides(slidesMarkdown)}


### PR DESCRIPTION
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'raw-loader' instead of 'raw',
                 see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed