### PR TITLE
Math Tag using KaTeX

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
   Appear, BlockQuote, Cite, CodePane, ComponentPlayground, Deck, Fill,
-  Heading, Image, Layout, Link, ListItem, List, Markdown, MarkdownSlides, Quote, Slide, SlideSet,
+  Heading, Image, Layout, Link, ListItem, List, Math, Markdown, MarkdownSlides, Quote, Slide, SlideSet,
   TableBody, TableHeader, TableHeaderItem, TableItem, TableRow, Table, Text, S
 } from '../../src';
 
@@ -159,6 +159,11 @@ Slides are separated with **three dashes** and can be used _anywhere_ in the dec
 * Imported Markdown from another file
           `
         }
+        <Slide>
+          <Text textSize="5rem"><Math>\KaTeX</Math> based math rendering</Text>
+          <Math math="\int_0^\infty x^2 dx" />
+          <Math displayMode >{'\\text{and } \\pm\\sqrt{a^2 + b^2} \\text{ set in display mode}'}</Math>
+        </Slide>
         <Slide transition={['slide', 'spin']} bgColor="primary">
           <Heading caps fit size={1} textColor="tertiary">
             Smooth

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/prismjs@1.8.1/themes/prism-tomorrow.css" rel="stylesheet" type="text/css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha1/katex.min.css" rel="stylesheet" type="text/css" integrity="sha384-8QOKbPtTFvh/lMY0qPVbXj9hDh+v8US0pD//FcoYFst2lCIf0BmT58+Heqj0IGyx" crossorigin="anonymous">
 </head>
 <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "component-playground": "^3.0.0",
     "emotion": "^8.0.8",
     "history": "^4.6.1",
+    "katex": "^0.9.0-alpha1",
     "lodash": "^4.17.4",
     "marksy": "^0.4.2",
     "normalize.css": "^7.0.0",

--- a/src/components/math.js
+++ b/src/components/math.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { getStyles } from '../utils/base';
+import styled from 'react-emotion';
+import katex from 'katex';
+
+const StyledMath = styled.span(props => props.styles);
+const StyledDisplayMath = styled.div(props => props.styles);
+
+/**
+ * KaTeX based Math tag for rendering LaTeX based math inside spectacle.
+ * 
+ * Following features are supported:
+ *  - displayMode
+ *  - Usage of react children attribute for input
+ *  - Usage of math attribute for input
+ *  - Pass in additional styling in the theme
+ *  - Renders the error message when rendering fails
+ * @export
+ * @class Math
+ * @extends {Component}
+ */
+export default class Math extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      html: this.generateHtml(this.props)
+    };
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    nextState.html = this.generateHtml(nextProps);
+  }
+
+  generateHtml(props) {
+    let rendered;
+    try {
+      rendered = katex.renderToString(props.math || props.children, {
+        displayMode: this.props.displayMode
+      });
+    } catch (e) {
+      rendered = `<span>${e.message}</span>`;
+    }
+
+    return rendered;
+  }
+
+  render() {
+    const markup = { __html: this.state.html };
+    const MathTag = this.props.displayMode ? StyledDisplayMath : StyledMath;
+
+    return (
+      <MathTag
+        className={this.props.className}
+        styles={[
+          this.context.styles.components.math,
+          getStyles.call(this),
+          this.props.style
+        ]}
+        dangerouslySetInnerHTML={markup}
+      />
+    );
+  }
+}
+
+Math.propTypes = {
+  children: PropTypes.string,
+  className: PropTypes.string,
+  displayMode: PropTypes.bool,
+  math: PropTypes.string,
+  style: PropTypes.object
+};
+
+Math.defaultProps = {
+  math: null,
+  displayMode: false
+};
+
+Math.contextTypes = {
+  styles: PropTypes.object,
+  store: PropTypes.object
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import Layout from './components/layout';
 import Link from './components/link';
 import ListItem from './components/list-item';
 import List from './components/list';
+import Math from './components/math';
 import Markdown from './components/markdown';
 import MarkdownSlides from './components/markdown-slides';
 import Notes from './components/notes';
@@ -52,6 +53,7 @@ export {
   Link,
   ListItem,
   List,
+  Math,
   Markdown,
   MarkdownSlides,
   Notes,

--- a/src/themes/default/screen.js
+++ b/src/themes/default/screen.js
@@ -295,6 +295,8 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
         listStylePosition: 'inside',
         padding: 0,
       },
+      math: {
+      },
       s: {
         strikethrough: {},
       },


### PR DESCRIPTION
This PR adds a Math Tag that supports simple and inline modes. The math is rendered by KaTeX.

You can use it like this:
```jsx
<Slide>
  <Text textSize="5rem"><Math>\KaTeX</Math> based math rendering</Text>
  <Math math="\int_0^\infty x^2 dx" />
  <Math displayMode >{'\\text{and } \\pm\\sqrt{a^2 + b^2} \\text{ set in display mode}'}</Math>
</Slide>
```

![image](https://user-images.githubusercontent.com/1634468/32142618-3e47e4cc-bc9b-11e7-9753-6e0f9ab44139.png)

ToDos:

- [ ] Create tests
- [ ] Integrate into Markdown-Component (marksy seems to use outdated chij/marked)
- [ ] improve example