### PR TITLE
Bundle Prism and use react-live's Editor instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,11 @@ We can start with this project's sample at [`one-page.html`](./one-page.html). I
     <title>Spectacle</title>
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
-    <link href="https://unpkg.com/prismjs@1/themes/prism-tomorrow.css" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/normalize.css@7/normalize.css" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/spectacle/lib/themes/default/index.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div id="root"></div>
-    <script src="https://unpkg.com/prismjs@1/prism.js"></script>
-    <script src="https://unpkg.com/prismjs@1/components/prism-jsx.min.js"></script>
     <script src="https://unpkg.com/prop-types@15/prop-types.js"></script>
     <script src="https://unpkg.com/react@15/dist/react.js"></script>
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
@@ -485,8 +482,6 @@ This tag displays a styled, highlighted code preview. I prefer putting my code s
 |---|---|---|
 |lang|PropTypes.string| Prism compatible language name. i.e: 'javascript' |
 |source| PropTypes.string| String of code to be shown |
-
-You can change your syntax highlighting theme by swapping the prism.js CSS file in `index.html`
 
 <a name="code-base"></a>
 #### Code (Base)

--- a/docs/tag-api.md
+++ b/docs/tag-api.md
@@ -112,7 +112,7 @@ This tag displays a styled, highlighted code preview. I prefer putting my code s
 |lang|PropTypes.string| Prism compatible language name. i.e: 'javascript' |
 |source| PropTypes.string| String of code to be shown |
 
-You can change your syntax highlighting theme by swapping the prism.js CSS file in `index.html`. Prism.js supports `Markup`, `CSS`, `C-like`and `Javascript` languages out of the box. To add more [supported languages](http://prismjs.com/#languages-list), you have to load the respective language's prism.js plugin in your index.html. 
+Prism.js supports `Markup`, `CSS`, `C-like`and `Javascript` languages out of the box. To add more [supported languages](http://prismjs.com/#languages-list), you have to import the respective language's prism.js component/plugin from `prismjs/components/prism-javascript`.
 
 <a name="code-base"></a>
 ### Code (Base)

--- a/docs/tag-api.md
+++ b/docs/tag-api.md
@@ -112,7 +112,7 @@ This tag displays a styled, highlighted code preview. I prefer putting my code s
 |lang|PropTypes.string| Prism compatible language name. i.e: 'javascript' |
 |source| PropTypes.string| String of code to be shown |
 
-Prism.js supports `Markup`, `CSS`, `C-like`and `Javascript` languages out of the box. To add more [supported languages](http://prismjs.com/#languages-list), you have to import the respective language's prism.js component/plugin from `prismjs/components/prism-javascript`.
+Prism.js supports `Markup`, `CSS`, `C-like`and `Javascript` languages out of the box. To add more [supported languages](http://prismjs.com/#languages-list), you have to import the respective language's prism.js component/plugin from `prismjs/components/prism-LANG`, where `LANG` is the language/component you'd like to add.
 
 <a name="code-base"></a>
 ### Code (Base)

--- a/index.html
+++ b/index.html
@@ -6,12 +6,9 @@
     <title>Spectacle</title>
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
-    <link href="https://unpkg.com/prismjs@1.8.1/themes/prism-tomorrow.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div id="root"></div>
-    <script src="https://unpkg.com/prismjs@1.8.1/prism.js"></script>
-    <script src="https://unpkg.com/prismjs@1.8.1/components/prism-jsx.min.js"></script>
     <script src="./dist/bundle.js"></script>
 </body>
 </html>

--- a/one-page.html
+++ b/one-page.html
@@ -6,14 +6,11 @@
     <title>Spectacle</title>
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
-    <link href="https://unpkg.com/prismjs@1/themes/prism-tomorrow.css" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/normalize.css@7/normalize.css" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/spectacle/lib/themes/default/index.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div id="root"></div>
-    <script src="https://unpkg.com/prismjs@1/prism.js"></script>
-    <script src="https://unpkg.com/prismjs@1/components/prism-jsx.min.js"></script>
     <script src="https://unpkg.com/prop-types@15/prop-types.js"></script>
     <script src="https://unpkg.com/react@15/dist/react.js"></script>
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>

--- a/one-page.html
+++ b/one-page.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
     <link href="https://unpkg.com/normalize.css@7/normalize.css" rel="stylesheet" type="text/css">
-    <link href="https://unpkg.com/spectacle/lib/themes/default/index.css" rel="stylesheet" type="text/css">
+    <link href="https://unpkg.com/spectacle@^4/lib/themes/default/index.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div id="root"></div>
@@ -15,8 +15,8 @@
     <script src="https://unpkg.com/react@15/dist/react.js"></script>
     <script src="https://unpkg.com/react-dom@15/dist/react-dom.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
-    <script src="https://unpkg.com/spectacle/dist/spectacle.js"></script>
-    <script src="https://unpkg.com/spectacle/lib/one-page.js"></script>
+    <script src="https://unpkg.com/spectacle@^4/dist/spectacle.js"></script>
+    <script src="https://unpkg.com/spectacle@^4/lib/one-page.js"></script>
     <script type="text/spectacle">
       () => {
         // --------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "normalize.css": "^7.0.0",
     "prismjs": "^1.6.0",
     "react-emotion": "^8.0.8",
-    "react-live": "^1.7.1",
+    "react-live": "^1.8.0-1",
     "react-redux": "^5.0.5",
     "react-transition-group": "^1.1.3",
     "react-typography": "^0.16.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.17.4",
     "marksy": "^0.4.2",
     "normalize.css": "^7.0.0",
+    "prismjs": "^1.6.0",
     "react-emotion": "^8.0.8",
     "react-live": "^1.7.1",
     "react-redux": "^5.0.5",

--- a/src/components/__snapshots__/code-pane.test.js.snap
+++ b/src/components/__snapshots__/code-pane.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`<CodePane /> should render correctly. 1`] = `
 <CodePane
+  className=""
+  contentEditable={false}
   lang="jsx"
   source="
       const myButton = (
@@ -13,57 +15,80 @@ exports[`<CodePane /> should render correctly. 1`] = `
         </CustomButton>
       );
     "
+  theme="dark"
 >
-  <Styled(pre)
-    className={undefined}
+  <Styled(div)
+    className="react-live react-live-dark "
     styles={
       Array [
-        Object {},
+        undefined,
         Object {},
         undefined,
       ]
     }
   >
-    <pre
-      className="css-0"
+    <div
+      className="react-live react-live-dark  css-0"
     >
-      <Styled(code)
-        className="language-jsx"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "
-                const myButton = (
-                  &lt;CustomButton
-                    style={{ background: '#f00' }}
-                    onClick={this.action}
-                  &gt;
-                   Click Me
-                  &lt;/CustomButton&gt;
-                );
-              ",
-          }
-        }
+      <Styled(Editor)
+        code="
+            const myButton = (
+              <CustomButton
+                style={{ background: '#f00' }}
+                onClick={this.action}
+              >
+               Click Me
+              </CustomButton>
+            );
+          "
+        contentEditable={false}
+        language="jsx"
         styles={undefined}
       >
-        <code
-          className="language-jsx css-0"
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "
-                  const myButton = (
-                    &lt;CustomButton
-                      style={{ background: '#f00' }}
-                      onClick={this.action}
-                    &gt;
-                     Click Me
-                    &lt;/CustomButton&gt;
-                  );
-                ",
+        <Editor
+          className="css-0"
+          code="
+              const myButton = (
+                <CustomButton
+                  style={{ background: '#f00' }}
+                  onClick={this.action}
+                >
+                 Click Me
+                </CustomButton>
+              );
+            "
+          contentEditable={false}
+          language="jsx"
+          styles={undefined}
+        >
+          <pre
+            className="prism-code css-0"
+            contentEditable={false}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "
+                    <span class=\\"token keyword\\">const</span> myButton <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>
+                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>CustomButton</span>
+                        <span class=\\"token attr-name\\">style</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">{</span> background<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">'#f00'</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">}</span></span>
+                        <span class=\\"token attr-name\\">onClick</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">.</span>action<span class=\\"token punctuation\\">}</span></span>
+                      <span class=\\"token punctuation\\">></span></span>
+                       Click Me
+                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>CustomButton</span><span class=\\"token punctuation\\">></span></span>
+                    <span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>
+                  ",
+              }
             }
-          }
-        />
-      </Styled(code)>
-    </pre>
-  </Styled(pre)>
+            language="jsx"
+            onClick={undefined}
+            onKeyDown={undefined}
+            onKeyUp={undefined}
+            spellCheck="false"
+            style={undefined}
+            styles={undefined}
+          />
+        </Editor>
+      </Styled(Editor)>
+    </div>
+  </Styled(div)>
 </CodePane>
 `;

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -48,6 +48,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
+        language="jsx"
         spellcheck="false"
       >
         <span
@@ -80,7 +81,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -93,7 +94,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -111,7 +112,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -124,7 +125,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -136,7 +137,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -149,7 +150,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -162,7 +163,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -230,7 +231,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -251,7 +252,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -304,7 +305,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -328,7 +329,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -349,7 +350,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -402,8 +403,8 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -424,7 +425,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -569,6 +570,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
+        language="jsx"
         spellcheck="false"
       >
         <span
@@ -601,7 +603,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -614,7 +616,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -632,7 +634,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -645,7 +647,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -657,7 +659,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -670,7 +672,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -683,7 +685,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -751,7 +753,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -772,7 +774,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -825,7 +827,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -849,7 +851,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -870,7 +872,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -923,8 +925,8 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -945,7 +947,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1091,6 +1093,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
+        language="jsx"
         spellcheck="false"
       >
         <span
@@ -1123,7 +1126,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -1136,7 +1139,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -1154,7 +1157,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -1167,7 +1170,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -1179,7 +1182,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -1192,7 +1195,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -1205,7 +1208,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -1273,7 +1276,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1294,7 +1297,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1347,7 +1350,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -1371,7 +1374,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1392,7 +1395,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1445,8 +1448,8 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -1467,7 +1470,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1607,6 +1610,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
+        language="jsx"
         spellcheck="false"
       >
         <span
@@ -1746,7 +1750,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
           ;
         </span>
         
-        			
+              
         <span
           class="token function"
         >

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-import '../utils/prismImport';
+import '../utils/prism-import';
 import { Editor } from 'react-live';
 
 const StyledWrapper = styled.div(props => props.styles);

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -1,44 +1,42 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
-import isUndefined from 'lodash/isUndefined';
 import styled from 'react-emotion';
 
-const format = (str) => {
-  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-};
+import '../utils/prismImport';
+import { Editor } from 'react-live';
 
-const StyledPre = styled.pre(props => props.styles);
-const StyledCode = styled.code(props => props.styles);
+const StyledWrapper = styled.div(props => props.styles);
+const StyledEditor = styled(Editor)(props => props.styles);
 
 export default class CodePane extends Component {
-  componentDidMount() {
-    return window.Prism && window.Prism.highlightAll();
-  }
-  createMarkup() {
-    const { source, children } = this.props;
-    const code = (isUndefined(source) || source === '') ? children : source;
-    return {
-      __html: format(code)
-    };
-  }
   render() {
-    const preStyles = [
-      this.context.styles.components.codePane.pre,
+    const useDarkTheme = this.props.theme === 'dark';
+
+    if (useDarkTheme) {
+      require('../themes/default/prism.dark.css');
+    } else {
+      require('../themes/default/prism.light.css');
+    }
+
+    const wrapperStyles = [
+      this.context.styles.components.codePane.wrapper,
       getStyles.call(this),
       this.props.style
     ];
+
     return (
-      <StyledPre
-        className={this.props.className}
-        styles={preStyles}
+      <StyledWrapper
+        className={`react-live react-live-${useDarkTheme ? 'dark' : 'light'} ${this.props.className}`}
+        styles={wrapperStyles}
       >
-        <StyledCode
-          className={`language-${this.props.lang}`}
-          styles={this.context.styles.components.codePane.code}
-          dangerouslySetInnerHTML={this.createMarkup()}
+        <StyledEditor
+          code={this.props.source}
+          language={this.props.lang}
+          contentEditable={this.props.contentEditable}
+          styles={this.context.styles.components.codePane.editor}
         />
-      </StyledPre>
+      </StyledWrapper>
     );
   }
 }
@@ -51,12 +49,17 @@ CodePane.contextTypes = {
 CodePane.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  contentEditable: PropTypes.bool,
   lang: PropTypes.string,
   source: PropTypes.string,
-  style: PropTypes.object
+  style: PropTypes.object,
+  theme: PropTypes.string,
 };
 
 CodePane.defaultProps = {
+  theme: 'dark',
+  className: '',
+  contentEditable: false,
   lang: 'markup',
-  source: ''
+  source: '',
 };

--- a/src/themes/default/print.js
+++ b/src/themes/default/print.js
@@ -168,18 +168,18 @@ const print = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
         textAlign: 'center',
       },
       codePane: {
-        pre: {
+        wrapper: {
           maxWidth: 800,
           margin: 'auto',
           fontSize: '0.8rem',
           fontWeight: 'normal',
           fontFamily: fonts.tertiary,
         },
-        code: {
+        editor: {
           textAlign: 'left',
           padding: 20,
           fontWeight: 'normal',
-        },
+        }
       },
       code: {
         color: 'black',

--- a/src/themes/default/screen.js
+++ b/src/themes/default/screen.js
@@ -207,7 +207,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
         textAlign: 'center',
       },
       codePane: {
-        pre: {
+        wrapper: {
           margin: 'auto',
           fontSize: '0.8rem',
           fontWeight: 'normal',
@@ -215,8 +215,9 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
           minWidth: '100%',
           maxWidth: 800,
         },
-        code: {
+        editor: {
           textAlign: 'left',
+          padding: 20,
           fontWeight: 'normal',
         },
       },

--- a/src/utils/prism-import.js
+++ b/src/utils/prism-import.js
@@ -1,5 +1,3 @@
-/* eslint-disable filenames/match-regex */
-
 import 'prismjs/components/prism-core';
 
 // NOTE: This includes a "slim" list of some components of prism, but not all

--- a/src/utils/prismImport.js
+++ b/src/utils/prismImport.js
@@ -1,0 +1,48 @@
+/* eslint-disable filenames/match-regex */
+
+import 'prismjs/components/prism-core';
+
+// NOTE: This includes a "slim" list of some components of prism, but not all
+// For more, see: https://github.com/PrismJS/prism/blob/1fd690dd8a652dee375acb78b6034c3fc2db687c/components.js
+// and: https://github.com/PrismJS/prism/tree/gh-pages/components
+import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-clike';
+import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-cpp';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-coffeescript';
+import 'prismjs/components/prism-actionscript';
+import 'prismjs/components/prism-css-extras';
+import 'prismjs/components/prism-diff';
+import 'prismjs/components/prism-docker';
+import 'prismjs/components/prism-elixir';
+import 'prismjs/components/prism-erlang';
+import 'prismjs/components/prism-git';
+import 'prismjs/components/prism-go';
+import 'prismjs/components/prism-graphql';
+import 'prismjs/components/prism-handlebars';
+import 'prismjs/components/prism-haskell';
+import 'prismjs/components/prism-java';
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-latex';
+import 'prismjs/components/prism-less';
+import 'prismjs/components/prism-makefile';
+import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-objectivec';
+import 'prismjs/components/prism-ocaml';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-php-extras';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-reason';
+import 'prismjs/components/prism-ruby';
+import 'prismjs/components/prism-rust';
+import 'prismjs/components/prism-sass';
+import 'prismjs/components/prism-scss';
+import 'prismjs/components/prism-sql';
+import 'prismjs/components/prism-stylus';
+import 'prismjs/components/prism-swift';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-vim';
+import 'prismjs/components/prism-yaml';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,9 +4915,9 @@ react-emotion@^8.0.8:
     babel-plugin-emotion "^8.0.6"
     emotion-utils "^8.0.6"
 
-react-live@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.7.1.tgz#a4fc7a4d23c2596cf7d4ed10f62dca9a02915e26"
+react-live@^1.8.0-1:
+  version "1.8.0-1"
+  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.8.0-1.tgz#9ee81589e6ae2e728ef0d993e517af133de27c5b"
   dependencies:
     buble "^0.15.2"
     core-js "^2.4.1"


### PR DESCRIPTION
Fix #388 

- Remove all references to prism's CSS and CDN bundle from the readme
- Add prismjs package
- Use react-live's `1.8.0-1` i.e. `spectacletest` release which includes a `language` prop and externalised prism build
- Add `src/utils/prism-import` file (**This includes all syntaxes that we'll support out of the box**)
- Mirror ComponentPlayground theming and setup
- Rename theme properties

**Breaking Changes:**

- The `codePane` theme's properties have been changed to `wrapper` and `editor`. They could stay `pre` and `code`, but this wouldn't reflect the actual elements accurately.

**Future:**

It'd be great to add some instructions on how to add more prism components. The added text to the Readme is minimal but doesn't really say much.

It'd be great to make the playground and codepane's theme props only recognise `light` and `dark` so that it can be set to another value so the user can write/use their own themes.

**Improvements Summary:**

So while the bundle will grow, since more prism components are now included (which doesn't matter much since removing codemirror and babel-standalone for buble should've helper it a little), this gets rid of extra setup steps for the user. Previously a Prism CSS and CDN bundle would have to be added manually.

Also, this should make the syntax theme between the playground and the codepane 100% consistent.