### PR TITLE
Added out-of-order slide navigation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ The slide tag represents each slide in the presentation. Giving a slide tag an `
 |Name|PropType|Description|
 |---|---|---|
 |align| PropTypes.string | Accepts a space delimited value for positioning interior content. The first value can be `flex-start` (left), `center` (middle), or `flex-end` (right). The second value can be `flex-start` (top) , `center` (middle), or `flex-end` (bottom). You would provide this prop like `align="center center"`, which is its default.
+|goTo| PropTypes.number | Used to navigate to a slide for out-of-order presenting. Slide numbers start at `1`. This can also be used to skip slides as well.
 |id| PropTypes.string | Used to create a string based hash.
 |maxHeight| PropTypes.number | Used to set max dimensions of the Slide.
 |maxWidth| PropTypes.number | Used to set max dimensions of the Slide.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -59,6 +59,7 @@ export default class Presentation extends React.Component {
         </Slide>
         <Slide
           id="wait-what"
+          goTo={4}
           transition={[
             'fade',
             (transitioning, forward) => {
@@ -93,7 +94,7 @@ export default class Presentation extends React.Component {
             overflow = "overflow"
           />
         </Slide>
-        <Slide>
+        <Slide goTo={3}>
           <ComponentPlayground
             theme="dark"
           />

--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -17,6 +17,11 @@ exports[`<Manager /> should render correctly. 1`] = `
     contentWidth={1000}
     controls={true}
     dispatch={[Function]}
+    fragment={
+      Object {
+        "fragments": Array [],
+      }
+    }
     globalStyles={true}
     progress="pacman"
     route={
@@ -101,7 +106,11 @@ exports[`<Manager /> should render correctly. 1`] = `
               <MockSlide
                 dispatch={[Function]}
                 export={false}
-                fragments={undefined}
+                fragments={
+                  Object {
+                    "fragments": Array [],
+                  }
+                }
                 hash={0}
                 key=".$0"
                 lastSlideIndex={0}
@@ -273,6 +282,11 @@ exports[`<Manager /> should render the export configuration when specified. 1`] 
     contentWidth={1000}
     controls={true}
     dispatch={[Function]}
+    fragment={
+      Object {
+        "fragments": Array [],
+      }
+    }
     globalStyles={true}
     progress="pacman"
     route={
@@ -396,6 +410,11 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
     contentWidth={1000}
     controls={true}
     dispatch={[Function]}
+    fragment={
+      Object {
+        "fragments": Array [],
+      }
+    }
     globalStyles={true}
     progress="pacman"
     route={
@@ -567,6 +586,11 @@ exports[`<Manager /> should render with slideset slides 1`] = `
     contentWidth={1000}
     controls={true}
     dispatch={[Function]}
+    fragment={
+      Object {
+        "fragments": Array [],
+      }
+    }
     globalStyles={true}
     progress="pacman"
     route={
@@ -664,7 +688,11 @@ exports[`<Manager /> should render with slideset slides 1`] = `
               <MockSlide
                 dispatch={[Function]}
                 export={false}
-                fragments={undefined}
+                fragments={
+                  Object {
+                    "fragments": Array [],
+                  }
+                }
                 hash={1}
                 key=".$1"
                 lastSlideIndex={1}

--- a/src/components/manager.test.js
+++ b/src/components/manager.test.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 import Manager from './manager';
+import range from 'lodash/range';
 
 const _mockContext = function(slide, routeParams) {
   return {
@@ -23,6 +24,9 @@ const _mockContext = function(slide, routeParams) {
         style: {
           globalStyleSet: [],
         },
+        fragment: {
+          fragments: []
+        }
       }),
       dispatch: () => {},
       subscribe: () => {},
@@ -54,6 +58,12 @@ const _mockChildContext = function() {
 };
 
 describe('<Manager />', () => {
+  beforeEach(() => {
+    window.localStorage = { setItem: () => {} };
+  });
+  afterEach(() => {
+    window.localStorage = undefined;
+  });
   test('should render correctly.', () => {
     const wrapper = mount(
       <Manager transition={['zoom', 'slide']} transitionDuration={500}>
@@ -105,5 +115,69 @@ describe('<Manager />', () => {
       { context: _mockContext(1, []), childContextTypes: _mockChildContext() }
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  test('should get the next index when using out-of-order viewing', () => {
+    const wrapper = mount(
+      <Manager>
+        {range(0, 10).map(value => <MockSlide key={value} />)}
+      </Manager>,
+      { context: _mockContext(5, []), childContextTypes: _mockChildContext() }
+    );
+    const managerInstance = wrapper.instance().getWrappedInstance();
+    managerInstance.viewedIndexes = new Set([0, 1, 2, 5, 4, 3]);
+    // The next unviwed index should sort the set and figure out the next
+    // best slide to go to, since 0 through 5 have been visited, 6 is the best.
+    expect(managerInstance._nextUnviewedIndex()).toEqual(6);
+  });
+
+  test('should not exceed the maximum number of slides for next index', () => {
+    const wrapper = mount(
+      <Manager>
+        {range(0, 11).map(value => <MockSlide key={value} />)}
+      </Manager>,
+      { context: _mockContext(10, []), childContextTypes: _mockChildContext() }
+    );
+    const managerInstance = wrapper.instance().getWrappedInstance();
+    managerInstance.viewedIndexes = new Set([0, 1, 2, 5, 4, 3, 6, 9, 10, 7, 8]);
+    // Even though we are on index 10, index 10 is still the next best index
+    // because there are no more slides in the deck.
+    expect(managerInstance._nextUnviewedIndex()).toEqual(10);
+  });
+
+  test('should calc a negative offset when routing from a higher index slide to lower', () => {
+    const wrapper = mount(
+      <Manager>
+        <MockSlide />
+        <MockSlide goTo={4} />
+        <MockSlide />
+        <MockSlide goTo={3} />
+        <MockSlide />
+      </Manager>,
+      { context: _mockContext(3, []), childContextTypes: _mockChildContext() }
+    );
+    const managerInstance = wrapper.instance().getWrappedInstance();
+    managerInstance.viewedIndexes = new Set([0, 1, 3]);
+    // We are at slide 4 (index 3) which directs us to go to
+    // slide 3 (index 2) the delta should be 2 - 3, thus -1.
+    expect(managerInstance._getOffset(3)).toEqual(-1);
+  });
+
+  test('should calc a positive offset when routing from a lower index slide to higher', () => {
+    const wrapper = mount(
+      <Manager>
+        <MockSlide />
+        <MockSlide goTo={4} />
+        <MockSlide />
+        <MockSlide goTo={3} />
+        <MockSlide />
+      </Manager>,
+      { context: _mockContext(1, []), childContextTypes: _mockChildContext() }
+    );
+    const managerInstance = wrapper.instance().getWrappedInstance();
+    managerInstance.viewedIndexes = new Set([0, 1]);
+    // We are at slide 2 (index 1) which directs us to go to
+    // slide 4 (index 3) the delta should be 3 - 1, thus 2.
+    expect(managerInstance._getOffset(1)).toEqual(2);
   });
 });


### PR DESCRIPTION
- [x] Adds support for out-of-order presenting via a `goTo` prop on `<Slide />`
- [x] Added unit tests for helper functions for calculating offsets and next unviewed slide index

I used a `Set` to track viewed indexes to ensure slides are only shown once. Indexes _are_ removed when we navigate backwards so slides can be re-shown. A viewed index ordered set is necessary to prevent an infinite loop. For example, if Slide 2 directs to 4, and Slide 4 directs to 3, when we go forward from 3, we want to go to 5, otherwise we will be stuck in a loop of 4 to 2, 2 to 3 to 4.

Addresses #375 

