### PR TITLE
Fix ComponentPlayground invalid props and key events

### DIFF
--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -1069,7 +1069,6 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
     >
       <div
         class="react-live-preview css-cv4xj2"
-        previewbackgroundcolor="#ff0"
       >
         <div>
           <h1
@@ -1591,7 +1590,6 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
     >
       <div
         class="react-live-preview css-cv4xj2"
-        previewbackgroundcolor="#ff0"
       >
         
       </div>

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -18,13 +18,13 @@ export const PlaygroundProvider = styled(LiveProvider)`
   overflow: hidden;
 `;
 
-const PlaygroundPreview = styled(LivePreview)`
+const PlaygroundPreview = styled(({ className }) => (
+  <LivePreview className={className} />
+))`
   padding: 0.5rem;
   min-height: 100%;
 
-  background: ${(props) => (
-    props.previewBackgroundColor || '#fff'
-  )};
+  background: ${p => p.previewBackgroundColor || '#fff'};
 `;
 
 const PlaygroundEditor = styled(LiveEditor)`
@@ -86,48 +86,63 @@ const PlaygroundError = styled(LiveError)`
   padding: 0.5rem;
 `;
 
-const ComponentPlayground = ({
-  code,
-  previewBackgroundColor,
-  scope = {},
-  theme = 'dark'
-}) => {
-  const useDarkTheme = theme === 'dark';
+class ComponentPlayground extends Component {
+  onKeyUp = evt => {
+    evt.stopPropagation();
+  };
 
-  if (useDarkTheme) {
-    require('../themes/default/prism.dark.css');
-  } else {
-    require('../themes/default/prism.light.css');
+  onKeyDown = evt => {
+    evt.stopPropagation();
+  };
+
+  render() {
+    const {
+      code,
+      previewBackgroundColor,
+      scope = {},
+      theme = 'dark'
+    } = this.props;
+
+    const useDarkTheme = theme === 'dark';
+
+    if (useDarkTheme) {
+      require('../themes/default/prism.dark.css');
+    } else {
+      require('../themes/default/prism.light.css');
+    }
+
+    return (
+      <PlaygroundProvider
+        className={`react-live-${useDarkTheme ? 'dark' : 'light'}`}
+        mountStylesheet={false}
+        code={(code || defaultCode).trim()}
+        scope={{ Component, ...scope }}
+        noInline
+      >
+        <PlaygroundRow>
+          <Title>Live Preview</Title>
+          <Title useDarkTheme={useDarkTheme}>Source Code</Title>
+        </PlaygroundRow>
+
+        <PlaygroundRow>
+          <PlaygroundColumn>
+            <PlaygroundPreview
+              previewBackgroundColor={previewBackgroundColor}
+            />
+            <PlaygroundError />
+          </PlaygroundColumn>
+
+          <PlaygroundColumn>
+            <PlaygroundEditor
+              onKeyUp={this.onKeyUp}
+              onKeyDown={this.onKeyDown}
+            />
+          </PlaygroundColumn>
+        </PlaygroundRow>
+      </PlaygroundProvider>
+    );
   }
-
-  return (
-    <PlaygroundProvider
-      className={`react-live-${useDarkTheme ? 'dark' : 'light'}`}
-      mountStylesheet={false}
-      code={(code || defaultCode).trim()}
-      scope={{ Component, ...scope }}
-      noInline
-    >
-      <PlaygroundRow>
-        <Title>Live Preview</Title>
-        <Title useDarkTheme={useDarkTheme}>Source Code</Title>
-      </PlaygroundRow>
-
-      <PlaygroundRow>
-        <PlaygroundColumn>
-          <PlaygroundPreview
-            previewBackgroundColor={previewBackgroundColor}
-          />
-          <PlaygroundError />
-        </PlaygroundColumn>
-
-        <PlaygroundColumn>
-          <PlaygroundEditor useDarkTheme={useDarkTheme} />
-        </PlaygroundColumn>
-      </PlaygroundRow>
-    </PlaygroundProvider>
-  );
-};
+}
 
 ComponentPlayground.propTypes = {
   code: PropTypes.string,


### PR DESCRIPTION
- Prevent passing invalid HTML attributes as props to emotion
- Stop propagation of key events in the Editor to be able to use all
keys

(Otherwise space, arrows, etc, would still change slides/modes)