### PR TITLE
Add fullscreen button to ComponentPlayground

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "normalize.css": "^7.0.0",
     "prismjs": "^1.6.0",
     "react-emotion": "^8.0.8",
-    "react-live": "^1.8.0-1",
+    "react-live": "^1.8.0-2",
     "react-redux": "^5.0.5",
     "react-transition-group": "^1.1.3",
     "react-typography": "^0.16.5",

--- a/src/components/__snapshots__/code-pane.test.js.snap
+++ b/src/components/__snapshots__/code-pane.test.js.snap
@@ -67,21 +67,21 @@ exports[`<CodePane /> should render correctly. 1`] = `
             dangerouslySetInnerHTML={
               Object {
                 "__html": "
-                    <span class=\\"token keyword\\">const</span> myButton <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>
-                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>CustomButton</span>
-                        <span class=\\"token attr-name\\">style</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">{</span> background<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">'#f00'</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">}</span></span>
-                        <span class=\\"token attr-name\\">onClick</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">.</span>action<span class=\\"token punctuation\\">}</span></span>
-                      <span class=\\"token punctuation\\">></span></span>
-                       Click Me
-                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>CustomButton</span><span class=\\"token punctuation\\">></span></span>
-                    <span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>
-                  ",
+              			<span class=\\"token keyword\\">const</span> myButton <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>
+              				<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>CustomButton</span>
+              					<span class=\\"token attr-name\\">style</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">{</span> background<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">'#f00'</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">}</span></span>
+              					<span class=\\"token attr-name\\">onClick</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">.</span>action<span class=\\"token punctuation\\">}</span></span>
+              				<span class=\\"token punctuation\\">></span></span>
+              				 Click Me
+              				<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>CustomButton</span><span class=\\"token punctuation\\">></span></span>
+              			<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>
+              		",
               }
             }
             language="jsx"
-            onClick={undefined}
-            onKeyDown={undefined}
-            onKeyUp={undefined}
+            onClick={false}
+            onKeyDown={false}
+            onKeyUp={false}
             spellCheck="false"
             style={undefined}
             styles={undefined}

--- a/src/components/__snapshots__/code-pane.test.js.snap
+++ b/src/components/__snapshots__/code-pane.test.js.snap
@@ -43,6 +43,9 @@ exports[`<CodePane /> should render correctly. 1`] = `
           "
         contentEditable={false}
         language="jsx"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
         styles={undefined}
       >
         <Editor
@@ -59,6 +62,9 @@ exports[`<CodePane /> should render correctly. 1`] = `
             "
           contentEditable={false}
           language="jsx"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
           styles={undefined}
         >
           <pre
@@ -67,21 +73,20 @@ exports[`<CodePane /> should render correctly. 1`] = `
             dangerouslySetInnerHTML={
               Object {
                 "__html": "
-              			<span class=\\"token keyword\\">const</span> myButton <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>
-              				<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>CustomButton</span>
-              					<span class=\\"token attr-name\\">style</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">{</span> background<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">'#f00'</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">}</span></span>
-              					<span class=\\"token attr-name\\">onClick</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">.</span>action<span class=\\"token punctuation\\">}</span></span>
-              				<span class=\\"token punctuation\\">></span></span>
-              				 Click Me
-              				<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>CustomButton</span><span class=\\"token punctuation\\">></span></span>
-              			<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>
-              		",
+                    <span class=\\"token keyword\\">const</span> myButton <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span>
+                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>CustomButton</span>
+                        <span class=\\"token attr-name\\">style</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">{</span> background<span class=\\"token punctuation\\">:</span> <span class=\\"token string\\">'#f00'</span> <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">}</span></span>
+                        <span class=\\"token attr-name\\">onClick</span><span class=\\"token script language-javascript\\"><span class=\\"token punctuation\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token keyword\\">this</span><span class=\\"token punctuation\\">.</span>action<span class=\\"token punctuation\\">}</span></span>
+                      <span class=\\"token punctuation\\">></span></span>
+                       Click Me
+                      <span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>CustomButton</span><span class=\\"token punctuation\\">></span></span>
+                    <span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>
+                  ",
               }
             }
-            language="jsx"
-            onClick={false}
-            onKeyDown={false}
-            onKeyUp={false}
+            onClick={undefined}
+            onKeyDown={undefined}
+            onKeyUp={undefined}
             spellCheck="false"
             style={undefined}
             styles={undefined}

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -9,16 +9,16 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
     class="css-wx5pb5"
   >
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Live Preview
     </div>
     <div
-      class="css-h4hzi8"
+      class="css-1qi44w1"
     >
       Source Code
       <button
-        class="css-1ashtcx"
+        class="css-1a7vuu6"
       >
         <svg
           viewBox="0 0 24 24"
@@ -551,16 +551,16 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
     class="css-wx5pb5"
   >
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Live Preview
     </div>
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Source Code
       <button
-        class="css-1ashtcx"
+        class="css-1a7vuu6"
       >
         <svg
           viewBox="0 0 24 24"
@@ -1093,16 +1093,16 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
     class="css-wx5pb5"
   >
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Live Preview
     </div>
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Source Code
       <button
-        class="css-1ashtcx"
+        class="css-1a7vuu6"
       >
         <svg
           viewBox="0 0 24 24"
@@ -1635,16 +1635,16 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
     class="css-wx5pb5"
   >
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Live Preview
     </div>
     <div
-      class="css-12ijxqn"
+      class="css-1j4k5g3"
     >
       Source Code
       <button
-        class="css-1ashtcx"
+        class="css-1a7vuu6"
       >
         <svg
           viewBox="0 0 24 24"

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -100,7 +100,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -113,7 +113,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -131,7 +131,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -144,7 +144,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -156,7 +156,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -169,7 +169,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -182,7 +182,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -250,7 +250,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -271,7 +271,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -324,7 +324,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -348,7 +348,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -369,7 +369,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -422,8 +422,8 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -444,7 +444,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -641,7 +641,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -654,7 +654,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -672,7 +672,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -685,7 +685,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -697,7 +697,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -710,7 +710,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -723,7 +723,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -791,7 +791,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -812,7 +812,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -865,7 +865,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -889,7 +889,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -910,7 +910,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -963,8 +963,8 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -985,7 +985,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1182,7 +1182,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        	heading
+          heading
         <span
           class="token punctuation"
         >
@@ -1195,7 +1195,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -1213,7 +1213,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-        		fontWeight
+            fontWeight
         <span
           class="token punctuation"
         >
@@ -1226,7 +1226,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "bold"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -1238,7 +1238,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-        	copy
+          copy
         <span
           class="token punctuation"
         >
@@ -1251,7 +1251,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-        		fontSize
+            fontSize
         <span
           class="token punctuation"
         >
@@ -1264,7 +1264,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "1.5rem"
         </span>
         
-        	
+          
         <span
           class="token punctuation"
         >
@@ -1332,7 +1332,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           (
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1353,7 +1353,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1406,7 +1406,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        			Create Live Code Examples 
+              Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -1430,7 +1430,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           !
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1451,7 +1451,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        		
+            
         <span
           class="token tag"
         >
@@ -1504,8 +1504,8 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        			Supports Light and Dark Syntax Themes
-        		
+              Supports Light and Dark Syntax Themes
+            
         <span
           class="token tag"
         >
@@ -1526,7 +1526,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-        	
+          
         <span
           class="token tag"
         >
@@ -1824,7 +1824,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
           ;
         </span>
         
-        			
+              
         <span
           class="token function"
         >

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -68,7 +68,6 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
-        language="jsx"
         spellcheck="false"
       >
         <span
@@ -101,7 +100,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-          heading
+        	heading
         <span
           class="token punctuation"
         >
@@ -114,7 +113,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -132,7 +131,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-            fontWeight
+        		fontWeight
         <span
           class="token punctuation"
         >
@@ -145,7 +144,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "bold"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -157,7 +156,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           ,
         </span>
         
-          copy
+        	copy
         <span
           class="token punctuation"
         >
@@ -170,7 +169,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -183,7 +182,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           "1.5rem"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -251,7 +250,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           (
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -272,7 +271,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -325,7 +324,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-              Create Live Code Examples 
+        			Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -349,7 +348,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           !
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -370,7 +369,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -423,8 +422,8 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-              Supports Light and Dark Syntax Themes
-            
+        			Supports Light and Dark Syntax Themes
+        		
         <span
           class="token tag"
         >
@@ -445,7 +444,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
           </span>
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -610,7 +609,6 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
-        language="jsx"
         spellcheck="false"
       >
         <span
@@ -643,7 +641,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-          heading
+        	heading
         <span
           class="token punctuation"
         >
@@ -656,7 +654,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -674,7 +672,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-            fontWeight
+        		fontWeight
         <span
           class="token punctuation"
         >
@@ -687,7 +685,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "bold"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -699,7 +697,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           ,
         </span>
         
-          copy
+        	copy
         <span
           class="token punctuation"
         >
@@ -712,7 +710,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -725,7 +723,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           "1.5rem"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -793,7 +791,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           (
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -814,7 +812,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -867,7 +865,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-              Create Live Code Examples 
+        			Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -891,7 +889,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           !
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -912,7 +910,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -965,8 +963,8 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-              Supports Light and Dark Syntax Themes
-            
+        			Supports Light and Dark Syntax Themes
+        		
         <span
           class="token tag"
         >
@@ -987,7 +985,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
           </span>
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -1152,7 +1150,6 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
-        language="jsx"
         spellcheck="false"
       >
         <span
@@ -1185,7 +1182,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-          heading
+        	heading
         <span
           class="token punctuation"
         >
@@ -1198,7 +1195,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -1216,7 +1213,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-            fontWeight
+        		fontWeight
         <span
           class="token punctuation"
         >
@@ -1229,7 +1226,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "bold"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -1241,7 +1238,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           ,
         </span>
         
-          copy
+        	copy
         <span
           class="token punctuation"
         >
@@ -1254,7 +1251,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           {
         </span>
         
-            fontSize
+        		fontSize
         <span
           class="token punctuation"
         >
@@ -1267,7 +1264,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           "1.5rem"
         </span>
         
-          
+        	
         <span
           class="token punctuation"
         >
@@ -1335,7 +1332,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           (
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -1356,7 +1353,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -1409,7 +1406,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-              Create Live Code Examples 
+        			Create Live Code Examples 
         <span
           class="token keyword"
         >
@@ -1433,7 +1430,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           !
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -1454,7 +1451,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-            
+        		
         <span
           class="token tag"
         >
@@ -1507,8 +1504,8 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-              Supports Light and Dark Syntax Themes
-            
+        			Supports Light and Dark Syntax Themes
+        		
         <span
           class="token tag"
         >
@@ -1529,7 +1526,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
           </span>
         </span>
         
-          
+        	
         <span
           class="token tag"
         >
@@ -1688,7 +1685,6 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
       <pre
         class="prism-code css-egp0ia"
         contenteditable="true"
-        language="jsx"
         spellcheck="false"
       >
         <span
@@ -1828,7 +1824,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
           ;
         </span>
         
-              
+        			
         <span
           class="token function"
         >

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -6,21 +6,41 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
   scope="[object Object]"
 >
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Live Preview
     </div>
     <div
-      class="css-1x4bol9"
+      class="css-h4hzi8"
     >
       Source Code
+      <button
+        class="css-1ashtcx"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          >
+            
+          </path>
+          <path
+            d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+            fill="currentColor"
+          >
+            
+          </path>
+        </svg>
+      </button>
     </div>
   </div>
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
       class="css-1fc71w4"
@@ -528,21 +548,41 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
   scope="[object Object]"
 >
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Live Preview
     </div>
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Source Code
+      <button
+        class="css-1ashtcx"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          >
+            
+          </path>
+          <path
+            d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+            fill="currentColor"
+          >
+            
+          </path>
+        </svg>
+      </button>
     </div>
   </div>
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
       class="css-1fc71w4"
@@ -1050,21 +1090,41 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
   scope="[object Object]"
 >
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Live Preview
     </div>
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Source Code
+      <button
+        class="css-1ashtcx"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          >
+            
+          </path>
+          <path
+            d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+            fill="currentColor"
+          >
+            
+          </path>
+        </svg>
+      </button>
     </div>
   </div>
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
       class="css-1fc71w4"
@@ -1572,21 +1632,41 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
   scope="[object Object]"
 >
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Live Preview
     </div>
     <div
-      class="css-55vg9w"
+      class="css-12ijxqn"
     >
       Source Code
+      <button
+        class="css-1ashtcx"
+      >
+        <svg
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          >
+            
+          </path>
+          <path
+            d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+            fill="currentColor"
+          >
+            
+          </path>
+        </svg>
+      </button>
     </div>
   </div>
   <div
-    class="css-60wkrg"
+    class="css-wx5pb5"
   >
     <div
       class="css-1fc71w4"

--- a/src/components/__snapshots__/fullscreen.test.js.snap
+++ b/src/components/__snapshots__/fullscreen.test.js.snap
@@ -2,22 +2,43 @@
 
 exports[`<Fullscreen /> should render correctly. 1`] = `
 <Fullscreen>
-  <Styled(div)>
-    <div
-      className="css-1j4mcul"
+  <Styled(FullscreenButton)
+    onClick={[Function]}
+    style={undefined}
+    viewBox="0 0 512 512"
+  >
+    <FullscreenButton
+      className="css-12n5ud"
+      onClick={[Function]}
+      style={undefined}
+      viewBox="0 0 512 512"
     >
-      <svg
-        height="30px"
+      <Styled(button)
+        className="css-12n5ud"
         onClick={[Function]}
         style={undefined}
         viewBox="0 0 512 512"
-        width="30px"
       >
-        <path
-          d="M73.143,329.143H0V512h182.857v-73.143H73.143V329.143z M0,182.857h73.143V73.143h109.715V0H0V182.857z M438.857,438.857 H329.143V512H512V329.143h-73.143V438.857z M329.143,0v73.143h109.715v109.715H512V0H329.143z"
-        />
-      </svg>
-    </div>
-  </Styled(div)>
+        <button
+          className="css-1hv29sw"
+          onClick={[Function]}
+          style={undefined}
+        >
+          <svg
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <path
+              d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+      </Styled(button)>
+    </FullscreenButton>
+  </Styled(FullscreenButton)>
 </Fullscreen>
 `;

--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -242,23 +242,44 @@ exports[`<Manager /> should render correctly. 1`] = `
           </Styled(div)>
         </Progress>
         <Fullscreen>
-          <Styled(div)>
-            <div
-              className="css-1j4mcul"
+          <Styled(FullscreenButton)
+            onClick={[Function]}
+            style={undefined}
+            viewBox="0 0 512 512"
+          >
+            <FullscreenButton
+              className="css-12n5ud"
+              onClick={[Function]}
+              style={undefined}
+              viewBox="0 0 512 512"
             >
-              <svg
-                height="30px"
+              <Styled(button)
+                className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
-                width="30px"
               >
-                <path
-                  d="M73.143,329.143H0V512h182.857v-73.143H73.143V329.143z M0,182.857h73.143V73.143h109.715V0H0V182.857z M438.857,438.857 H329.143V512H512V329.143h-73.143V438.857z M329.143,0v73.143h109.715v109.715H512V0H329.143z"
-                />
-              </svg>
-            </div>
-          </Styled(div)>
+                <button
+                  className="css-1hv29sw"
+                  onClick={[Function]}
+                  style={undefined}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </Styled(button)>
+            </FullscreenButton>
+          </Styled(FullscreenButton)>
         </Fullscreen>
         <style
           dangerouslySetInnerHTML={
@@ -546,23 +567,44 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
           </Styled(div)>
         </Overview>
         <Fullscreen>
-          <Styled(div)>
-            <div
-              className="css-1j4mcul"
+          <Styled(FullscreenButton)
+            onClick={[Function]}
+            style={undefined}
+            viewBox="0 0 512 512"
+          >
+            <FullscreenButton
+              className="css-12n5ud"
+              onClick={[Function]}
+              style={undefined}
+              viewBox="0 0 512 512"
             >
-              <svg
-                height="30px"
+              <Styled(button)
+                className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
-                width="30px"
               >
-                <path
-                  d="M73.143,329.143H0V512h182.857v-73.143H73.143V329.143z M0,182.857h73.143V73.143h109.715V0H0V182.857z M438.857,438.857 H329.143V512H512V329.143h-73.143V438.857z M329.143,0v73.143h109.715v109.715H512V0H329.143z"
-                />
-              </svg>
-            </div>
-          </Styled(div)>
+                <button
+                  className="css-1hv29sw"
+                  onClick={[Function]}
+                  style={undefined}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </Styled(button)>
+            </FullscreenButton>
+          </Styled(FullscreenButton)>
         </Fullscreen>
         <style
           dangerouslySetInnerHTML={
@@ -846,23 +888,44 @@ exports[`<Manager /> should render with slideset slides 1`] = `
           </Styled(div)>
         </Progress>
         <Fullscreen>
-          <Styled(div)>
-            <div
-              className="css-1j4mcul"
+          <Styled(FullscreenButton)
+            onClick={[Function]}
+            style={undefined}
+            viewBox="0 0 512 512"
+          >
+            <FullscreenButton
+              className="css-12n5ud"
+              onClick={[Function]}
+              style={undefined}
+              viewBox="0 0 512 512"
             >
-              <svg
-                height="30px"
+              <Styled(button)
+                className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
-                width="30px"
               >
-                <path
-                  d="M73.143,329.143H0V512h182.857v-73.143H73.143V329.143z M0,182.857h73.143V73.143h109.715V0H0V182.857z M438.857,438.857 H329.143V512H512V329.143h-73.143V438.857z M329.143,0v73.143h109.715v109.715H512V0H329.143z"
-                />
-              </svg>
-            </div>
-          </Styled(div)>
+                <button
+                  className="css-1hv29sw"
+                  onClick={[Function]}
+                  style={undefined}
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    />
+                    <path
+                      d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </Styled(button)>
+            </FullscreenButton>
+          </Styled(FullscreenButton)>
         </Fullscreen>
         <style
           dangerouslySetInnerHTML={

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -10,6 +10,10 @@ const StyledWrapper = styled.div(props => props.styles);
 const StyledEditor = styled(Editor)(props => props.styles);
 
 export default class CodePane extends Component {
+  handleEditorEvent(evt) {
+    evt.stopPropagation();
+  }
+
   render() {
     const useDarkTheme = this.props.theme === 'dark';
 
@@ -35,6 +39,9 @@ export default class CodePane extends Component {
           language={this.props.lang}
           contentEditable={this.props.contentEditable}
           styles={this.context.styles.components.codePane.editor}
+          onKeyDown={this.handleEditorEvent}
+          onKeyUp={this.handleEditorEvent}
+          onClick={this.handleEditorEvent}
         />
       </StyledWrapper>
     );

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -7,7 +7,8 @@ import FullscreenButton from './fullscreen-button';
 
 import {
   requestFullscreen,
-  exitFullscreen
+  exitFullscreen,
+  getFullscreenElement
 } from '../utils/fullscreen';
 
 import {
@@ -124,7 +125,7 @@ class ComponentPlayground extends Component {
     evt.stopPropagation();
 
     // Esc: When entering the editor or an input element the default esc-to-exit might not work anymore
-    if (evt.keyCode === 27 && document.fullscreenElement) {
+    if (evt.keyCode === 27 && getFullscreenElement()) {
       exitFullscreen();
     }
   }

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -102,7 +102,14 @@ const PlaygroundError = styled(LiveError)`
 `;
 
 class ComponentPlayground extends Component {
-  onKeyUp = evt => {
+  constructor() {
+    super();
+
+    this.onRef = this.onRef.bind(this);
+    this.requestFullscreen = this.requestFullscreen.bind(this);
+  }
+
+  onKeyUp(evt) {
     evt.stopPropagation();
 
     // Esc: When entering the editor or an input element the default esc-to-exit might not work anymore
@@ -113,17 +120,17 @@ class ComponentPlayground extends Component {
         exit.call(document);
       }
     }
-  };
+  }
 
-  onKeyDown = evt => {
+  onKeyDown(evt) {
     evt.stopPropagation();
-  };
+  }
 
-  onRef = node => {
+  onRef(node) {
     this.node = node;
-  };
+  }
 
-  requestFullscreen = () => {
+  requestFullscreen() {
     const requestFullscreen = (
       this.node.requestFullscreen ||
       this.node.webkitRequestFullscreen ||
@@ -134,7 +141,7 @@ class ComponentPlayground extends Component {
     if (typeof requestFullscreen === 'function') {
       requestFullscreen.call(this.node);
     }
-  };
+  }
 
   render() {
     const {

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -6,6 +6,11 @@ import { defaultCode } from '../utils/playground.default-code';
 import FullscreenButton from './fullscreen-button';
 
 import {
+  requestFullscreen,
+  exitFullscreen
+} from '../utils/fullscreen';
+
+import {
   LiveProvider,
   LiveEditor,
   LiveError,
@@ -71,6 +76,12 @@ const Title = styled.div`
     border-left: 1px solid #999;
   }
 
+  > button {
+    position: absolute;
+    right: 1em;
+    margin-top: -0.1em;
+  }
+
   ${props => props.useDarkTheme && css`
     background: #272822;
     border-bottom: 1px solid #000;
@@ -114,11 +125,7 @@ class ComponentPlayground extends Component {
 
     // Esc: When entering the editor or an input element the default esc-to-exit might not work anymore
     if (evt.keyCode === 27 && document.fullscreenElement) {
-      const exit = (document.exitFullscreen || document.mozCancelFullScreen);
-
-      if (typeof exit === 'function') {
-        exit.call(document);
-      }
+      exitFullscreen();
     }
   }
 
@@ -131,16 +138,7 @@ class ComponentPlayground extends Component {
   }
 
   requestFullscreen() {
-    const requestFullscreen = (
-      this.node.requestFullscreen ||
-      this.node.webkitRequestFullscreen ||
-      this.node.mozRequestFullScreen ||
-      this.node.mozRequestFullScreen
-    );
-
-    if (typeof requestFullscreen === 'function') {
-      requestFullscreen.call(this.node);
-    }
+    requestFullscreen(this.node);
   }
 
   render() {

--- a/src/components/fullscreen-button.js
+++ b/src/components/fullscreen-button.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+const Button = styled.button`
+  display: inline-block;
+  position: absolute;
+  right: 1em;
+  margin-top: -0.1em;
+
+  appearance: none;
+  background: none;
+  border: none;
+  outline: 0;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+
+  > svg {
+    height: 1.5em;
+    width: 1.5em;
+  }
+`;
+
+const FullscreenButton = props => (
+  <Button {...props}>
+    <svg viewBox="0 0 24 24">
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" fill="currentColor" />
+    </svg>
+  </Button>
+);
+
+export default FullscreenButton;

--- a/src/components/fullscreen-button.js
+++ b/src/components/fullscreen-button.js
@@ -3,10 +3,6 @@ import styled from 'react-emotion';
 
 const Button = styled.button`
   display: inline-block;
-  position: absolute;
-  right: 1em;
-  margin-top: -0.1em;
-
   appearance: none;
   background: none;
   border: none;

--- a/src/components/fullscreen.js
+++ b/src/components/fullscreen.js
@@ -2,54 +2,44 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
-const StyledFullscreen = styled.div({
-  position: 'absolute',
-  bottom: 20,
-  right: 20,
-  opacity: 0,
-  cursor: 'pointer',
-  transition: '300ms opacity ease',
-  ':hover': { opacity: 1 }
-});
+import FullscreenButton from './fullscreen-button';
+
+import {
+  requestFullscreen,
+  exitFullscreen,
+  getFullscreenElement
+} from '../utils/fullscreen';
+
+const StyledFullscreen = styled(FullscreenButton)`
+  position: absolute;
+  bottom: 10px;
+  right: 20px;
+  opacity: 0;
+  transition: 300ms opacity ease;
+  font-size: 30px;
+  color: #fff;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
 
 export class Fullscreen extends Component {
-  handleToggleFullScreen() {
-    if (!document.fullscreenElement &&
-        !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
-      if (document.documentElement.requestFullscreen) {
-        document.documentElement.requestFullscreen();
-      } else if (document.documentElement.msRequestFullscreen) {
-        document.documentElement.msRequestFullscreen();
-      } else if (document.documentElement.mozRequestFullScreen) {
-        document.documentElement.mozRequestFullScreen();
-      } else if (document.documentElement.webkitRequestFullscreen) {
-        document.documentElement.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-      }
-    } else if (document.exitFullscreen) {
-      document.exitFullscreen();
-    } else if (document.msExitFullscreen) {
-      document.msExitFullscreen();
-    } else if (document.mozCancelFullScreen) {
-      document.mozCancelFullScreen();
-    } else if (document.webkitExitFullscreen) {
-      document.webkitExitFullscreen();
+  toggleFullscreen() {
+    if (!getFullscreenElement()) {
+      requestFullscreen(document.documentElement);
+    } else {
+      exitFullscreen();
     }
   }
+
   render() {
     return (
-      <StyledFullscreen>
-        <svg
-          onClick={() => this.handleToggleFullScreen()}
-          style={this.context.styles.fullscreen}
-          width="30px"
-          height="30px"
-          viewBox="0 0 512 512"
-        >
-          <path d="M73.143,329.143H0V512h182.857v-73.143H73.143V329.143z M0,182.857h73.143V73.143h109.715V0H0V182.857z M438.857,438.857
-            H329.143V512H512V329.143h-73.143V438.857z M329.143,0v73.143h109.715v109.715H512V0H329.143z"
-          />
-        </svg>
-      </StyledFullscreen>
+      <StyledFullscreen
+        onClick={() => this.toggleFullscreen()}
+        style={this.context.styles.fullscreen}
+        viewBox="0 0 512 512"
+      />
     );
   }
 }

--- a/src/components/fullscreen.test.js
+++ b/src/components/fullscreen.test.js
@@ -13,9 +13,9 @@ describe('<Fullscreen />', () => {
     const context = { styles: { styles: { fullscreen: {} } } };
     const wrapper = mount(<Fullscreen />, { context });
     const stub = jest.fn();
-    wrapper.instance().handleToggleFullScreen = stub;
+    wrapper.instance().toggleFullscreen = stub;
     wrapper.update();
-    wrapper.find('svg').simulate('click');
+    wrapper.children().first().simulate('click');
     expect(stub).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/fullscreen.js
+++ b/src/utils/fullscreen.js
@@ -1,0 +1,32 @@
+export const requestFullscreen = element => {
+  const request = (
+    element.requestFullscreen ||
+    element.webkitRequestFullscreen ||
+    element.mozRequestFullScreen ||
+    element.mozRequestFullScreen
+  );
+
+  if (typeof request === 'function') {
+    request.call(element);
+  }
+};
+
+export const exitFullscreen = () => {
+  const exit = (
+    document.exitFullscreen ||
+    document.msExitFullscreen ||
+    document.mozCancelFullScreen ||
+    document.webkitExitFullscreen
+  );
+
+  if (typeof exit === 'function') {
+    exit.call(document);
+  }
+};
+
+export const getFullscreenElement = () => (
+  document.fullscreenElement ||
+  document.mozFullScreenElement ||
+  document.webkitFullscreenElement ||
+  document.msFullscreenElement
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,9 +4915,9 @@ react-emotion@^8.0.8:
     babel-plugin-emotion "^8.0.6"
     emotion-utils "^8.0.6"
 
-react-live@^1.8.0-1:
-  version "1.8.0-1"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.8.0-1.tgz#9ee81589e6ae2e728ef0d993e517af133de27c5b"
+react-live@^1.8.0-2:
+  version "1.8.0-2"
+  resolved "https://registry.yarnpkg.com/react-live/-/react-live-1.8.0-2.tgz#0207113212fb5cc4ebb33080219c2feb29ea3398"
   dependencies:
     buble "^0.15.2"
     core-js "^2.4.1"


### PR DESCRIPTION
Fix #316 
Depends on #391 

Adds a fullscreen button to the `ComponentPlayground` that uses the Fullscreen API.


<img src="https://user-images.githubusercontent.com/2041385/32293951-a469daf0-bf3c-11e7-92ec-dadecce51f5b.gif" width=550 />
