### PR TITLE
Progress updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,12 +393,14 @@ The slide tag represents each slide in the presentation. Giving a slide tag an `
 |Name|PropType|Description|
 |---|---|---|
 |align| PropTypes.string | Accepts a space delimited value for positioning interior content. The first value can be `flex-start` (left), `center` (middle), or `flex-end` (right). The second value can be `flex-start` (top) , `center` (middle), or `flex-end` (bottom). You would provide this prop like `align="center center"`, which is its default.
+|controlColor| PropTypes.string | Used to override color of control arrows on a per slide basis, accepts color aliases, or valid color values.
 |goTo| PropTypes.number | Used to navigate to a slide for out-of-order presenting. Slide numbers start at `1`. This can also be used to skip slides as well.
 |id| PropTypes.string | Used to create a string based hash.
 |maxHeight| PropTypes.number | Used to set max dimensions of the Slide.
 |maxWidth| PropTypes.number | Used to set max dimensions of the Slide.
 |notes| PropTypes.string| Text which will appear in the presenter mode. Can be HTML.
 |onActive|PropTypes.func| Optional function that is called with the slide index when the slide comes into view.
+|progressColor| PropTypes.string | Used to override color of progress elements on a per slide basis, accepts color aliases, or valid color values.
 |transition|PropTypes.array|Accepts `slide`, `zoom`, `fade`, `spin`, or a [function](#transition-function), and can be combined. Sets the slide transition. This will affect both enter and exit transitions. **Note: If you use the 'scale' transition, fitted text won't work in Safari.**|
 |transitionIn|PropTypes.array|Specifies the slide transition when the slide comes into view. Accepts the same values as transition.|
 |transitionOut|PropTypes.array|Specifies the slide transition when the slide exits. Accepts the same values as transition.|
@@ -656,6 +658,7 @@ Heading tags are special in that, when you specify a `size` prop, they generate 
 
 |Name|PropType|Description|
 |---|---|---|
+|alt|PropTypes.string| Set the `alt` property of the image|
 |display|PropTypes.string| Set the display style property of the image |
 |height|PropTypes.string or PropTypes.number| Supply a height to the image |
 |src|PropTypes.string| Image src |
@@ -761,12 +764,18 @@ Every component above that has `(Base)` after it has been extended from a common
 | margin | PropTypes.number or string | Set `margin` value|
 | padding | PropTypes.number or string | Set `padding` value|
 | textColor | PropTypes.string | Set `color` value|
+| textFont | PropTypes.string | Set `fontFamily` value|
 | textSize | PropTypes.string | Set `fontSize` value|
 | textAlign | PropTypes.string | Set `textAlign` value|
 | textFont | PropTypes.string | Set `textFont` value|
 | bgColor | PropTypes.string | Set `backgroundColor` value|
 | bgImage | PropTypes.string | Set `backgroundImage` value|
+| bgSize | PropTypes.string | Set `backgroundSize` value|
+| bgPosition | PropTypes.string | Set `backgroundPosition` value|
+| bgRepeat | PropTypes.string | Set `backgroundRepeat` value|
 | bgDarken | PropTypes.number | Float value from 0.0 to 1.0 specifying how much to darken the bgImage image|
+| overflow | PropTypes.string | Set `overflow` value|
+| height | PropTypes.string | Set `height` value|
 
 <a name="typeface"></a>
 #### Typeface

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -191,7 +191,7 @@ export default class Presentation extends React.Component {
             <Cite>Ken Wheeler</Cite>
           </BlockQuote>
         </Slide>
-        <Slide transition={['spin', 'zoom']} bgColor="tertiary">
+        <Slide transition={['spin', 'zoom']} bgColor="tertiary" controlColor="primary" progressColor="primary">
           <Heading caps fit size={1} textColor="primary">
             Inline Markdown
           </Heading>

--- a/src/components/__snapshots__/image.test.js.snap
+++ b/src/components/__snapshots__/image.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Image /> should render correctly. 1`] = `
   width={2560}
 >
   <Styled(img)
+    alt={undefined}
     className={undefined}
     src="foo.png"
     styles={
@@ -26,6 +27,7 @@ exports[`<Image /> should render correctly. 1`] = `
     }
   >
     <img
+      alt={undefined}
       className="css-17as7hl"
       src="foo.png"
     />

--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -66,6 +66,7 @@ exports[`<Manager /> should render correctly. 1`] = `
         onTouchStart={[Function]}
       >
         <Controls
+          controlColor={null}
           currentSlideIndex={0}
           onNext={[Function]}
           onPrev={[Function]}
@@ -160,10 +161,16 @@ exports[`<Manager /> should render correctly. 1`] = `
               },
             ]
           }
+          progressColor={null}
           type="pacman"
         >
           <Styled(div)
-            styles={undefined}
+            styles={
+              Array [
+                undefined,
+                null,
+              ]
+            }
           >
             <div
               className="css-0"
@@ -188,6 +195,7 @@ exports[`<Manager /> should render correctly. 1`] = `
                           Object {
                             "animation": "animation-vwhb3c 0.12s linear 10 alternate both",
                           },
+                          null,
                         ]
                       }
                     >
@@ -202,6 +210,7 @@ exports[`<Manager /> should render correctly. 1`] = `
                           Object {
                             "animation": "animation-1p18wsg 0.12s linear 10 alternate both",
                           },
+                          null,
                         ]
                       }
                     >
@@ -220,7 +229,12 @@ exports[`<Manager /> should render correctly. 1`] = `
                       "top": "-20px",
                     }
                   }
-                  styles={undefined}
+                  styles={
+                    Array [
+                      undefined,
+                      null,
+                    ]
+                  }
                 >
                   <div
                     className="css-16u37i9"
@@ -234,7 +248,12 @@ exports[`<Manager /> should render correctly. 1`] = `
                       "top": "-20px",
                     }
                   }
-                  styles={undefined}
+                  styles={
+                    Array [
+                      undefined,
+                      null,
+                    ]
+                  }
                 >
                   <div
                     className="css-1qz1mlg"
@@ -679,6 +698,7 @@ exports[`<Manager /> should render with slideset slides 1`] = `
         onTouchStart={[Function]}
       >
         <Controls
+          controlColor={null}
           currentSlideIndex={1}
           onNext={[Function]}
           onPrev={[Function]}
@@ -801,10 +821,16 @@ exports[`<Manager /> should render with slideset slides 1`] = `
               },
             ]
           }
+          progressColor={null}
           type="pacman"
         >
           <Styled(div)
-            styles={undefined}
+            styles={
+              Array [
+                undefined,
+                null,
+              ]
+            }
           >
             <div
               className="css-0"
@@ -829,6 +855,7 @@ exports[`<Manager /> should render with slideset slides 1`] = `
                           Object {
                             "animation": "animation-v6s9vi 0.12s linear 10 alternate both",
                           },
+                          null,
                         ]
                       }
                     >
@@ -843,6 +870,7 @@ exports[`<Manager /> should render with slideset slides 1`] = `
                           Object {
                             "animation": "animation-9hbgqx 0.12s linear 10 alternate both",
                           },
+                          null,
                         ]
                       }
                     >
@@ -861,7 +889,12 @@ exports[`<Manager /> should render with slideset slides 1`] = `
                       "top": "-20px",
                     }
                   }
-                  styles={undefined}
+                  styles={
+                    Array [
+                      undefined,
+                      null,
+                    ]
+                  }
                 >
                   <div
                     className="css-1xucvt"
@@ -876,7 +909,12 @@ exports[`<Manager /> should render with slideset slides 1`] = `
                       "top": "-20px",
                     }
                   }
-                  styles={undefined}
+                  styles={
+                    Array [
+                      undefined,
+                      null,
+                    ]
+                  }
                 >
                   <div
                     className="css-ci3gz3"
@@ -890,7 +928,12 @@ exports[`<Manager /> should render with slideset slides 1`] = `
                       "top": "-20px",
                     }
                   }
-                  styles={undefined}
+                  styles={
+                    Array [
+                      undefined,
+                      null,
+                    ]
+                  }
                 >
                   <div
                     className="css-tyaqbb"

--- a/src/components/__snapshots__/progress.test.js.snap
+++ b/src/components/__snapshots__/progress.test.js.snap
@@ -19,7 +19,12 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
   type="pacman"
 >
   <Styled(div)
-    styles={undefined}
+    styles={
+      Array [
+        undefined,
+        null,
+      ]
+    }
   >
     <div
       className="css-0"
@@ -44,6 +49,7 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
                   Object {
                     "animation": "animation-vwhb3c 0.12s linear 10 alternate both",
                   },
+                  null,
                 ]
               }
             >
@@ -58,6 +64,7 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
                   Object {
                     "animation": "animation-1p18wsg 0.12s linear 10 alternate both",
                   },
+                  null,
                 ]
               }
             >
@@ -76,7 +83,12 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
               "top": "-20px",
             }
           }
-          styles={undefined}
+          styles={
+            Array [
+              undefined,
+              null,
+            ]
+          }
         >
           <div
             className="css-1xucvt"
@@ -91,7 +103,12 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
               "top": "-20px",
             }
           }
-          styles={undefined}
+          styles={
+            Array [
+              undefined,
+              null,
+            ]
+          }
         >
           <div
             className="css-ci3gz3"
@@ -106,7 +123,12 @@ exports[`<Progress /> should render PacMan correctly 1`] = `
               "top": "-20px",
             }
           }
-          styles={undefined}
+          styles={
+            Array [
+              undefined,
+              null,
+            ]
+          }
         >
           <div
             className="css-41ffu3"
@@ -157,13 +179,23 @@ exports[`<Progress /> should render the bar style correctly 1`] = `
   type="bar"
 >
   <Styled(div)
-    styles={undefined}
+    styles={
+      Array [
+        undefined,
+        null,
+      ]
+    }
   >
     <div
       className="css-0"
     >
       <Styled(div)
-        styles={undefined}
+        styles={
+          Array [
+            undefined,
+            null,
+          ]
+        }
         width={
           Object {
             "width": "50%",
@@ -203,7 +235,12 @@ exports[`<Progress /> should render the number style correctly 1`] = `
   type="number"
 >
   <Styled(div)
-    styles={undefined}
+    styles={
+      Array [
+        undefined,
+        null,
+      ]
+    }
   >
     <div
       className="css-0"

--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -2,6 +2,21 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 export default class Controls extends Component {
+  resolveFillStyle = (name) => {
+    let color;
+    const { controlColor } = this.props;
+    if (controlColor) {
+      if (!this.context.styles.colors.hasOwnProperty(controlColor)) {
+        color = controlColor;
+      } else {
+        color = this.context.styles.colors[controlColor];
+      }
+      return {
+        fill: color
+      };
+    }
+    return this.context.styles.controls[name];
+  }
   render() {
     return (
       <div>
@@ -15,7 +30,7 @@ export default class Controls extends Component {
           >
             <svg
               key="prevIcon"
-              style={this.context.styles.controls.prevIcon}
+              style={this.resolveFillStyle('prevIcon')}
               width="32px"
               height="32px"
               viewBox="0 0 512 828.586"
@@ -35,7 +50,7 @@ export default class Controls extends Component {
           >
             <svg
               key="nextIcon"
-              style={this.context.styles.controls.nextIcon}
+              style={this.resolveFillStyle('nextIcon')}
               width="32px"
               height="32px"
               viewBox="0 0 512 828.586"
@@ -51,6 +66,7 @@ export default class Controls extends Component {
 }
 
 Controls.propTypes = {
+  controlColor: PropTypes.string,
   currentSlideIndex: PropTypes.number,
   onNext: PropTypes.func,
   onPrev: PropTypes.func,

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -30,6 +30,7 @@ export default class Image extends Component {
       <StyledImg
         className={this.props.className}
         src={this.props.src}
+        alt={this.props.alt}
         styles={styles}
       />
     );
@@ -37,6 +38,7 @@ export default class Image extends Component {
 }
 
 Image.propTypes = {
+  alt: PropTypes.string,
   className: PropTypes.string,
   display: PropTypes.string,
   height: PropTypes.oneOfType([

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -634,6 +634,24 @@ export class Manager extends Component {
       slideReference: this.state.slideReference,
     });
   }
+  _getProgressStyles = () => {
+    const slideIndex = this._getSlideIndex();
+    const slide = this._getSlideByIndex(slideIndex);
+
+    if (slide.props.progressColor) {
+      return slide.props.progressColor;
+    }
+    return null;
+  }
+  _getControlStyles = () => {
+    const slideIndex = this._getSlideIndex();
+    const slide = this._getSlideByIndex(slideIndex);
+
+    if (slide.props.controlColor) {
+      return slide.props.controlColor;
+    }
+    return null;
+  }
   render() {
     if (this.props.route.slide === null) {
       return false;
@@ -728,6 +746,7 @@ export class Manager extends Component {
               totalSlides={this.state.slideReference.length}
               onPrev={this._prevSlide.bind(this)}
               onNext={this._nextSlide.bind(this)}
+              controlColor={this._getControlStyles()}
             />
           )}
 
@@ -740,6 +759,7 @@ export class Manager extends Component {
             items={this.state.slideReference}
             currentSlideIndex={this._getSlideIndex()}
             type={this.props.progress}
+            progressColor={this._getProgressStyles()}
           />
         ) : (
           ''

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -34,6 +34,27 @@ const Bar = styled.div(({ styles, width }) => [ styles, width ]);
 const Container = styled.div(props => props.styles);
 
 export default class Progress extends Component {
+  resolveProgressStyles = (field) => {
+    const { progressColor } = this.props;
+
+    if (!this.props.progressColor) {
+      return null;
+    }
+
+    const style = {};
+    let color;
+
+    if (!this.context.styles.colors.hasOwnProperty(progressColor)) {
+      color = progressColor;
+    } else {
+      color = this.context.styles.colors[progressColor];
+    }
+
+    style[field] = color;
+
+    return style;
+  }
+
   getWidth() {
     return {
       width: `${(100 * this.props.currentSlideIndex / (this.props.items.length - 1))}%`
@@ -86,13 +107,13 @@ export default class Progress extends Component {
               styles={style.pacman}
               position={this.getPointPosition(currentSlideIndex)}
             >
-              <Pacman.Body styles={[style.pacmanTop, this.getPacmanStyle('top')]} />
-              <Pacman.Body styles={[style.pacmanBottom, this.getPacmanStyle('bottom')]} />
+              <Pacman.Body styles={[style.pacmanTop, this.getPacmanStyle('top'), this.resolveProgressStyles('background')]} />
+              <Pacman.Body styles={[style.pacmanBottom, this.getPacmanStyle('bottom'), this.resolveProgressStyles('background')]} />
             </Pacman.Base>
             {items.map((item, i) => {
               return (
                 <Point
-                  styles={style.point}
+                  styles={[style.point, this.resolveProgressStyles('borderColor')]}
                   position={this.getPointStyle(i)}
                   key={`presentation-progress-${i}`}
                 />
@@ -110,14 +131,14 @@ export default class Progress extends Component {
     case 'bar':
       style = style.bar;
       markup = (
-          <Bar styles={style.bar} width={this.getWidth()} />
+          <Bar styles={[style.bar, this.resolveProgressStyles('background')]} width={this.getWidth()} />
         );
       break;
     default:
       return false;
     }
     return (
-      <Container styles={style.container}>
+      <Container styles={[style.container, this.resolveProgressStyles('color')]}>
         {markup}
       </Container>
     );
@@ -127,6 +148,7 @@ export default class Progress extends Component {
 Progress.propTypes = {
   currentSlideIndex: PropTypes.number,
   items: PropTypes.array,
+  progressColor: PropTypes.string,
   type: PropTypes.oneOf(['pacman', 'bar', 'number', 'none'])
 };
 

--- a/src/themes/default/screen.js
+++ b/src/themes/default/screen.js
@@ -102,6 +102,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
       },
       prevIcon: {
         fill: colors.quarternary,
+        transition: 'fill 1s ease-in-out 0.2s',
       },
       next: {
         position: 'absolute',
@@ -115,6 +116,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
       },
       nextIcon: {
         fill: colors.quarternary,
+        transition: 'fill 1s ease-in-out 0.2s',
       },
     },
     prism: {
@@ -144,6 +146,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
           height: '10px',
           borderTopLeftRadius: '10px',
           borderTopRightRadius: '10px',
+          transition: 'all 0.3s ease-out',
           background: colors.quarternary,
         },
         pacmanBottom: {
@@ -154,6 +157,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
           borderBottomLeftRadius: '10px',
           borderBottomRightRadius: '10px',
           background: colors.quarternary,
+          transition: 'all 0.3s ease-out',
           top: '10px',
         },
         point: {
@@ -166,7 +170,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
           borderStyle: 'solid',
           borderColor: colors.quarternary,
           borderRadius: '50%',
-          transition: 'all 0.01s ease-out 0.4s',
+          transition: 'all 0.3s ease-out',
         },
       },
       bar: {
@@ -192,6 +196,7 @@ const screen = (colorArgs = defaultColors, fontArgs = defaultFonts) => {
           right: 10,
           zIndex: 1000,
           color: colors.quarternary,
+          transition: 'all 0.3s ease-out',
         },
       },
     },


### PR DESCRIPTION
This adds the props `controlColor` and `progressColor` to the Slide tag, adding the ability to override the colors for control arrows and progress elements on a per slide basis.

Also updates docs for this feature, updates the docs for some missing props, and adds the `alt` attr to the Image element.

Fixes #420 