### PR TITLE
Inline code w/ markdown produces a `CodePane`, not `Code`

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -203,6 +203,7 @@ export default class Presentation extends React.Component {
   * Lists too!
   * With ~~strikethrough~~ and _italic_
   * And let's not forget **bold**
+  * Add some \`inline code\` to your sldes!
             `}
           </Markdown>
         </Slide>
@@ -214,6 +215,12 @@ All the same tags and elements supported in <Markdown /> are supported in Markdo
 Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
 * A Tagged Template Literal
 * Imported Markdown from another file
+---
+Add some inline code to your markdown!
+
+\`\`\`js
+const myCode = (is, great) => 'for' + 'sharing';
+\`\`\`
           `
         }
         <Slide transition={['slide', 'spin']} bgColor="primary">

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "emotion": "^8.0.8",
     "history": "^4.6.1",
     "lodash": "^4.17.4",
-    "marksy": "^5.0.0",
+    "marksy": "^6.0.0",
     "normalize.css": "^7.0.0",
     "prismjs": "^1.6.0",
     "react-emotion": "^8.0.8",

--- a/src/components/__snapshots__/markdown.test.js.snap
+++ b/src/components/__snapshots__/markdown.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Markdown> should render correctly when using inline code 1`] = `
+<Styled(div)
+  styles={
+    Array [
+      Object {},
+      Object {},
+    ]
+  }
+>
+  <Text
+    context={Object {}}
+    key="1"
+    lineHeight={1}
+  >
+    This should 
+    <CodePane
+      className=""
+      contentEditable={false}
+      context={Object {}}
+      key="0"
+      lang="markup"
+      source=""
+      theme="dark"
+    >
+      work
+    </CodePane>
+  </Text>
+</Styled(div)>
+`;

--- a/src/components/__snapshots__/markdown.test.js.snap
+++ b/src/components/__snapshots__/markdown.test.js.snap
@@ -15,17 +15,12 @@ exports[`<Markdown> should render correctly when using inline code 1`] = `
     lineHeight={1}
   >
     This should 
-    <CodePane
-      className=""
-      contentEditable={false}
+    <Code
       context={Object {}}
       key="0"
-      lang="markup"
-      source=""
-      theme="dark"
     >
       work
-    </CodePane>
+    </Code>
   </Text>
 </Styled(div)>
 `;

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -12,7 +12,7 @@ const StyledCode = styled.code(props => props.styles);
 export default class Code extends Component {
   createMarkup() {
     return {
-      __html: format(this.props.children)
+      __html: Array.isArray(this.props.children) ? this.props.children.map(format) : format(this.props.children)
     };
   }
   render() {

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -43,12 +43,15 @@ const _CombineBlockQuote = ({ children }) => (
 );
 _CombineBlockQuote.propTypes = { children: PropTypes.node };
 
+const _CodePane = ({ language, code }) => <CodePane lang={language} source={code}/>;
+_CodePane.propTypes = { source: PropTypes.string, lang: PropTypes.string };
+
 const compile = marksy({
   createElement,
   elements: {
     a: Link,
     blockquote: _CombineBlockQuote,
-    code: CodePane,
+    code: _CodePane,
     del: _S('strikethrough'),
     em: _S('italic'),
     h1: _Heading(1),

--- a/src/components/markdown.test.js
+++ b/src/components/markdown.test.js
@@ -1,0 +1,13 @@
+import Markdown from './markdown';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+describe('<Markdown>', () => {
+  test('should render correctly when using inline code', () => {
+    const wrapper = shallow(
+      <Markdown>This should `work`</Markdown>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3871,9 +3871,9 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-marksy@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/marksy/-/marksy-5.0.0.tgz#70e9015154994df339528c43511f71540f6559fe"
+marksy@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.0.1.tgz#ea05f170a5f8a3f935b2ef51a9b7847c947b7402"
   dependencies:
     babel-standalone "^6.24.0"
     he "^1.1.1"


### PR DESCRIPTION
Created a test case for it. You can see in the snapshot that a `CodePane` is produce, which should be a `Code` element.

Both the `Code` and `CodePane` elements work strangely when produced by the Markdown output. Besides this, correctly formatted `CodePane` elements are only highlighted if the slide is focused on page load. Switching into a Slide with a `CodePane` generated by Markdown leaves the `CodePane` unhighlighted. Pretty strange.

This was also an issue in Spectacle 2.* (which I was using previously). I'm in the process of upgrading to 4.0, which also means converting the Markdown slides into React ones, because I keep running into this issue and need more control over the styles.

I'm opening this PR to get some thoughts as to why these things may be happening and where I should look to fix it.