### PR TITLE
Update marksy to 6.0.2 for CVE-2017-17461 and CVE-2017-1000427

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "emotion": "^8.0.8",
     "history": "^4.6.1",
     "lodash": "^4.17.4",
-    "marksy": "^6.0.0",
+    "marksy": "^6.0.2",
     "normalize.css": "^7.0.0",
     "prismjs": "^1.6.0",
     "react-emotion": "^8.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,17 +3867,17 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+marked@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.9.tgz#54ce6a57e720c3ac6098374ec625fcbcc97ff290"
 
-marksy@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.0.1.tgz#ea05f170a5f8a3f935b2ef51a9b7847c947b7402"
+marksy@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.0.2.tgz#2c7b54b43652144cfddc8d674f88d61aee9fc63e"
   dependencies:
     babel-standalone "^6.24.0"
     he "^1.1.1"
-    marked "^0.3.6"
+    marked "^0.3.9"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.14"


### PR DESCRIPTION
As filled in #447.

A dependency of spectacle did had two security vulnerabilities, CVE-2017-17461 and CVE-2017-1000427.

The yarn.lock file enforced to install a lower version in development so I did upgrade this one. 
There has not been any breaking change in dependencies of the marksy package or marksy itself.