### PR TITLE
ADD a repository field on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   },
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/spectacle.git"
+  },
   "dependencies": {
     "deep-object-diff": "^1.0.4",
     "emotion": "^8.0.8",


### PR DESCRIPTION
This adds a link on the npm package page:
https://www.npmjs.com/package/spectacle
which is currently missing.