### PR TITLE
Add `theme="external"` to disable the built-in prism themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,8 +573,15 @@ This tag displays a styled, highlighted code preview. I prefer putting my code s
 |---|---|---|
 |lang|PropTypes.string| Prism compatible language name. i.e: 'javascript' |
 |source| PropTypes.string| String of code to be shown |
+|className| PropTypes.string| String of a className to be appended to the CodePane |
+|theme| PropTypes.string| Accepts `light`, `dark`, or `external` for the source editor's syntax highlighting. Defaults to `dark`. |
 
-If you want to change the theme used here, you can include a prism theme in index.html via a script tag. CodePane and Playground both use the prism library under the hood, which has several themes that are available to include.
+If you want to change the theme used here, you can include a prism theme in index.html via a style or a link tag. For your theme to be actually applied
+correctly you need to set the `theme` prop to `"external"`, which disables our builtin light and dark themes.
+Please note that including a theme can actually influence all CodePane and Playground components, even if you don't set this prop, since some Prism
+themes use very generic CSS selectors.
+
+CodePane and Playground both use the prism library under the hood, which has several themes that are available to include.
 
 <a name="code-base"></a>
 #### Code (Base)
@@ -592,7 +599,7 @@ For more information on the playground read the docs over at [react-live](https:
 |---|---|---|
 |code|PropTypes.string|The code block you want to initially supply to the component playground. If none is supplied a demo component will be displayed.|
 |previewBackgroundColor|PropTypes.string|The background color you want for the preview pane. Defaults to `#fff`.|
-|theme|PropTypes.string|Accepts `light` or `dark` for the source editor's syntax highlighting. Defaults to `light`.|
+|theme| PropTypes.string| Accepts `light`, `dark`, or `external` for the source editor's syntax highlighting. Defaults to `dark`. |
 |scope|PropTypes.object|Defines any outside modules or components to expose to the playground. React, Component, and render are supplied for you.|
 
 Example code blocks:
@@ -614,6 +621,8 @@ class View extends React.Component {
 }
 render(<View />);
 ```
+
+If you want to change the theme used here, please refer to the instructions above in the [CodePane's API reference](#codepane-base).
 
 <a name="go-to-action"></a>
 #### Go To Action (Base)

--- a/src/components/__snapshots__/code-pane.test.js.snap
+++ b/src/components/__snapshots__/code-pane.test.js.snap
@@ -31,7 +31,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
       className="css-0"
     >
       <Styled(Component)
-        className="language-prism"
+        className="language-jsx builtin-prism-theme "
         code="
             const myButton = (
               <CustomButton
@@ -51,7 +51,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
         syntaxStyles={Object {}}
       >
         <Component
-          className="language-prism css-1i53um3"
+          className="language-jsx builtin-prism-theme  css-3w3gcf"
           code="
               const myButton = (
                 <CustomButton
@@ -71,7 +71,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
           syntaxStyles={Object {}}
         >
           <Editor
-            className="language-prism css-1i53um3"
+            className="language-jsx builtin-prism-theme  css-3w3gcf"
             code="
                 const myButton = (
                   <CustomButton
@@ -89,7 +89,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
             onKeyUp={[Function]}
           >
             <pre
-              className="prism-code language-prism css-1i53um3"
+              className="prism-code language-jsx builtin-prism-theme  css-3w3gcf"
               contentEditable={false}
               dangerouslySetInnerHTML={
                 Object {

--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -66,7 +66,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
       class="css-1fc71w4"
     >
       <pre
-        class="prism-code language-prism css-1y25kh4"
+        class="prism-code language-jsx builtin-prism-theme css-1tqequ7"
         contenteditable="true"
         spellcheck="false"
       >
@@ -607,7 +607,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
       class="css-1fc71w4"
     >
       <pre
-        class="prism-code language-prism css-x6ttwb"
+        class="prism-code language-jsx builtin-prism-theme css-62ms6n"
         contenteditable="true"
         spellcheck="false"
       >
@@ -1148,7 +1148,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
       class="css-1fc71w4"
     >
       <pre
-        class="prism-code language-prism css-x6ttwb"
+        class="prism-code language-jsx builtin-prism-theme css-62ms6n"
         contenteditable="true"
         spellcheck="false"
       >
@@ -1683,7 +1683,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
       class="css-1fc71w4"
     >
       <pre
-        class="prism-code language-prism css-x6ttwb"
+        class="prism-code language-jsx builtin-prism-theme css-62ms6n"
         contenteditable="true"
         spellcheck="false"
       >

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -10,9 +10,11 @@ const StyledWrapper = styled.div(props => props.styles);
 const StyledEditor = styled(({ syntaxStyles: _, prismTheme: __, ...rest }) => <Editor {...rest} />)`
   && {
     ${props => props.syntaxStyles}
-  }
 
-  ${props => props.prismTheme}
+    &.builtin-prism-theme {
+      ${props => props.prismTheme}
+    }
+  }
 `;
 
 export default class CodePane extends Component {
@@ -22,6 +24,8 @@ export default class CodePane extends Component {
 
   render() {
     const useDarkTheme = this.props.theme === 'dark';
+    const externalPrismTheme = this.props.theme === 'external';
+    const className = `language-${this.props.lang} ${externalPrismTheme ? '' : 'builtin-prism-theme'} ${this.props.className}`;
 
     const wrapperStyles = [
       this.context.styles.components.codePane,
@@ -35,7 +39,7 @@ export default class CodePane extends Component {
         styles={wrapperStyles}
       >
         <StyledEditor
-          className="language-prism"
+          className={className}
           code={this.props.source}
           language={this.props.lang}
           contentEditable={this.props.contentEditable}
@@ -62,13 +66,13 @@ CodePane.propTypes = {
   lang: PropTypes.string,
   source: PropTypes.string,
   style: PropTypes.object,
-  theme: PropTypes.string,
+  theme: PropTypes.oneOf(['dark', 'light', 'external']),
 };
 
 CodePane.defaultProps = {
-  theme: 'dark',
   className: '',
   contentEditable: false,
   lang: 'markup',
   source: '',
+  theme: 'dark',
 };

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -40,9 +40,11 @@ const PlaygroundEditor = styled(({ syntaxStyles: _, prismTheme: __, ...rest }) =
     ${props => props.syntaxStyles}
     min-height: 100%;
     font-size: 1.25vw;
-  }
 
-  ${props => props.prismTheme}
+    &.builtin-prism-theme {
+      ${props => props.prismTheme}
+    }
+  }
 `;
 
 const PlaygroundRow = styled.div`
@@ -188,6 +190,8 @@ class ComponentPlayground extends Component {
     } = this.props;
 
     const useDarkTheme = theme === 'dark';
+    const externalPrismTheme = this.props.theme === 'external';
+    const className = `language-jsx ${externalPrismTheme ? '' : 'builtin-prism-theme'}`;
 
     return (
       <PlaygroundProvider
@@ -218,7 +222,7 @@ class ComponentPlayground extends Component {
 
           <PlaygroundColumn>
             <PlaygroundEditor
-              className="language-prism"
+              className={className}
               syntaxStyles={this.context.styles.components.syntax}
               prismTheme={this.context.styles.prism[useDarkTheme ? 'dark' : 'light']}
               onChange={this.onEditorChange}
@@ -239,7 +243,11 @@ ComponentPlayground.propTypes = {
   code: PropTypes.string,
   previewBackgroundColor: PropTypes.string,
   scope: PropTypes.object,
-  theme: PropTypes.string
+  theme: PropTypes.oneOf(['dark', 'light', 'external']),
+};
+
+ComponentPlayground.defaultProps = {
+  theme: 'dark',
 };
 
 export default ComponentPlayground;


### PR DESCRIPTION
Fix #458

When applied this PR 'hides' our built-in Prism themes behind the `.builtin-prism-theme` class, which is applied by default. It can be disabled by setting the `theme` prop to `"external"` which allows external themes to style Prism in whatever way they'd like.

This also adds a stricter prop-types check for the theme prop, and passes on the correct `language-X` class for Prism. (Quick on-the-side-fix)

A user might still run into specificity problems where themes can mix when their own Prism theme contains some really generic selectors with a higher specificity than ours. I don't think there's any value in preventing this with even more specific selectors on our end, instead the README now just mentions this.

~Edit: not quite sure why, but an unrelated snapshot changed as well. Might be worth to take a look at that as well :/~
Edit 2: nevermind, I forgot to run yarn 🤦‍♂️ 