### PR TITLE
Add aria-label to fullscreen button

### DIFF
--- a/src/components/__snapshots__/component-playground.test.js.snap
+++ b/src/components/__snapshots__/component-playground.test.js.snap
@@ -18,6 +18,7 @@ exports[`<ComponentPlayground /> Should render the dark theme correctly 1`] = `
     >
       Source Code
       <button
+        aria-label="Toggle full screen"
         class="css-1a7vuu6"
       >
         <svg
@@ -559,6 +560,7 @@ exports[`<ComponentPlayground /> Should render the light theme correctly 1`] = `
     >
       Source Code
       <button
+        aria-label="Toggle full screen"
         class="css-1a7vuu6"
       >
         <svg
@@ -1100,6 +1102,7 @@ exports[`<ComponentPlayground /> Should render with a custom background color 1`
     >
       Source Code
       <button
+        aria-label="Toggle full screen"
         class="css-1a7vuu6"
       >
         <svg
@@ -1641,6 +1644,7 @@ exports[`<ComponentPlayground /> Should render with a custom code block 1`] = `
     >
       Source Code
       <button
+        aria-label="Toggle full screen"
         class="css-1a7vuu6"
       >
         <svg

--- a/src/components/__snapshots__/fullscreen.test.js.snap
+++ b/src/components/__snapshots__/fullscreen.test.js.snap
@@ -14,12 +14,14 @@ exports[`<Fullscreen /> should render correctly. 1`] = `
       viewBox="0 0 512 512"
     >
       <Styled(button)
+        aria-label="Toggle full screen"
         className="css-12n5ud"
         onClick={[Function]}
         style={undefined}
         viewBox="0 0 512 512"
       >
         <button
+          aria-label="Toggle full screen"
           className="css-1hv29sw"
           onClick={[Function]}
           style={undefined}

--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -276,12 +276,14 @@ exports[`<Manager /> should render correctly. 1`] = `
               viewBox="0 0 512 512"
             >
               <Styled(button)
+                aria-label="Toggle full screen"
                 className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
               >
                 <button
+                  aria-label="Toggle full screen"
                   className="css-1hv29sw"
                   onClick={[Function]}
                   style={undefined}
@@ -605,12 +607,14 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
               viewBox="0 0 512 512"
             >
               <Styled(button)
+                aria-label="Toggle full screen"
                 className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
               >
                 <button
+                  aria-label="Toggle full screen"
                   className="css-1hv29sw"
                   onClick={[Function]}
                   style={undefined}
@@ -956,12 +960,14 @@ exports[`<Manager /> should render with slideset slides 1`] = `
               viewBox="0 0 512 512"
             >
               <Styled(button)
+                aria-label="Toggle full screen"
                 className="css-12n5ud"
                 onClick={[Function]}
                 style={undefined}
                 viewBox="0 0 512 512"
               >
                 <button
+                  aria-label="Toggle full screen"
                   className="css-1hv29sw"
                   onClick={[Function]}
                   style={undefined}

--- a/src/components/fullscreen-button.js
+++ b/src/components/fullscreen-button.js
@@ -18,7 +18,7 @@ const Button = styled.button`
 `;
 
 const FullscreenButton = props => (
-  <Button {...props}>
+  <Button aria-label="Toggle full screen" {...props}>
     <svg viewBox="0 0 24 24">
       <path d="M0 0h24v24H0z" fill="none" />
       <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" fill="currentColor" />


### PR DESCRIPTION
Adds an `aria-label` to the fullscreen button so that screen reader users can tell what it is.