### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,21 @@ The `S` tag is used to add styling to a piece of text, such as underline or stri
 |---|---|---|
 |type|PropTypes.string| Accepts `strikethrough`, `underline`, `bold` or `italic`|
 
+<a name="slideset"></a>
+### SlideSet (Base)
+
+Import an entirely separate `Deck` component and wrap it in `SlideSet` tags to include it in another presentation. Easy.
+
+```jsx
+<Deck>
+  <Slide>
+  </Slide>
+  <SlideSet>
+    <ImportedDeck/>
+  </SlideSet>
+</Deck>
+```
+
 <a name="table-tablerow-tableheaderitem-and-tableitem-base"></a>
 #### Table, TableRow, TableHeaderItem and TableItem (Base)
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,12 @@ import slidesMarkdown from "raw-loader!markdown.md";
 </Deck>
 ```
 
+All markdown files, by our webpack configuration, are sent through an `html-loader!`. If you run into formatting issues when sourcing your markdown files, supplememt the import with a `!raw-loader!` declaration. This will override the config that is breaking your markdown format. For example:
+
+```jsx
+<Markdown source={require("!raw-loader!../assets/stuff.md")} />
+```
+
 <a name="layout-tags"></a>
 ### Layout Tags
 

--- a/docs/tag-api.md
+++ b/docs/tag-api.md
@@ -76,6 +76,11 @@ Markdown generated tags aren't prop configurable, and instead render with your t
 |source|PropTypes.string| Markdown source |
 |mdastConfig| PropTypes.object | Mdast configuration object |
 
+All markdown files, by our webpack configuration, are sent through an `html-loader!`. If you run into formatting issues when sourcing your markdown files, supplememt the import with a `!raw-loader!` declaration. This will override the config that is breaking your markdown format. For example:
+```
+<Markdown source={require("!raw-loader!../assets/stuff.md")} />
+```
+
 <a name="element-tags"></a>
 ## Element Tags
 

--- a/docs/tag-api.md
+++ b/docs/tag-api.md
@@ -41,6 +41,24 @@ The slide tag represents each slide in the presentation. Giving a slide tag an `
 |notes| PropTypes.string| Text which will appear in the presenter mode. Can be HTML.
 |id| PropTypes.string | Used to create a string based hash.
 
+<a name="notes"></a>
+#### Notes
+
+The notes tag allows to use any tree of react elements as the notes of a slide. It is used as a child node of a slide tag and its children override any value given as the `notes` attribute of its parent slide.
+
+```jsx
+<Slide ...>
+  <Notes>
+    <h4>Slide notes</h4>
+    <ol>
+      <li>First note</li>
+      <li>Second note</li>
+    </ol>
+  </Notes>
+  {/* Slide content */}
+</Slide>
+```
+
 <a name="layout-tags"></a>
 ## Layout Tags
 
@@ -77,7 +95,7 @@ Markdown generated tags aren't prop configurable, and instead render with your t
 |mdastConfig| PropTypes.object | Mdast configuration object |
 
 All markdown files, by our webpack configuration, are sent through an `html-loader!`. If you run into formatting issues when sourcing your markdown files, supplememt the import with a `!raw-loader!` declaration. This will override the config that is breaking your markdown format. For example:
-```
+```jsx
 <Markdown source={require("!raw-loader!../assets/stuff.md")} />
 ```
 

--- a/docs/tag-api.md
+++ b/docs/tag-api.md
@@ -195,6 +195,21 @@ The `S` tag is used to add inline styling to a piece of text, such as underline 
 |---|---|---|
 |type|PropTypes.string| Accepts `strikethrough`, `underline`, `bold` or `italic`|
 
+<a name="slideset"></a>
+### SlideSet (Base)
+
+Import an entirely separate `Deck` component and wrap it in `SlideSet` tags to include it in another presentation. Easy.
+
+```jsx
+<Deck>
+  <Slide>
+  </Slide>
+  <SlideSet>
+    <ImportedDeck/>
+  </SlideSet>
+</Deck>
+```
+
 <a name="table-tablerow-tableheaderitem-and-tableitem-base"></a>
 ### Table, TableRow, TableHeaderItem and TableItem (Base)
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -51,6 +51,7 @@ export default class Presentation extends React.Component {
           <Heading size={1} fit caps textColor="black">
             Where You Can Write Your Decks In JSX
           </Heading>
+          <Notes>... as well as annotate your decks in JSX!</Notes>
           <Link href="https://github.com/FormidableLabs/spectacle">
             <Text bold caps textColor="tertiary">View on Github</Text>
           </Link>
@@ -76,8 +77,8 @@ export default class Presentation extends React.Component {
             }
           ]}
           bgColor="black"
-          notes="You can even put notes on your slide. How awesome is that?"
         >
+          <Notes>You can even put notes on your slide. How awesome is that?</Notes>
           <Image src={images.kat.replace('/', '')} margin="0px auto 40px" />
           <Heading size={2} caps fit textColor="primary" textFont="primary">
             Wait what?
@@ -87,8 +88,8 @@ export default class Presentation extends React.Component {
           transitionIn={['zoom', 'fade']}
           transitionOut={['slide', 'fade']}
           bgColor="primary"
-          notes="<ul><li>talk about that</li><li>and that</li></ul>"
         >
+          <Notes><ul><li>talk about that</li><li>and that</li></ul></Notes>
           <CodePane
             lang="jsx"
             source={require('raw-loader!../assets/deck.example')}
@@ -248,9 +249,8 @@ const myCode = (is, great) => 'for' + 'sharing';
             <Interactive/>
           </Slide>
         </SlideSet>
-        <Slide transition={['slide']} bgColor="primary"
-          notes="Hard to find cities without any pizza"
-        >
+        <Slide transition={['slide']} bgColor="primary">
+          <Notes>Hard to find cities without any pizza</Notes>
           <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
             Pizza Toppings
           </Heading>
@@ -294,6 +294,7 @@ const myCode = (is, great) => 'for' + 'sharing';
           </Layout>
         </Slide>
         <Slide transition={['spin', 'slide']} bgColor="tertiary">
+          <Notes>Click on the Formidalogo to check out some of the other stuff we've built</Notes>
           <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
             Made with love in Seattle by
           </Heading>


### PR DESCRIPTION
Updating files between `README.md` and `/docs` to reflect each other _as well as_ the most up-to-date API. 

- [x] `<Notes/>` documentation → rel #71 
- [x] markdown tag updates → closes #467 
- [x] `<SlideSet/>` stuff → kinda rel #470 
- [x] miscellaneous other things I'm sure to come across