### PR TITLE
Add protocol to emotion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ The returned theme object can then be passed to the `Deck` tag via the `theme` p
 
 _How can I easily style the base components for my presentation?_
 
-Historically, custom styling in Spectacle has meant screwing with a theme file, or using gross `!important` overrides. We fixed that. Spectacle is now driven by [emotion](github.com/emotion-js/emotion), so you can bring your own styling library, whether its emotion itself, or something like styled-components or glamorous. For example, if you want to create a custom Heading style:
+Historically, custom styling in Spectacle has meant screwing with a theme file, or using gross `!important` overrides. We fixed that. Spectacle is now driven by [emotion](https://github.com/emotion-js/emotion), so you can bring your own styling library, whether its emotion itself, or something like styled-components or glamorous. For example, if you want to create a custom Heading style:
 
 ```javascript
 import styled from 'styled-components';


### PR DESCRIPTION
Previously, the browser treated `github.com/emotion-js/emotion` as a relative link. Specifying `https://` gives the browser a full URL so it correctly navigates to the Emotion repository.