### PR TITLE
Throw error if heading size is higher than 6

### DIFF
--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -88,6 +88,7 @@ export default class Heading extends Component {
   }
   render() {
     const { size, lineHeight, fit, style, children } = this.props;
+    if (size > 6) throw new Error("Heading size must be between 1 and 6");
     const Tag = `h${size}`;
     const typefaceStyle = this.context.typeface || {};
 

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -88,7 +88,9 @@ export default class Heading extends Component {
   }
   render() {
     const { size, lineHeight, fit, style, children } = this.props;
-    if (size > 6) throw new Error("Heading size must be between 1 and 6");
+    if (size > 6) {
+      throw new Error('Heading size must be between 1 and 6');
+    }
     const Tag = `h${size}`;
     const typefaceStyle = this.context.typeface || {};
 


### PR DESCRIPTION
Got a quite cryptic error:

```
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.
You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports. Check the render method of `Heading`.
```

Took me a while to realize, that I tried to use a `Heading` with `size` `7`.  The proposed error is more obvious to me.