### PR TITLE
Expose LiveProvider's transformCode prop

### DIFF
--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -186,7 +186,8 @@ class ComponentPlayground extends Component {
     const {
       previewBackgroundColor,
       scope = {},
-      theme = 'dark'
+      theme = 'dark',
+      transformCode
     } = this.props;
 
     const useDarkTheme = theme === 'dark';
@@ -198,6 +199,7 @@ class ComponentPlayground extends Component {
         mountStylesheet={false}
         code={this.state.code}
         scope={{ Component, ...scope }}
+        transformCode={transformCode}
         noInline
       >
         <PlaygroundRow>


### PR DESCRIPTION
`LiveProvider` uses Buble to transform code, but that only supports ES2015, and not newer syntax like Class Properties.  

`LiveProvider` accepts a `transformCode` prop that can be used as an alternative to the built-in transformation, but Spectacle's `ComponentPlayground` doesn't expose that.  By passing `transformCode` through, end users can customize the compilation process (such as using `babel-standalone` instead of Buble).

I've got some code samples that use Class Properties, and they worked on older versions of Spectacle.  I hand-edited my local copy of Spectacle to expose the `transformCode` prop, and was able to successfully compile the code using `babel-standalone`.  I'd like to get this merged in and published.