### PR TITLE
Flexible <Anim> component

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ For best performance, wrap the contents of this tag in a native DOM element like
 |fromStyle|Proptypes.object|A style object that defines the starting, inactive state of the Anim tag.
 |toStyle|Proptypes.array|An array of style objects that define each step in the animation. They will step from one toStyle object to another, until that fragment is finished with its animations.
 |easing|PropTypes.string|A victory easing curve for the Appear animation. The various options are documented in the [Victory Animation easing docs](https://formidable.com/open-source/victory/docs/victory-animation/#easing).
-
+|onAnim|PropTypes.fun|This function is called every time the Anim component plays an animation. It'll be called with two arguments, forwards, a boolean indicating if it was stepped forwards or backwards, and the index of the animation that was just played.
 
 <a name="blockquote-quote-and-cite-base"></a>
 #### BlockQuote, Quote and Cite (Base)

--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ The element tags are the bread and butter of your slide content. Most of these t
 
 This tag does not extend from Base. It's special. Wrapping elements in the appear tag makes them appear/disappear in order in response to navigation.
 
+For best performance, wrap the contents of this tag in a native DOM element like a `<div>` or `<span>`.
+
 |Name|PropType|Description|
 |---|---|---|
 |order|PropTypes.number| An optional integer starting at 1 for the presentation order of the Appear tags within a slide. If a slide contains ordered and unordered Appear tags, the unordered will show first.
@@ -554,6 +556,21 @@ This tag does not extend from Base. It's special. Wrapping elements in the appea
 |startValue|Proptypes.object|An optional style object that defines the starting, inactive state of the Appear tag. The default animation is a simple fade-in, so the default `startValue` value is `{ opacity: 0 }`.
 |endValue|Proptypes.object|An optional style object that defines the ending, active state of the Appear tag. The default animation is a simple fade-in, so the default `endValue` value is `{ opacity: 1 }`.
 |easing|PropTypes.string|An optional victory easing curve for the Appear animation. The various options are documented in the [Victory Animation easing docs](https://formidable.com/open-source/victory/docs/victory-animation/#easing). Default value is `quadInOut`
+
+<a name="anim"></a>
+#### Anim
+
+If you want extra flexibility with animated animation, you can use the Anim component instead of Appear. It will let you have multi-step animations for each individual fragment. You can use this to create fancy animated intros, in-slide carousels, and many other fancy things. This tag does not extend from Base. It's special. 
+
+For best performance, wrap the contents of this tag in a native DOM element like a `<div>` or `<span>`.
+
+|Name|PropType|Description|
+|---|---|---|
+|order|PropTypes.number| An optional integer starting at 1 for the presentation order of the Appear tags within a slide. If a slide contains ordered and unordered Appear tags, the unordered will show first.
+|transitionDuration|PropTypes.number|A duration (in milliseconds) for the animation. Default value is `300`.
+|fromStyle|Proptypes.object|A style object that defines the starting, inactive state of the Anim tag.
+|toStyle|Proptypes.array|An array of style objects that define each step in the animation. They will step from one toStyle object to another, until that fragment is finished with its animations.
+|easing|PropTypes.string|A victory easing curve for the Appear animation. The various options are documented in the [Victory Animation easing docs](https://formidable.com/open-source/victory/docs/victory-animation/#easing).
 
 
 <a name="blockquote-quote-and-cite-base"></a>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -42,19 +42,29 @@ export default class Presentation extends React.Component {
     return (
       <Deck transition={['zoom', 'slide']} theme={theme} transitionDuration={500}>
         <Slide transition={['zoom']} bgColor="primary">
-          <Heading size={1} fit caps lineHeight={1} textColor="black">
-            Spectacle
-          </Heading>
-          <Heading size={1} fit caps>
-            A ReactJS Presentation Library
-          </Heading>
-          <Heading size={1} fit caps textColor="black">
-            Where You Can Write Your Decks In JSX
-          </Heading>
-          <Link href="https://github.com/FormidableLabs/spectacle">
-            <Text bold caps textColor="tertiary">View on Github</Text>
-          </Link>
-          <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
+          <Heading>Hi</Heading>
+        </Slide>
+        <Slide transition={['zoom']} bgColor="primary">
+          <Appear
+            startValue={{
+              opacity: 0.2,
+              transform: 'translateY(-100px) translateX(0px)'
+            }}
+            endValue={[
+              {
+                opacity: 1,
+                transform: 'translateY(0px) translateX(0px)'
+              },
+              {
+                opacity: 1,
+                transform: 'translateY(100px) translateX(0px)'
+              },
+              {
+                opacity: 1,
+                transform: 'translateY(100px) translateX(100px)'
+              }
+          ]}
+          ><div>hey friend</div></Appear>
         </Slide>
         <Slide
           onActive={slideIndex => {

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -120,6 +120,12 @@ export default class Presentation extends React.Component {
         </Slide>
         <Slide transition={['slide']}>
           <Anim
+            onAnim={(forwards, animIndex) => {
+              /* eslint-disable */
+              console.log('forwards ', forwards)
+              console.log('animIndex ', animIndex)
+              /* eslint-enable */
+            }}
             fromStyle={{
               opacity: 0,
               transform: 'translate3d(0px, -100px, 0px)  scale(1) rotate(0deg)'
@@ -196,7 +202,7 @@ export default class Presentation extends React.Component {
             )}
           />
         </Slide>
-        <Slide transition={['slide']} bgDarken={0.75} getAppearStep={this.updateSteps}>
+        <Slide transition={['slide']} bgDarken={0.75} getAnimStep={this.updateSteps}>
           <Appear>
             <Heading size={1} caps textColor="tertiary">
               Can

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -46,6 +46,7 @@ export default class Presentation extends React.Component {
         </Slide>
         <Slide transition={['zoom']} bgColor="primary">
           <Appear
+            order={2}
             startValue={{
               opacity: 0.2,
               transform: 'translateY(-100px) translateX(0px)'
@@ -65,6 +66,27 @@ export default class Presentation extends React.Component {
               }
           ]}
           ><div>hey friend</div></Appear>
+          <Appear
+            order={1}
+            startValue={{
+              opacity: 0.2,
+              transform: 'translateY(-100px) translateX(0px)'
+            }}
+            endValue={[
+              {
+                opacity: 1,
+                transform: 'translateY(0px) translateX(0px)'
+              },
+              {
+                opacity: 1,
+                transform: 'translateY(100px) translateX(0px)'
+              },
+              {
+                opacity: 1,
+                transform: 'translateY(100px) translateX(100px)'
+              }
+            ]}
+          ><div>hey friend no 2</div></Appear>
         </Slide>
         <Slide
           onActive={slideIndex => {

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -42,66 +42,20 @@ export default class Presentation extends React.Component {
     return (
       <Deck transition={['zoom', 'slide']} theme={theme} transitionDuration={500}>
         <Slide transition={['zoom']} bgColor="primary">
-          <Heading>Hi</Heading>
+          <Heading size={1} fit caps lineHeight={1} textColor="black">
+            Spectacle
+          </Heading>
+          <Heading size={1} fit caps>
+            A ReactJS Presentation Library
+          </Heading>
+          <Heading size={1} fit caps textColor="black">
+            Where You Can Write Your Decks In JSX
+          </Heading>
+          <Link href="https://github.com/FormidableLabs/spectacle">
+            <Text bold caps textColor="tertiary">View on Github</Text>
+          </Link>
+          <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
         </Slide>
-        <Slide transition={['zoom']} bgColor="primary">
-          <Anim
-            order={2}
-            fromStyle={{
-              opacity: 0.2,
-              transform: 'translateY(-100px) translateX(0px)'
-            }}
-            toStyle={[
-              {
-                opacity: 1,
-                transform: 'translateY(0px) translateX(0px)'
-              },
-              {
-                opacity: 1,
-                transform: 'translateY(100px) translateX(0px)'
-              },
-              {
-                opacity: 1,
-                transform: 'translateY(100px) translateX(100px)'
-              }
-          ]}
-            easing="bounceOut"
-            transitionDuration={300}
-          >
-            <div>hey friend</div>
-          </Anim>
-          <Anim
-            order={1}
-            fromStyle={{
-              opacity: 0.2,
-              transform: 'translateY(-100px) translateX(0px)'
-            }}
-            toStyle={[
-              {
-                opacity: 1,
-                transform: 'translateY(0px) translateX(0px)'
-              },
-              {
-                opacity: 1,
-                transform: 'translateY(100px) translateX(0px)'
-              },
-              {
-                opacity: 1,
-                transform: 'translateY(100px) translateX(100px)'
-              }
-            ]}
-            easing="bounceOut"
-            transitionDuration={300}
-          >
-            <div>hey friend no 2</div>
-          </Anim>
-        </Slide>
-
-        <Slide>
-          <Appear><span>oh hey der</span></Appear>
-          <Appear><span>hi gain</span></Appear>
-        </Slide>
-
         <Slide
           onActive={slideIndex => {
             console.info(`Viewing slide index: ${slideIndex}.`); // eslint-disable-line no-console
@@ -139,7 +93,7 @@ export default class Presentation extends React.Component {
             lang="jsx"
             source={require('raw-loader!../assets/deck.example')}
             margin="20px auto"
-            overflow = "overflow"
+            overflow="overflow"
           />
         </Slide>
         <Slide goTo={3}>
@@ -192,7 +146,7 @@ export default class Presentation extends React.Component {
         </Slide>
         <Slide>
           <Heading size={2} textColor="secondary" margin="0.25em">
-           Mix it up!
+            Mix it up!
           </Heading>
           <Heading size={6} textColor="tertiary">
             You can even jump to different slides with a standard button or custom component!
@@ -238,9 +192,9 @@ export default class Presentation extends React.Component {
               Steps
             </Heading>
           </Appear>
-            <Heading size={1} caps fit textColor="secondary">
-              Steps: {this.state.steps}
-            </Heading>
+          <Heading size={1} caps fit textColor="secondary">
+            Steps: {this.state.steps}
+          </Heading>
         </Slide>
         <Slide transition={['zoom', 'fade']} bgColor="primary">
           <Heading caps fit>Flexible Layouts</Heading>
@@ -317,7 +271,7 @@ const myCode = (is, great) => 'for' + 'sharing';
             <Heading size={1} caps fit textColor="tertiary">
               Your presentations are interactive
             </Heading>
-            <Interactive/>
+            <Interactive />
           </Slide>
         </SlideSet>
         <Slide transition={['slide']} bgColor="primary"
@@ -330,7 +284,7 @@ const myCode = (is, great) => 'for' + 'sharing';
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHeaderItem/>
+                  <TableHeaderItem />
                   <TableHeaderItem>2011</TableHeaderItem>
                   <TableHeaderItem>2013</TableHeaderItem>
                   <TableHeaderItem>2015</TableHeaderItem>
@@ -351,13 +305,13 @@ const myCode = (is, great) => 'for' + 'sharing';
                 </TableRow>
                 <TableRow>
                   <TableItem>Pepperoni</TableItem>
-                  <TableItem/>
+                  <TableItem />
                   <TableItem>50.2%</TableItem>
                   <TableItem>77.2%</TableItem>
                 </TableRow>
                 <TableRow>
                   <TableItem>Olives</TableItem>
-                  <TableItem/>
+                  <TableItem />
                   <TableItem>24.9%</TableItem>
                   <TableItem>55.9%</TableItem>
                 </TableRow>
@@ -369,7 +323,7 @@ const myCode = (is, great) => 'for' + 'sharing';
           <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
             Made with love in Seattle by
           </Heading>
-          <Link href="http://www.formidable.com"><Image width="100%" src={images.logo}/></Link>
+          <Link href="http://www.formidable.com"><Image width="100%" src={images.logo} /></Link>
         </Slide>
       </Deck>
     );

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {
-  Appear, BlockQuote, Cite, CodePane, ComponentPlayground, Deck, Fill,
+  Anim, Appear, BlockQuote, Cite, CodePane, ComponentPlayground, Deck, Fill,
   Heading, Image, Layout, Link, ListItem, List, Markdown, MarkdownSlides, Quote, Slide, SlideSet,
   TableBody, TableHeader, TableHeaderItem, TableItem, TableRow, Table, Text, GoToAction
 } from '../../src';
@@ -45,13 +45,13 @@ export default class Presentation extends React.Component {
           <Heading>Hi</Heading>
         </Slide>
         <Slide transition={['zoom']} bgColor="primary">
-          <Appear
+          <Anim
             order={2}
-            startValue={{
+            fromStyle={{
               opacity: 0.2,
               transform: 'translateY(-100px) translateX(0px)'
             }}
-            endValue={[
+            toStyle={[
               {
                 opacity: 1,
                 transform: 'translateY(0px) translateX(0px)'
@@ -65,14 +65,18 @@ export default class Presentation extends React.Component {
                 transform: 'translateY(100px) translateX(100px)'
               }
           ]}
-          ><div>hey friend</div></Appear>
-          <Appear
+            easing="bounceOut"
+            transitionDuration={300}
+          >
+            <div>hey friend</div>
+          </Anim>
+          <Anim
             order={1}
-            startValue={{
+            fromStyle={{
               opacity: 0.2,
               transform: 'translateY(-100px) translateX(0px)'
             }}
-            endValue={[
+            toStyle={[
               {
                 opacity: 1,
                 transform: 'translateY(0px) translateX(0px)'
@@ -86,8 +90,18 @@ export default class Presentation extends React.Component {
                 transform: 'translateY(100px) translateX(100px)'
               }
             ]}
-          ><div>hey friend no 2</div></Appear>
+            easing="bounceOut"
+            transitionDuration={300}
+          >
+            <div>hey friend no 2</div>
+          </Anim>
         </Slide>
+
+        <Slide>
+          <Appear><span>oh hey der</span></Appear>
+          <Appear><span>hi gain</span></Appear>
+        </Slide>
+
         <Slide
           onActive={slideIndex => {
             console.info(`Viewing slide index: ${slideIndex}.`); // eslint-disable-line no-console

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -133,6 +133,26 @@ export default class Presentation extends React.Component {
                 opacity: 1,
                 transform: 'translate3d(0px, 0px, 0px) scale(1.6) rotate(-15deg)'
               },
+              {
+                opacity: 1,
+                transform: 'translate3d(0px, 0px, 0px)  scale(0.8) rotate(0deg)'
+              },
+              {
+                opacity: 1,
+                transform: 'translate3d(0px, -200px, 0px)  scale(0.8) rotate(0deg)'
+              },
+              {
+                opacity: 1,
+                transform: 'translate3d(200px, 0px, 0px)  scale(0.8) rotate(0deg)'
+              },
+              {
+                opacity: 1,
+                transform: 'translate3d(0px, 200px, 0px)  scale(0.8) rotate(0deg)'
+              },
+              {
+                opacity: 1,
+                transform: 'translate3d(-200px, 0px, 0px)  scale(0.8) rotate(0deg)'
+              }
             ]}
             easing={'bounceOut'}
             transitionDuration={500}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -164,6 +164,32 @@ export default class Presentation extends React.Component {
             </Heading>
           </Appear>
         </Slide>
+        <Slide transition={['slide']}>
+          <Anim
+            fromStyle={{
+              opacity: 0,
+              transform: 'translate3d(0px, -100px, 0px)  scale(1) rotate(0deg)'
+            }}
+            toStyle={[
+              {
+                opacity: 1,
+                transform: 'translate3d(0px, 0px, 0px)  scale(1) rotate(0deg)'
+              },
+              {
+                opacity: 1,
+                transform: 'translate3d(0px, 0px, 0px) scale(1.6) rotate(-15deg)'
+              },
+            ]}
+            easing={'bounceOut'}
+            transitionDuration={500}
+          >
+            <div>
+              <Heading size={6} caps fit textColor="secondary">
+                Flexible<br />animations
+              </Heading>
+            </div>
+          </Anim>
+        </Slide>
         <Slide>
           <Heading size={2} textColor="secondary" margin="0.25em">
            Mix it up!

--- a/src/components/anim.js
+++ b/src/components/anim.js
@@ -44,14 +44,21 @@ class Anim extends Component {
 
     const animationStatus = this.getAnimationStatus();
     if (animationStatus) {
-      const state = nextProps.fragment;
-      const { slide } = this.props.route;
-      this.context.stepCounter.setFragments(state.fragments[slide], slide);
-      this.setState({
-        activeAnimation: animationStatus.every(a => a === true) ?
-          animationStatus.length - 1 :
-          animationStatus.indexOf(false) - 1
-      });
+      const nextAnimation = animationStatus.every(a => a === true) ?
+        animationStatus.length - 1 :
+        animationStatus.indexOf(false) - 1;
+      if (this.state.activeAnimation !== nextAnimation) {
+        const state = nextProps.fragment;
+        const { slide } = this.props.route;
+        this.context.stepCounter.setFragments(state.fragments[slide], slide);
+        if (this.props.onAnim) {
+          const forward = this.state.activeAnimation < nextAnimation;
+          this.props.onAnim(forward, nextAnimation);
+        }
+        this.setState({
+          activeAnimation: nextAnimation
+        });
+      }
     }
   }
 
@@ -111,6 +118,7 @@ Anim.propTypes = {
   easing: PropTypes.oneOf(victoryEases).isRequired,
   fragment: PropTypes.object,
   fromStyle: PropTypes.object.isRequired,
+  onAnim: PropTypes.func,
   order: PropTypes.number,
   route: PropTypes.object,
   style: PropTypes.object,

--- a/src/components/anim.js
+++ b/src/components/anim.js
@@ -33,14 +33,6 @@ class Anim extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const state = nextProps.fragment;
-    const slide = this.props.route.slide;
-    const fragment = findDOMNode(this.fragmentRef);
-    const slideHash = parseInt(this.context.slideHash);
-    const key = findKey(state.fragments[slide], {
-      id: `${slideHash}-${parseInt(fragment.dataset.fid)}`,
-    });
-
     const shouldDisableAnimation =
       nextProps.route.params.indexOf('export') !== -1 ||
       nextProps.route.params.indexOf('overview') !== -1;
@@ -50,11 +42,10 @@ class Anim extends Component {
       return;
     }
 
-    if (
-      slide in state.fragments &&
-      state.fragments[slide].hasOwnProperty(key)
-    ) {
-      const animationStatus = state.fragments[slide][key].animations;
+    const animationStatus = this.getAnimationStatus();
+    if (animationStatus) {
+      const state = nextProps.fragment;
+      const { slide } = this.props.route;
       this.context.stepCounter.setFragments(state.fragments[slide], slide);
       this.setState({
         activeAnimation: animationStatus.every(a => a === true) ?
@@ -62,6 +53,23 @@ class Anim extends Component {
           animationStatus.indexOf(false) - 1
       });
     }
+  }
+
+  getAnimationStatus() {
+    const state = this.props.fragment;
+    const { slide } = this.props.route;
+    const fragment = findDOMNode(this.fragmentRef);
+    const slideHash = parseInt(this.context.slideHash, 10);
+    const key = findKey(state.fragments[slide], {
+      id: `${slideHash}-${parseInt(fragment.dataset.fid, 10)}`,
+    });
+    if (
+      slide in state.fragments &&
+      state.fragments[slide].hasOwnProperty(key)
+    ) {
+      return state.fragments[slide][key].animations;
+    }
+    return null;
   }
 
   render() {

--- a/src/components/anim.js
+++ b/src/components/anim.js
@@ -1,0 +1,123 @@
+/* eslint-disable react/no-did-mount-set-state */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { findDOMNode } from 'react-dom';
+import findKey from 'lodash/findKey';
+import { connect } from 'react-redux';
+import { VictoryAnimation } from 'victory-core';
+import { victoryEases } from '../utils/types';
+
+class Anim extends Component {
+  state = {
+    activeAnimation: -1
+  };
+
+  componentDidMount() {
+    const shouldDisableAnimation =
+      this.props.route.params.indexOf('export') !== -1 ||
+      this.props.route.params.indexOf('overview') !== -1;
+
+    if (shouldDisableAnimation) {
+      this.setState({ activeAnimation: this.props.toStyle.length - 1 });
+      return;
+    }
+
+    const order = this.props.order;
+    const node = findDOMNode(this.fragmentRef);
+    if (!node.dataset) {
+      node.dataset = {};
+    }
+    node.dataset.order = order;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const state = nextProps.fragment;
+    const slide = this.props.route.slide;
+    const fragment = findDOMNode(this.fragmentRef);
+    const slideHash = parseInt(this.context.slideHash);
+    const key = findKey(state.fragments[slide], {
+      id: `${slideHash}-${parseInt(fragment.dataset.fid)}`,
+    });
+
+    const shouldDisableAnimation =
+      nextProps.route.params.indexOf('export') !== -1 ||
+      nextProps.route.params.indexOf('overview') !== -1;
+
+    if (shouldDisableAnimation) {
+      this.setState({ activeAnimation: this.props.toStyle.length - 1 });
+      return;
+    }
+
+    if (
+      slide in state.fragments &&
+      state.fragments[slide].hasOwnProperty(key)
+    ) {
+      const animationStatus = state.fragments[slide][key].animations;
+      this.context.stepCounter.setFragments(state.fragments[slide], slide);
+      this.setState({
+        activeAnimation: animationStatus.every(a => a === true) ?
+          animationStatus.length - 1 :
+          animationStatus.indexOf(false) - 1
+      });
+    }
+  }
+
+  render() {
+    const {
+      children,
+      fromStyle,
+      toStyle,
+      transitionDuration,
+      easing,
+      style
+    } = this.props;
+    const child = React.Children.only(children);
+    const tweenData = this.state.activeAnimation === -1 ? fromStyle : toStyle[this.state.activeAnimation];
+    return (
+      <VictoryAnimation
+        data={tweenData}
+        duration={transitionDuration}
+        easing={easing}
+      >
+        {(tweenStyle) =>
+          React.cloneElement(child, {
+            className: `fragment ${child.props.className}`.trim(),
+            style: { ...child.props.style, ...style, ...tweenStyle },
+            ref: f => {
+              this.fragmentRef = f;
+            },
+            'data-animation-count': this.props.toStyle.length
+          })}
+      </VictoryAnimation>
+    );
+  }
+}
+
+Anim.defaultProps = {
+  order: 0
+};
+
+Anim.propTypes = {
+  children: PropTypes.node,
+  easing: PropTypes.oneOf(victoryEases).isRequired,
+  fragment: PropTypes.object,
+  fromStyle: PropTypes.object.isRequired,
+  order: PropTypes.number,
+  route: PropTypes.object,
+  style: PropTypes.object,
+  toStyle: PropTypes.arrayOf(PropTypes.object).isRequired,
+  transitionDuration: PropTypes.number.isRequired
+};
+
+Anim.contextTypes = {
+  export: PropTypes.bool,
+  overview: PropTypes.bool,
+  slide: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  slideHash: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  stepCounter: PropTypes.shape({
+    setFragments: PropTypes.func
+  })
+};
+
+export default connect(state => state)(Anim);

--- a/src/components/anim.js
+++ b/src/components/anim.js
@@ -29,6 +29,7 @@ class Anim extends Component {
       node.dataset = {};
     }
     node.dataset.order = order;
+    node.dataset.animCount = this.props.toStyle.length;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -86,8 +87,7 @@ class Anim extends Component {
             style: { ...child.props.style, ...style, ...tweenStyle },
             ref: f => {
               this.fragmentRef = f;
-            },
-            'data-animation-count': this.props.toStyle.length
+            }
           })}
       </VictoryAnimation>
     );

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -9,7 +9,8 @@ import { VictoryAnimation } from 'victory-core';
 
 class Appear extends Component {
   state = {
-    active: false,
+    // active: false,
+    activeAnimation: -1
   };
 
   componentDidMount() {
@@ -18,7 +19,8 @@ class Appear extends Component {
       this.props.route.params.indexOf('overview') !== -1;
 
     if (shouldDisableAnimation) {
-      this.setState({ active: true });
+      // this.setState({ active: true });
+      this.setState({ activeAnimation: this.props.endValue.length - 1 });
       return;
     }
 
@@ -44,7 +46,8 @@ class Appear extends Component {
     nextProps.route.params.indexOf('overview') !== -1;
 
     if (shouldDisableAnimation) {
-      this.setState({ active: true });
+      // this.setState({ active: true });
+      this.setState({ activeAnimation: this.props.endValue.length - 1 });
       return;
     }
 
@@ -52,9 +55,10 @@ class Appear extends Component {
       slide in state.fragments &&
       state.fragments[slide].hasOwnProperty(key)
     ) {
-      const active = state.fragments[slide][key].visible;
+      // const active = state.fragments[slide][key].visible;
+      const animationStatus = state.fragments[slide][key].animations;
       this.context.stepCounter.setFragments(state.fragments[slide], slide);
-      this.setState({ active });
+      this.setState({ activeAnimation: animationStatus.indexOf(false) - 1 });
     }
   }
 
@@ -68,7 +72,7 @@ class Appear extends Component {
       style
     } = this.props;
     const child = React.Children.only(children);
-    const tweenData = this.state.active ? endValue : startValue;
+    const tweenData = this.state.activeAnimation === -1 ? startValue : endValue[this.state.activeAnimation];
     return (
       <VictoryAnimation
         data={tweenData}
@@ -82,6 +86,7 @@ class Appear extends Component {
             ref: f => {
               this.fragmentRef = f;
             },
+            'data-animation-count': this.props.endValue.length
           })}
       </VictoryAnimation>
     );

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -58,7 +58,11 @@ class Appear extends Component {
       // const active = state.fragments[slide][key].visible;
       const animationStatus = state.fragments[slide][key].animations;
       this.context.stepCounter.setFragments(state.fragments[slide], slide);
-      this.setState({ activeAnimation: animationStatus.indexOf(false) - 1 });
+      this.setState({
+        activeAnimation: animationStatus.every(a => a === true) ?
+          animationStatus.length - 1 :
+          animationStatus.indexOf(false) - 1
+      });
     }
   }
 

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -1,8 +1,5 @@
-/* eslint-disable react/no-did-mount-set-state */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import Anim from './anim';
 import { victoryEases } from '../utils/types';
 
@@ -17,6 +14,7 @@ class Appear extends Component {
     } = this.props;
     return (
       <Anim
+        {...this.props}
         transitionDuration={transitionDuration}
         fromStyle={startValue}
         toStyle={[endValue]}
@@ -43,20 +41,9 @@ Appear.propTypes = {
   endValue: PropTypes.object,
   fragment: PropTypes.object,
   order: PropTypes.number,
-  route: PropTypes.object,
   startValue: PropTypes.object,
   style: PropTypes.object,
   transitionDuration: PropTypes.number
 };
 
-Appear.contextTypes = {
-  export: PropTypes.bool,
-  overview: PropTypes.bool,
-  slide: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  slideHash: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  stepCounter: PropTypes.shape({
-    setFragments: PropTypes.func
-  })
-};
-
-export default connect(state => state)(Appear);
+export default Appear;

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -2,99 +2,32 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { findDOMNode } from 'react-dom';
-import findKey from 'lodash/findKey';
 import { connect } from 'react-redux';
-import { VictoryAnimation } from 'victory-core';
+import Anim from './anim';
+import { victoryEases } from '../utils/types';
 
 class Appear extends Component {
-  state = {
-    // active: false,
-    activeAnimation: -1
-  };
-
-  componentDidMount() {
-    const shouldDisableAnimation =
-      this.props.route.params.indexOf('export') !== -1 ||
-      this.props.route.params.indexOf('overview') !== -1;
-
-    if (shouldDisableAnimation) {
-      // this.setState({ active: true });
-      this.setState({ activeAnimation: this.props.endValue.length - 1 });
-      return;
-    }
-
-    const order = this.props.order || 0;
-    const node = findDOMNode(this.fragmentRef);
-    if (!node.dataset) {
-      node.dataset = {};
-    }
-    node.dataset.order = order;
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const state = nextProps.fragment;
-    const slide = this.props.route.slide;
-    const fragment = findDOMNode(this.fragmentRef);
-    const slideHash = parseInt(this.context.slideHash);
-    const key = findKey(state.fragments[slide], {
-      id: `${slideHash}-${parseInt(fragment.dataset.fid)}`,
-    });
-
-    const shouldDisableAnimation =
-    nextProps.route.params.indexOf('export') !== -1 ||
-    nextProps.route.params.indexOf('overview') !== -1;
-
-    if (shouldDisableAnimation) {
-      // this.setState({ active: true });
-      this.setState({ activeAnimation: this.props.endValue.length - 1 });
-      return;
-    }
-
-    if (
-      slide in state.fragments &&
-      state.fragments[slide].hasOwnProperty(key)
-    ) {
-      // const active = state.fragments[slide][key].visible;
-      const animationStatus = state.fragments[slide][key].animations;
-      this.context.stepCounter.setFragments(state.fragments[slide], slide);
-      this.setState({
-        activeAnimation: animationStatus.every(a => a === true) ?
-          animationStatus.length - 1 :
-          animationStatus.indexOf(false) - 1
-      });
-    }
-  }
-
   render() {
     const {
-      children,
+      transitionDuration,
       startValue,
       endValue,
-      transitionDuration,
       easing,
       style
     } = this.props;
-    const child = React.Children.only(children);
-    const tweenData = this.state.activeAnimation === -1 ? startValue : endValue[this.state.activeAnimation];
     return (
-      <VictoryAnimation
-        data={tweenData}
-        duration={transitionDuration}
+      <Anim
+        transitionDuration={transitionDuration}
+        fromStyle={startValue}
+        toStyle={[endValue]}
         easing={easing}
+        style={style}
       >
-        {(tweenStyle) =>
-          React.cloneElement(child, {
-            className: `fragment ${child.props.className}`.trim(),
-            style: { ...child.props.style, ...style, ...tweenStyle },
-            ref: f => {
-              this.fragmentRef = f;
-            },
-            'data-animation-count': this.props.endValue.length
-          })}
-      </VictoryAnimation>
+        {this.props.children}
+      </Anim>
     );
   }
+
 }
 
 Appear.defaultProps = {
@@ -106,18 +39,7 @@ Appear.defaultProps = {
 
 Appear.propTypes = {
   children: PropTypes.node,
-  easing: PropTypes.oneOf([
-    'back', 'backIn', 'backOut', 'backInOut',
-    'bounce', 'bounceIn', 'bounceOut', 'bounceInOut',
-    'circle', 'circleIn', 'circleOut', 'circleInOut',
-    'linear', 'linearIn', 'linearOut', 'linearInOut',
-    'cubic', 'cubicIn', 'cubicOut', 'cubicInOut',
-    'elastic', 'elasticIn', 'elasticOut', 'elasticInOut',
-    'exp', 'expIn', 'expOut', 'expInOut',
-    'poly', 'polyIn', 'polyOut', 'polyInOut',
-    'quad', 'quadIn', 'quadOut', 'quadInOut',
-    'sin', 'sinIn', 'sinOut', 'sinInOut'
-  ]),
+  easing: PropTypes.oneOf(victoryEases),
   endValue: PropTypes.object,
   fragment: PropTypes.object,
   order: PropTypes.number,

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -492,6 +492,7 @@ export class Manager extends Component {
         );
         return false;
       }
+      return true;
     } else {
       return true;
     }

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -464,9 +464,26 @@ export class Manager extends Component {
         );
         return false;
       }
-      if (forward === false && notFullyAnimated.length !== count) {
-        const target = fullyAnimated[size(fullyAnimated) - 1];
-        target.animations[target.animations.indexOf(true)] = false;
+      if (forward === false) {
+        if (
+          notFullyAnimated.length === count &&
+          notFullyAnimated.every(frag => frag.animations.every(anim => anim === false))
+        ) {
+          // If every fragment is animated back to square one, then switch slides
+          return true;
+        }
+
+        let target;
+        const lastFullyAnimatedFragment = fullyAnimated[size(fullyAnimated) - 1];
+        const lastNotFullyAnimatedFragment = notFullyAnimated[0];
+        if (fullyAnimated.length === count || lastNotFullyAnimatedFragment.animations.every(a => a === false)) {
+          // if all fragments are fully animated, target the last fully animated fragment
+          target = lastFullyAnimatedFragment;
+        } else if (notFullyAnimated !== count) {
+          // if some fragments are not fully animated, continue targeting that fragment
+          target = lastNotFullyAnimatedFragment;
+        }
+        target.animations[target.animations.lastIndexOf(true)] = false;
         this.props.dispatch(
           updateFragment({
             fragment: target,
@@ -475,7 +492,6 @@ export class Manager extends Component {
         );
         return false;
       }
-      return true;
     } else {
       return true;
     }

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -426,6 +426,9 @@ export class Manager extends Component {
   _getHash(slideIndex) {
     return this.state.slideReference[slideIndex].id;
   }
+  _updateFragment(fragData) {
+    return updateFragment(fragData);
+  }
   _checkFragments(slide, forward) {
     const state = this.context.store.getState();
     const fragments = state.fragment.fragments;
@@ -457,7 +460,7 @@ export class Manager extends Component {
         const target = notFullyAnimated[0];
         target.animations[target.animations.indexOf(false)] = true;
         this.props.dispatch(
-          updateFragment({
+          this._updateFragment({
             fragment: target,
             animations: target.animations
           })
@@ -485,7 +488,7 @@ export class Manager extends Component {
         }
         target.animations[target.animations.lastIndexOf(true)] = false;
         this.props.dispatch(
-          updateFragment({
+          this._updateFragment({
             fragment: target,
             animations: target.animations,
           })

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -442,23 +442,35 @@ export class Manager extends Component {
       }
     }
     if (slide in fragments) {
-      const count = size(fragments[slide]);
-      const visible = filter(fragments[slide], s => s.visible === true);
-      const hidden = filter(fragments[slide], s => s.visible !== true);
-      if (forward === true && visible.length !== count) {
+      const currentSlideFragments = fragments[slide];
+      const count = size(currentSlideFragments);
+      const fullyAnimated = filter(
+        currentSlideFragments,
+        frag => frag.animations.every(anim => anim === true)
+      );
+      const notFullyAnimated = filter(
+        currentSlideFragments,
+        frag => !frag.animations.every(anim => anim === true)
+      );
+
+      if (forward === true && fullyAnimated.length !== count) {
+        const target = notFullyAnimated[0];
+        target.animations[target.animations.indexOf(false)] = true;
         this.props.dispatch(
           updateFragment({
-            fragment: hidden[0],
-            visible: true,
+            fragment: target,
+            animations: target.animations
           })
         );
         return false;
       }
-      if (forward === false && hidden.length !== count) {
+      if (forward === false && notFullyAnimated.length !== count) {
+        const target = fullyAnimated[size(fullyAnimated) - 1];
+        target.animations[target.animations.indexOf(true)] = false;
         this.props.dispatch(
           updateFragment({
-            fragment: visible[size(visible) - 1],
-            visible: false,
+            fragment: target,
+            animations: target.animations,
           })
         );
         return false;

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -43,12 +43,14 @@ class Slide extends React.PureComponent {
         .forEach(frag => {
           frag.dataset.fid = currentOrder;
           if (this.props.dispatch) {
+            const animCount = frag.getAttribute('data-animation-count');
             this.props.dispatch(
               addFragment({
                 className: frag.className || '',
                 slide: this.props.hash,
                 id: `${this.props.slideIndex}-${currentOrder}`,
-                visible: this.props.lastSlideIndex > this.props.slideIndex,
+                animations: Array.from({ length: animCount })
+                  .fill(this.props.lastSlideIndex > this.props.slideIndex)
               })
             );
           }

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -43,13 +43,12 @@ class Slide extends React.PureComponent {
         .forEach(frag => {
           frag.dataset.fid = currentOrder;
           if (this.props.dispatch) {
-            const animCount = frag.getAttribute('data-animation-count');
             this.props.dispatch(
               addFragment({
                 className: frag.className || '',
                 slide: this.props.hash,
                 id: `${this.props.slideIndex}-${currentOrder}`,
-                animations: Array.from({ length: animCount })
+                animations: Array.from({ length: frag.dataset.animCount })
                   .fill(this.props.lastSlideIndex > this.props.slideIndex)
               })
             );

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -62,13 +62,20 @@ class Slide extends React.PureComponent {
     if (isFunction(this.props.onActive)) {
       this.props.onActive(this.props.slideIndex);
     }
+
+    if (this.props.getAppearStep) {
+      /* eslint-disable no-console */
+      console.warn('getAppearStep has been deprecated, use getAnimStep instead');
+      /* eslint-enable */
+    }
   }
 
   componentDidUpdate() {
     const { steps, slideIndex } = this.stepCounter.getSteps();
-    if (this.props.getAppearStep) {
+    const stepFunc = this.props.getAnimStep || this.props.getAppearStep;
+    if (stepFunc) {
       if (slideIndex === this.props.slideIndex) {
-        this.props.getAppearStep(steps);
+        stepFunc(steps);
       }
     }
   }
@@ -272,6 +279,7 @@ Slide.propTypes = {
   className: PropTypes.string,
   dispatch: PropTypes.func,
   export: PropTypes.bool,
+  getAnimStep: PropTypes.func,
   getAppearStep: PropTypes.func,
   hash: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   lastSlideIndex: PropTypes.number,

--- a/src/components/slide.test.js
+++ b/src/components/slide.test.js
@@ -98,15 +98,15 @@ describe('<Slide />', () => {
     expect(spy).toHaveBeenCalledTimes(3);
     expect(spy.mock.calls).toEqual([
       [{
-        payload: { slide: 4, id: '4-0', visible: false, className: 'fragment first' },
+        payload: { slide: 4, id: '4-0', animations: [false], className: 'fragment first' },
         type: 'ADD_FRAGMENT'
       }],
       [{
-        payload: { slide: 4, id: '4-1', visible: false, className: 'fragment second' },
+        payload: { slide: 4, id: '4-1', animations: [false], className: 'fragment second' },
         type: 'ADD_FRAGMENT'
       }],
       [{
-        payload: { slide: 4, id: '4-2', visible: false, className: 'fragment third' },
+        payload: { slide: 4, id: '4-2', animations: [false], className: 'fragment third' },
         type: 'ADD_FRAGMENT'
       }]
     ]);
@@ -131,15 +131,15 @@ describe('<Slide />', () => {
     expect(spy).toHaveBeenCalledTimes(3);
     expect(spy.mock.calls).toEqual([
       [{
-        payload: { slide: 7, id: '7-0', visible: false, className: 'fragment no-order' },
+        payload: { slide: 7, id: '7-0', animations: [false], className: 'fragment no-order' },
         type: 'ADD_FRAGMENT'
       }],
       [{
-        payload: { slide: 7, id: '7-1', visible: false, className: 'fragment first' },
+        payload: { slide: 7, id: '7-1', animations: [false], className: 'fragment first' },
         type: 'ADD_FRAGMENT'
       }],
       [{
-        payload: { slide: 7, id: '7-2', visible: false, className: 'fragment second' },
+        payload: { slide: 7, id: '7-2', animations: [false], className: 'fragment second' },
         type: 'ADD_FRAGMENT'
       }]
     ]);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import Anim from './components/anim';
 import Appear from './components/appear';
 import BlockQuote from './components/block-quote';
 import Cite from './components/cite';
@@ -39,6 +40,7 @@ const themes = {
 };
 
 export {
+  Anim,
   Appear,
   BlockQuote,
   Cite,

--- a/src/reducers/fragment.js
+++ b/src/reducers/fragment.js
@@ -16,7 +16,7 @@ const reducer = handleActions({
       fragment
     } = action.payload;
     const s = Object.assign({}, state);
-    s.fragments[fragment.slide][fragment.id].visible = action.payload.visible;
+    s.fragments[fragment.slide][fragment.id].animations = action.payload.animations;
     return s;
   }
 }, { fragments: {} });

--- a/src/utils/step-counter.js
+++ b/src/utils/step-counter.js
@@ -7,7 +7,7 @@ const stepCounter = () => {
   };
   const getSteps = () => {
     const steps = Object.keys(frags).reduce((previous, key) => {
-      return previous + (frags[key].visible === true);
+      return previous + (frags[key].animations.every(a => a === true));
     }, 0);
     return { steps, slideIndex };
   };

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -1,0 +1,12 @@
+export const victoryEases = [
+  'back', 'backIn', 'backOut', 'backInOut',
+  'bounce', 'bounceIn', 'bounceOut', 'bounceInOut',
+  'circle', 'circleIn', 'circleOut', 'circleInOut',
+  'linear', 'linearIn', 'linearOut', 'linearInOut',
+  'cubic', 'cubicIn', 'cubicOut', 'cubicInOut',
+  'elastic', 'elasticIn', 'elasticOut', 'elasticInOut',
+  'exp', 'expIn', 'expOut', 'expInOut',
+  'poly', 'polyIn', 'polyOut', 'polyInOut',
+  'quad', 'quadIn', 'quadOut', 'quadInOut',
+  'sin', 'sinIn', 'sinOut', 'sinInOut'
+];


### PR DESCRIPTION
![mar-17-2018 18-14-29](https://user-images.githubusercontent.com/2495933/37560499-a1162d84-2a0f-11e8-9031-8ac37801601f.gif)

**Hi again Formidable folks 👋!** Really loving my time with spectacle, it's super fun to work with and a nice change of pace from reveal.js. Super appreciate all the work y'all've done on it and the opportunity to contribute to the project.

I'm using Spectacle to make a deck for a talk on web animation, so I wanted some more flexibility animating fragments. Specifically I wanted to be able to animate a fragment multiple times before moving on to the next fragment or slide.  I ended up more-or-less replacing the `<Appear>` component with a more generalized `<Anim>` component, creating a simpler `<Appear>` component which is just a wrapper for `<Anim>` to avoid shipping any breaking changes, and made a few small alterations in `<Slide>` and `<Manager>` to accommodate the ability to step through the same fragment several times.

You could use this to make a little carousel, step through an animated infographic, and so many other things my small brain can't conceive of. These changes also make animation in Spectacle much more extensible. They've enabled me to make a really robust GSAP powered animation component for my talk that wouldn't have been possible otherwise.

I concede that I would have liked to add some tests to lock down the new fragment logic, but I had some trouble grokking the tests for `<Manager>` and figuring out how to get the fragment functionality tested there.

I left my commits raw just in case you prefer looking at a PR that way, but I'd be totally happy to squash if that would help.

Oh, also went ahead and included documentation on the workaround discussed in #488.