### PR TITLE
Fix code pane languages

### DIFF
--- a/src/components/__snapshots__/code-pane.test.js.snap
+++ b/src/components/__snapshots__/code-pane.test.js.snap
@@ -51,7 +51,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
         syntaxStyles={Object {}}
       >
         <Component
-          className="language-jsx builtin-prism-theme  css-3w3gcf"
+          className="language-jsx builtin-prism-theme  css-1rm1mht"
           code="
       const myButton = (
         <CustomButton
@@ -71,7 +71,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
           syntaxStyles={Object {}}
         >
           <Editor
-            className="language-jsx builtin-prism-theme  css-3w3gcf"
+            className="language-jsx builtin-prism-theme  css-1rm1mht"
             code="
       const myButton = (
         <CustomButton
@@ -89,7 +89,7 @@ exports[`<CodePane /> should render correctly. 1`] = `
             onKeyUp={[Function]}
           >
             <pre
-              className="prism-code language-jsx builtin-prism-theme  css-3w3gcf"
+              className="prism-code language-jsx builtin-prism-theme  css-1rm1mht"
               contentEditable={false}
               dangerouslySetInnerHTML={
                 Object {

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -7,12 +7,12 @@ import { Editor } from 'react-live';
 import '../utils/prism-import';
 
 const StyledWrapper = styled.div(props => props.styles);
-const StyledEditor = styled(({ syntaxStyles: _, prismTheme: __, ...rest }) => <Editor {...rest} />)`
+const StyledEditor = styled(({ syntaxStyles: _, prismTheme: __, ...rest }) => (
+  <Editor {...rest} />
+))`
   && {
-    ${props => props.syntaxStyles}
-
-    &.builtin-prism-theme {
-      ${props => props.prismTheme}
+    ${props => props.syntaxStyles} &.builtin-prism-theme {
+      ${props => props.prismTheme};
     }
   }
 `;
@@ -25,7 +25,9 @@ export default class CodePane extends Component {
   render() {
     const useDarkTheme = this.props.theme === 'dark';
     const externalPrismTheme = this.props.theme === 'external';
-    const className = `language-${this.props.lang} ${externalPrismTheme ? '' : 'builtin-prism-theme'} ${this.props.className}`;
+    const className = `language-${this.props.lang} ${
+      externalPrismTheme ? '' : 'builtin-prism-theme'
+    } ${this.props.className}`;
 
     const wrapperStyles = [
       this.context.styles.components.codePane,
@@ -34,17 +36,16 @@ export default class CodePane extends Component {
     ];
 
     return (
-      <StyledWrapper
-        className={this.props.className}
-        styles={wrapperStyles}
-      >
+      <StyledWrapper className={this.props.className} styles={wrapperStyles}>
         <StyledEditor
           className={className}
           code={this.props.source}
           language={this.props.lang}
           contentEditable={this.props.contentEditable}
           syntaxStyles={this.context.styles.components.syntax}
-          prismTheme={this.context.styles.prism[useDarkTheme ? 'dark' : 'light']}
+          prismTheme={
+            this.context.styles.prism[useDarkTheme ? 'dark' : 'light']
+          }
           onKeyDown={this.handleEditorEvent}
           onKeyUp={this.handleEditorEvent}
           onClick={this.handleEditorEvent}
@@ -66,7 +67,7 @@ CodePane.propTypes = {
   lang: PropTypes.string,
   source: PropTypes.string,
   style: PropTypes.object,
-  theme: PropTypes.oneOf(['dark', 'light', 'external']),
+  theme: PropTypes.oneOf(['dark', 'light', 'external'])
 };
 
 CodePane.defaultProps = {
@@ -74,5 +75,5 @@ CodePane.defaultProps = {
   contentEditable: false,
   lang: 'markup',
   source: '',
-  theme: 'dark',
+  theme: 'dark'
 };

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-import '../utils/prism-import';
 import { Editor } from 'react-live';
+import '../utils/prism-import';
 
 const StyledWrapper = styled.div(props => props.styles);
 const StyledEditor = styled(({ syntaxStyles: _, prismTheme: __, ...rest }) => <Editor {...rest} />)`

--- a/src/components/code-pane.test.js
+++ b/src/components/code-pane.test.js
@@ -4,10 +4,12 @@ import CodePane from './code-pane';
 
 describe('<CodePane />', () => {
   test('should render correctly.', () => {
-    const context = { styles: {
-      components: { codePane: {}, syntax: {} },
-      prism: { light: 'light;', dark: 'dark;' }
-    } };
+    const context = {
+      styles: {
+        components: { codePane: {}, syntax: {} },
+        prism: { light: 'light;', dark: 'dark;' }
+      }
+    };
     const source = `
       const myButton = (
         <CustomButton

--- a/src/components/code-pane.test.js
+++ b/src/components/code-pane.test.js
@@ -21,4 +21,17 @@ describe('<CodePane />', () => {
     const wrapper = mount(<CodePane lang="jsx" source={source} />, { context });
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('should handle languages', () => {
+    const context = {
+      styles: {
+        components: { codePane: {}, syntax: {} },
+        prism: { light: 'light;', dark: 'dark;' }
+      }
+    };
+    const source = `import org.apache.commons.lang3.StringUtils;`;
+    expect(() => {
+      mount(<CodePane lang="java" source={source} />, { context });
+    }).not.toThrow();
+  });
 });

--- a/src/utils/prism-import.js
+++ b/src/utils/prism-import.js
@@ -1,5 +1,3 @@
-import 'prismjs/components/prism-core';
-
 // NOTE: This includes a "slim" list of some components of prism, but not all
 // For more, see: https://github.com/PrismJS/prism/blob/1fd690dd8a652dee375acb78b6034c3fc2db687c/components.js
 // and: https://github.com/PrismJS/prism/tree/gh-pages/components


### PR DESCRIPTION
This PR changes the import order and overwriting of Prism, fixes #526.

Prettier changes are committed separately since they're not part of the initial change.