### PR TITLE
Update markdown section to include `!raw-loader!` hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Slide Content
 **Function Usage**
 
 ```jsx
-import slidesMarkdown from "raw-loader!markdown.md";
+import slidesMarkdown from "!raw-loader!markdown.md";
 
 <Deck ...>
   {MarkdownSlides(slidesMarkdown)}


### PR DESCRIPTION
Without the leading '!', the slides are not properly formatted. 
Related [Issue](https://github.com/FormidableLabs/spectacle/issues/467) & [Commit](https://github.com/FormidableLabs/spectacle/pull/473/commits/669fc7eb830cb59d3522ba3266a7bd5db25595d7)
