### PR TITLE
Fix merging styles error on table components (#551)

### DIFF
--- a/src/components/table-item.js
+++ b/src/components/table-item.js
@@ -11,12 +11,15 @@ export default class TableItem extends Component {
     return (
       <StyledTableItem
         className={this.props.className}
-        style={[
-          this.context.styles.components.tableItem,
-          getStyles.call(this),
-          typefaceStyle,
-          this.props.style
-        ]}
+        style={
+          Object.assign(
+            {},
+            this.context.styles.components.tableItem,
+            getStyles.call(this),
+            typefaceStyle,
+            this.props.style
+          )
+        }
       >
         {this.props.children}
       </StyledTableItem>

--- a/src/components/table-row.js
+++ b/src/components/table-row.js
@@ -10,11 +10,14 @@ export default class TableRow extends Component {
     return (
       <StyledTableRow
         className={this.props.className}
-        style={[
-          this.context.styles.components.tableRow,
-          getStyles.call(this),
-          this.props.style
-        ]}
+        style={
+          Object.assign(
+            {},
+            this.context.styles.components.tableRow,
+            getStyles.call(this),
+            this.props.style
+          )
+        }
       >
         {this.props.children}
       </StyledTableRow>


### PR DESCRIPTION
- The table components will get this error "TypeError: CSS2Properties doesn't have an indexed property setter for '0'" on Firefox browser. For merging styles it can use the function Object.assign().