### PR TITLE
onCodeChange and onError callbacks for ComponentPlayground.

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,12 +674,14 @@ This tag displays a two-pane view with a ES6 source code editor on the right and
 
 For more information on the playground read the docs over at [react-live](https://github.com/FormidableLabs/react-live).
 
-| Name                   | PropType         | Description                                                                                                                      |
-| ---------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| code                   | PropTypes.string | The code block you want to initially supply to the component playground. If none is supplied a demo component will be displayed. |
-| previewBackgroundColor | PropTypes.string | The background color you want for the preview pane. Defaults to `#fff`.                                                          |
-| theme                  | PropTypes.string | Accepts `light`, `dark`, or `external` for the source editor's syntax highlighting. Defaults to `dark`.                          |
-| scope                  | PropTypes.object | Defines any outside modules or components to expose to the playground. React, Component, and render are supplied for you.        |
+| Name                   | PropType         | Description                                                                                                                                                                             |
+| ---------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| code                   | PropTypes.string | The code block you want to initially supply to the component playground. If none is supplied a demo component will be displayed.                                                        |
+| previewBackgroundColor | PropTypes.string | The background color you want for the preview pane. Defaults to `#fff`.                                                                                                                 |
+| theme                  | PropTypes.string | Accepts `light`, `dark`, or `external` for the source editor's syntax highlighting. Defaults to `dark`.                                                                                 |
+| scope                  | PropTypes.object | Defines any outside modules or components to expose to the playground. React, Component, and render are supplied for you.                                                               |
+| onCodeChange           | PropTypes.func   | Called whenever the code changes after the initial render with the new code as its argument.                                                                                            |
+| onError                | PropTypes.func   | Called whenever a new transpilation/execution error occurs in the code, or when the code becomes error-free again. The only argument will be either the caught error object, or `null`. |
 
 Example code blocks:
 

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -163,6 +163,12 @@ class ComponentPlayground extends Component {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.code !== prevState.code && this.props.onCodeChange) {
+      this.props.onCodeChange(this.state.code);
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('storage', this.syncCode);
   }
@@ -219,6 +225,7 @@ class ComponentPlayground extends Component {
         code={this.state.code}
         scope={{ Component, ...scope }}
         transformCode={transformCode}
+        onError={this.props.onError}
         noInline
       >
         <PlaygroundRow>
@@ -264,6 +271,8 @@ ComponentPlayground.contextTypes = {
 
 ComponentPlayground.propTypes = {
   code: PropTypes.string,
+  onCodeChange: PropTypes.func,
+  onError: PropTypes.func,
   previewBackgroundColor: PropTypes.string,
   scope: PropTypes.object,
   theme: PropTypes.oneOf(['dark', 'light', 'external']),


### PR DESCRIPTION
New feature: `onCodeChange` and `onError` props to `ComponentPlayground` which get called after each code update with the new code, or on any compile/eval error (or error resolution) in the preview window.

Useful when you may want to develop a piece of code across multiple slides in a presentation. `onCodeChange` lets you hold onto code that was edited in one slide and insert it into a later slide (and optionally avoid holding onto code that generated an error by also monitoring `onError`).

Ideally these could be the same callback so it's easier to know which piece of code triggered an error... not sure the best way to handle that. Might be ok without that.

Can't be merged before [this pull request for react-live](https://github.com/FormidableLabs/react-live/pull/86).