### PR TITLE
Memoize component playground scope.

### DIFF
--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -152,7 +152,7 @@ class ComponentPlayground extends Component {
 
     this.state = {
       code: (this.props.code || defaultCode).trim(),
-      scope: getEnhancedScope(this.props.scope),
+      scope: getEnhancedScope(this.props.scope)
     };
   }
 

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -134,6 +134,10 @@ const PlaygroundError = styled(LiveError)`
 
 const STORAGE_KEY = 'spectacle-playground';
 
+function getEnhancedScope(scope = {}) {
+  return { Component, ...scope };
+}
+
 // TODO(540): Refactor to non-deprecated lifecycle methods.
 // https://github.com/FormidableLabs/spectacle/issues/540
 // - componentWillReceiveProps
@@ -147,7 +151,8 @@ class ComponentPlayground extends Component {
     this.syncCode = this.syncCode.bind(this);
 
     this.state = {
-      code: (this.props.code || defaultCode).trim()
+      code: (this.props.code || defaultCode).trim(),
+      scope: getEnhancedScope(this.props.scope),
     };
   }
 
@@ -160,6 +165,10 @@ class ComponentPlayground extends Component {
     if (nextProps.code !== this.props.code) {
       const code = (this.props.code || defaultCode).trim();
       this.setState({ code });
+    }
+    if (nextProps.scope !== this.props.scope) {
+      const scope = getEnhancedScope(nextProps.scope);
+      this.setState({ scope });
     }
   }
 
@@ -202,7 +211,6 @@ class ComponentPlayground extends Component {
   render() {
     const {
       previewBackgroundColor,
-      scope = {},
       theme = 'dark',
       transformCode
     } = this.props;
@@ -217,7 +225,7 @@ class ComponentPlayground extends Component {
       <PlaygroundProvider
         mountStylesheet={false}
         code={this.state.code}
-        scope={{ Component, ...scope }}
+        scope={this.state.scope}
         transformCode={transformCode}
         noInline
       >


### PR DESCRIPTION
This is important for ensuring that transitions on a slide with a Component Playground don't cause the previewed component to get recreated/remounted.

## Before
![spectacle_before](https://user-images.githubusercontent.com/13558253/44064656-4768876a-9f34-11e8-9e98-3b1682813445.gif)

## After
![spectacle_after](https://user-images.githubusercontent.com/13558253/44064655-4754fdc6-9f34-11e8-8397-9886dd9a966d.gif)