### PR TITLE
add rel attribute into Link to prevent tabnabbing attack

### DIFF
--- a/src/components/__snapshots__/link.test.js.snap
+++ b/src/components/__snapshots__/link.test.js.snap
@@ -8,6 +8,7 @@ exports[`<Link /> should render correctly 1`] = `
   <Styled(a)
     className={undefined}
     href="https://www.formidable.com"
+    rel="noopener noreferrer"
     styles={
       Array [
         Object {
@@ -23,6 +24,7 @@ exports[`<Link /> should render correctly 1`] = `
     <a
       className="css-qjaoxy e1wojnuz0"
       href="https://www.formidable.com"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Formidable Labs

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -13,6 +13,9 @@ export default class Link extends Component {
         className={this.props.className}
         href={this.props.href}
         target={this.props.target}
+        {...(this.props.target === '_blank'
+          ? { rel: 'noopener noreferrer' }
+          : {})}
         styles={[
           this.context.styles.components.link,
           getStyles.call(this),
@@ -31,7 +34,11 @@ Link.propTypes = {
   className: PropTypes.string,
   href: PropTypes.string,
   style: PropTypes.object,
-  target: PropTypes.string
+  target: PropTypes.oneOf(['_blank', '_self', '_parent', '_top'])
+};
+
+Link.defaultProps = {
+  target: '_self'
 };
 
 Link.contextTypes = {


### PR DESCRIPTION
__changes__
This PR is for adding `rel="noopener noreferrer"` into `<a>` when its target is `_blank`.
Also, I changed `<Link>`'s propTypes. so that `target` can be one of `_blank`, `_self`, `_parent`, `_top`.

__references__
- [Opens External Anchors Using rel="noopener"](https://developers.google.com/web/tools/lighthouse/audits/noopener)
- [Html/Elements/a](https://www.w3.org/wiki/Html/Elements/a)
- [Reverse Tabnabbing](https://www.owasp.org/index.php/Reverse_Tabnabbing)