### PR TITLE
Allow Slide Margin of 0

### DIFF
--- a/src/components/slide-components.js
+++ b/src/components/slide-components.js
@@ -39,12 +39,26 @@ export const SlideContentWrapper = styled.div(({ align, overviewMode }) => {
 
 export const SlideContent = styled.div(props => {
   const { overviewMode, scale, zoom, margin, width, height, styles } = props;
+
+  const getMargin = margin => {
+    // ensure a "falsy" value of 0 still gets applied
+    if (margin === 0) {
+      return 0;
+    }
+
+    if (!margin) {
+      return 40;
+    }
+
+    return margin;
+  };
+
   const contentStyles = {
     flex: 1,
     maxHeight: height || 700,
     maxWidth: width || 1000,
     transform: `scale(${scale})`,
-    padding: zoom > 0.6 ? margin || 40 : 10
+    padding: zoom > 0.6 ? getMargin(margin) : 10
   };
   const overviewStyles = {
     width: '100%'

--- a/src/components/slide-components.js
+++ b/src/components/slide-components.js
@@ -40,7 +40,7 @@ export const SlideContentWrapper = styled.div(({ align, overviewMode }) => {
 export const SlideContent = styled.div(props => {
   const { overviewMode, scale, zoom, margin, width, height, styles } = props;
 
-  const getMargin = margin => {
+  const getMargin = () => {
     // ensure a "falsy" value of 0 still gets applied
     if (margin === 0) {
       return 0;
@@ -58,7 +58,7 @@ export const SlideContent = styled.div(props => {
     maxHeight: height || 700,
     maxWidth: width || 1000,
     transform: `scale(${scale})`,
-    padding: zoom > 0.6 ? getMargin(margin) : 10
+    padding: zoom > 0.6 ? getMargin() : 10
   };
   const overviewStyles = {
     width: '100%'


### PR DESCRIPTION
Fixes an issue originally raised in outdated PR #517 where since `0` is a falsey value, it wasn't properly being applied when specified by the user, and was reverting to the default of `40`.