### PR TITLE
Add `.github` dir with templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+
+-->
+
+### Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+#### Type of Change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+### How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+### Checklist: (Feel free to delete this section upon completion)
+
+- [ ] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/issues/bug_report.md
+++ b/.github/issues/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+
+-->
+
+### Prerequisites
+
+**Feel free to delete this section if you have checked off all of the following.**
+
+- [ ] I've searched open [issues](https://www.github.com/FormidableLabs/spectacle/issues) to make sure I'm not opening a duplicate issue
+- [ ] This issue not specific to `spectacle-boilerplate` (those issues should be opened [here](https://github.com/FormidableLabs/spectacle-boilerplate/issues/new)).
+- [ ] I have read through the [docs](https://formidable.com/open-source/spectacle/docs/) before asking a question
+- [ ] I am using the latest version of Spectacle
+
+### Describe Your Environment
+
+What version of Spectacle are you using? (can be found by running `npm list spectacle`)
+
+What version of React are you using? (can be found by running `npm list react`)
+
+What browser are you using?
+
+What machine are you on?
+
+### Describe the Problem
+
+It's easier to show us than tell us what's going wrong with your code. Because of this, we ask that you do one of three things to help us reproduce the bug:
+
+1. Create a public minimal repository that we can `git clone`, with install + error reproduction steps in the README.
+2. Fork our [simple Spectacle sample Sandbox](https://codesandbox.io/s/7wo8xv8nw0), reproduce your issue in the code, and paste the link here.
+3. Open up a PR, include "WIP" and the Issue # in the title, and point us to the failing regression tests.
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/.github/issues/feature_request.md
+++ b/.github/issues/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+<!--
+
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+
+-->
+
+### Description
+
+Including the problem you want to address, use cases, benefits, and/or goals.
+
+### Proposal
+
+How do you propose we implement this change?
+
+### Links / References
+
+Any resources you want to point to for reference or more information.


### PR DESCRIPTION
Reintroduces github templates that were accidentally wiped out with a prior commit. 🙂 