### PR TITLE
[WIP] Remove deprecated lifecycles

### DIFF
--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -139,10 +139,6 @@ function getEnhancedScope(scope = {}) {
   return { Component, ...scope };
 }
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillReceiveProps
-// eslint-disable-next-line react/no-deprecated
 class ComponentPlayground extends Component {
   constructor() {
     super(...arguments);
@@ -157,13 +153,13 @@ class ComponentPlayground extends Component {
     };
   }
 
-  static getDerivedStateFromProps(nextProps, preState) {
+  static getDerivedStateFromProps(nextProps, prevState) {
     const updatedState = {};
-    if (nextProps.code !== preState.code) {
+    if (nextProps.code !== prevState.code) {
       const code = (nextProps.code || defaultCode).trim();
       updatedState.code = code;
     }
-    if (nextProps.scope !== preState.scope) {
+    if (nextProps.scope !== prevState.scope) {
       const scope = getEnhancedScope(nextProps.scope);
       updatedState.scope = scope;
     }
@@ -176,14 +172,14 @@ class ComponentPlayground extends Component {
   }
 
   componentDidUpdate() {
-    this.playgroundsetState();
+    this.playgroundSetState();
   }
 
   componentWillUnmount() {
     window.removeEventListener('storage', this.syncCode);
   }
 
-  playgroundsetState() {
+  playgroundSetState() {
     if (this.props.code) {
       const code = (this.props.code || defaultCode).trim();
       this.setState({ code });

--- a/src/components/component-playground.js
+++ b/src/components/component-playground.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import styled, { css } from 'react-emotion';
 import { defaultCode } from '../utils/playground.default-code';
@@ -156,26 +157,42 @@ class ComponentPlayground extends Component {
     };
   }
 
+  static getDerivedStateFromProps(nextProps, preState) {
+    const updatedState = {};
+    if (nextProps.code !== preState.code) {
+      const code = (nextProps.code || defaultCode).trim();
+      updatedState.code = code;
+    }
+    if (nextProps.scope !== preState.scope) {
+      const scope = getEnhancedScope(nextProps.scope);
+      updatedState.scope = scope;
+    }
+    return isEmpty(updatedState) ? null : updatedState;
+  }
+
   componentDidMount() {
     localStorage.setItem(STORAGE_KEY, this.state.code);
     window.addEventListener('storage', this.syncCode);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.code !== this.props.code) {
-      const code = (this.props.code || defaultCode).trim();
-      this.setState({ code });
-    }
-    if (nextProps.scope !== this.props.scope) {
-      const scope = getEnhancedScope(nextProps.scope);
-      this.setState({ scope });
-    }
+  componentDidUpdate() {
+    this.playgroundsetState();
   }
 
   componentWillUnmount() {
     window.removeEventListener('storage', this.syncCode);
   }
 
+  playgroundsetState() {
+    if (this.props.code) {
+      const code = (this.props.code || defaultCode).trim();
+      this.setState({ code });
+    }
+    if (this.props.scope) {
+      const scope = getEnhancedScope(this.props.scope);
+      this.setState({ scope });
+    }
+  }
   onKeyUp(evt) {
     evt.stopPropagation();
 

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -70,7 +70,7 @@ export default class Heading extends Component {
     return nextProps.fit !== prevState.fit ? { fit: nextProps.fit } : null;
   }
 
-  componentDidUpdate(prevState, prevProps) {
+  componentDidUpdate(prevProps) {
     if (prevProps.fit !== this.props.fit) {
       this.resize();
     }

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -51,10 +51,6 @@ const dynamicStyledHeaders = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].reduce(
   {}
 );
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillReceiveProps
-// eslint-disable-next-line react/no-deprecated
 export default class Heading extends Component {
   constructor() {
     super(...arguments);

--- a/src/components/heading.js
+++ b/src/components/heading.js
@@ -69,9 +69,17 @@ export default class Heading extends Component {
     window.addEventListener('load', this.resize);
     window.addEventListener('resize', this.resize);
   }
-  componentWillReceiveProps() {
-    this.resize();
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.fit !== prevState.fit ? { fit: nextProps.fit } : null;
   }
+
+  componentDidUpdate(prevState, prevProps) {
+    if (prevProps.fit !== this.props.fit) {
+      this.resize();
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('load', this.resize);
     window.removeEventListener('resize', this.resize);

--- a/src/components/magic-wrapper.js
+++ b/src/components/magic-wrapper.js
@@ -128,38 +128,6 @@ export default class MagicText extends Component {
       }
     );
   }
-  // componentWillReceiveProps(nextProps) {
-  //   if (this.props.magicIndex === nextProps.magicIndex) {
-  //     return;
-  //   }
-  //   ReactDOM.render(
-  //     <Context context={this.context}>
-  //       <Deck>{nextProps.children}</Deck>
-  //     </Context>,
-  //     this.portal,
-  //     () => {
-  //       const styles = {};
-  //       const portalRoot = get(this.portal, 'childNodes[0].childNodes[0]');
-  //       if (portalRoot) {
-  //         updateChildren(portalRoot);
-  //         buildStyleMap(styles, portalRoot);
-  //         this.diffs = detailedDiff(this.portalMap, styles);
-  //         this.lastPortalMap = this.portalMap;
-  //         this.portalMap = styles;
-  //         if (this.mounted) {
-  //           this.setState(
-  //             {
-  //               renderedChildren: nextProps.children
-  //             },
-  //             () => {
-  //               this.forceUpdate();
-  //             }
-  //           );
-  //         }
-  //       }
-  //     }
-  //   );
-  // }
   shouldComponentUpdate() {
     return false;
   }

--- a/src/components/magic-wrapper.js
+++ b/src/components/magic-wrapper.js
@@ -53,10 +53,6 @@ class Context extends Component {
   }
 }
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillReceiveProps
-// eslint-disable-next-line react/no-deprecated
 export default class MagicText extends Component {
   static contextTypes = {
     contentHeight: PropTypes.number,

--- a/src/components/magic-wrapper.js
+++ b/src/components/magic-wrapper.js
@@ -86,6 +86,12 @@ export default class MagicText extends Component {
       renderedChildren: props.children
     };
   }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.magicIndex !== prevState.magicIndex
+      ? { magicIndex: nextProps.magicIndex }
+      : null;
+  }
   componentDidMount() {
     this.mounted = true;
     this.portal = document.getElementById('portal');
@@ -122,42 +128,42 @@ export default class MagicText extends Component {
       }
     );
   }
-  componentWillReceiveProps(nextProps) {
-    if (this.props.magicIndex === nextProps.magicIndex) {
-      return;
-    }
-    ReactDOM.render(
-      <Context context={this.context}>
-        <Deck>{nextProps.children}</Deck>
-      </Context>,
-      this.portal,
-      () => {
-        const styles = {};
-        const portalRoot = get(this.portal, 'childNodes[0].childNodes[0]');
-        if (portalRoot) {
-          updateChildren(portalRoot);
-          buildStyleMap(styles, portalRoot);
-          this.diffs = detailedDiff(this.portalMap, styles);
-          this.lastPortalMap = this.portalMap;
-          this.portalMap = styles;
-          if (this.mounted) {
-            this.setState(
-              {
-                renderedChildren: nextProps.children
-              },
-              () => {
-                this.forceUpdate();
-              }
-            );
-          }
-        }
-      }
-    );
-  }
+  // componentWillReceiveProps(nextProps) {
+  //   if (this.props.magicIndex === nextProps.magicIndex) {
+  //     return;
+  //   }
+  //   ReactDOM.render(
+  //     <Context context={this.context}>
+  //       <Deck>{nextProps.children}</Deck>
+  //     </Context>,
+  //     this.portal,
+  //     () => {
+  //       const styles = {};
+  //       const portalRoot = get(this.portal, 'childNodes[0].childNodes[0]');
+  //       if (portalRoot) {
+  //         updateChildren(portalRoot);
+  //         buildStyleMap(styles, portalRoot);
+  //         this.diffs = detailedDiff(this.portalMap, styles);
+  //         this.lastPortalMap = this.portalMap;
+  //         this.portalMap = styles;
+  //         if (this.mounted) {
+  //           this.setState(
+  //             {
+  //               renderedChildren: nextProps.children
+  //             },
+  //             () => {
+  //               this.forceUpdate();
+  //             }
+  //           );
+  //         }
+  //       }
+  //     }
+  //   );
+  // }
   shouldComponentUpdate() {
     return false;
   }
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const containerRoot = get(this.container, 'childNodes[0]');
     if (containerRoot) {
       updateChildren(containerRoot);
@@ -198,6 +204,35 @@ export default class MagicText extends Component {
           }
         }
       });
+    }
+    if (this.props.magicIndex !== prevProps.magicIndex) {
+      ReactDOM.render(
+        <Context context={this.context}>
+          <Deck>{this.props.children}</Deck>
+        </Context>,
+        this.portal,
+        () => {
+          const styles = {};
+          const portalRoot = get(this.portal, 'childNodes[0].childNodes[0]');
+          if (portalRoot) {
+            updateChildren(portalRoot);
+            buildStyleMap(styles, portalRoot);
+            this.diffs = detailedDiff(this.portalMap, styles);
+            this.lastPortalMap = this.portalMap;
+            this.portalMap = styles;
+            if (this.mounted) {
+              this.setState(
+                {
+                  renderedChildren: this.props.children
+                },
+                () => {
+                  this.forceUpdate();
+                }
+              );
+            }
+          }
+        }
+      );
     }
     this.lastDiffs = this.diffs;
   }

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -95,11 +95,6 @@ function buildSlideReference(props) {
   return slideReference;
 }
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillMount
-// - componentWillReceiveProps
-// eslint-disable-next-line react/no-deprecated
 export class Manager extends Component {
   static displayName = 'Manager';
 

--- a/src/components/notes.js
+++ b/src/components/notes.js
@@ -1,10 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillMount
-// eslint-disable-next-line react/no-deprecated
 export default class Notes extends Component {
   static contextTypes = {
     store: PropTypes.object,
@@ -16,7 +12,7 @@ export default class Notes extends Component {
     children: PropTypes.node.isRequired
   };
 
-  componentWillMount() {
+  componentDidMount() {
     const { store, slideHash: parentSlide, updateNotes } = this.context;
     const currentSlide = store.getState().route.slide;
 

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -54,8 +54,14 @@ export default class Text extends Component {
     window.addEventListener('load', this.resize);
     window.addEventListener('resize', this.resize);
   }
-  componentWillReceiveProps() {
-    this.resize();
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.fit !== prevState.fit ? { fit: nextProps.fit } : null;
+  }
+
+  componentDidUpdate(prevState, prevProps) {
+    if (prevProps.fit !== this.props.fit) {
+      this.resize();
+    }
   }
   componentWillUnmount() {
     window.removeEventListener('load', this.resize);

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -35,10 +35,6 @@ const UnfitText = styled.p(({ lineHeight, styles }) => [
   styles.user
 ]);
 
-// TODO(540): Refactor to non-deprecated lifecycle methods.
-// https://github.com/FormidableLabs/spectacle/issues/540
-// - componentWillReceiveProps
-// eslint-disable-next-line react/no-deprecated
 export default class Text extends Component {
   constructor() {
     super(...arguments);
@@ -49,16 +45,17 @@ export default class Text extends Component {
     };
   }
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return nextProps.fit !== prevState.fit ? { fit: nextProps.fit } : null;
+  }
+
   componentDidMount() {
     this.resize();
     window.addEventListener('load', this.resize);
     window.addEventListener('resize', this.resize);
   }
-  static getDerivedStateFromProps(nextProps, prevState) {
-    return nextProps.fit !== prevState.fit ? { fit: nextProps.fit } : null;
-  }
 
-  componentDidUpdate(prevState, prevProps) {
+  componentDidUpdate(prevProps) {
     if (prevProps.fit !== this.props.fit) {
       this.resize();
     }


### PR DESCRIPTION
Fixes # (issue) #540 
<!-- you can remove the `# (issue)` part of this -->

#### Type of Change

Please delete options that are not relevant.

- [x] Remove deprecated componentWillReceiveProps with getDerivedStateFromProps
- [x] Remove deprecated componentWillMount with componentDidMount

### How Has This Been Tested? (using unit testing)

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules