### PR TITLE
add div to surround Appear tag children

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ ReactJS based Presentation Library
     - [Magic](#magic)
   - [Element Tags](#element-tags)
     - [Appear](#appear)
+    - [Anim](#anim)
     - [BlockQuote, Quote and Cite (Base)](#blockquote-quote-and-cite-base)
     - [CodePane (Base)](#codepane-base)
     - [Code (Base)](#code-base)
@@ -624,6 +625,20 @@ The element tags are the bread and butter of your slide content. Most of these t
 
 This tag does not extend from Base. It's special. Wrapping elements in the appear tag makes them appear/disappear in order in response to navigation.
 
+For best performance, wrap the contents of this tag in a native DOM element like a `<div>` or `<span>`.
+
+_NOTE: When using `CodePane` tag inside an `Appear` tag you must wrap it inside a `<div>`_
+
+```jsx
+....
+<Appear>
+  <div>
+    <CodePane source="CodePane" lang="js" />
+  </div>
+<Appear>
+....
+```
+
 | Name               | PropType         | Description                                                                                                                                                                                                      | Default          |
 | ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | order              | PropTypes.number | An optional integer starting at 1 for the presentation order of the Appear tags within a slide. If a slide contains ordered and unordered Appear tags, the unordered will show first.                            |
@@ -639,6 +654,8 @@ This tag does not extend from Base. It's special. Wrapping elements in the appea
 If you want extra flexibility with animated animation, you can use the Anim component instead of Appear. It will let you have multi-step animations for each individual fragment. You can use this to create fancy animated intros, in-slide carousels, and many other fancy things. This tag does not extend from Base. It's special.
 
 For best performance, wrap the contents of this tag in a native DOM element like a `<div>` or `<span>`.
+
+_NOTE: `CodePane` tag can not be used inside a `Anim` tag._
 
 | Name               | PropType         | Description                                                                                                                                                                                                                                | Default         |
 | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |

--- a/README.md
+++ b/README.md
@@ -624,8 +624,6 @@ The element tags are the bread and butter of your slide content. Most of these t
 
 This tag does not extend from Base. It's special. Wrapping elements in the appear tag makes them appear/disappear in order in response to navigation.
 
-For best performance, wrap the contents of this tag in a native DOM element like a `<div>` or `<span>`.
-
 | Name               | PropType         | Description                                                                                                                                                                                                      | Default          |
 | ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | order              | PropTypes.number | An optional integer starting at 1 for the presentation order of the Appear tags within a slide. If a slide contains ordered and unordered Appear tags, the unordered will show first.                            |

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -21,7 +21,7 @@ class Appear extends Component {
         easing={easing}
         style={style}
       >
-        <div>{this.props.children}</div>
+        {this.props.children}
       </Anim>
     );
   }

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -21,7 +21,7 @@ class Appear extends Component {
         easing={easing}
         style={style}
       >
-        {this.props.children}
+        <div>{this.props.children}</div>
       </Anim>
     );
   }


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

`Appear` can only have one child to behave correctly which caused issue #597. `CodePane` has a child of its own. When it is inside an `Appear` tag it changes the slide index...
```
Slide with index of 0
Slide with index of 1(Slide with an `CodePane` inside an `Appear` tag)
Slide with index of 2
```
to

```
Slide with index of 0
Slide with index of 1
Slide with index of 0
Slide with index of 1
Slide with index of 2
```
Updated Readme docs to reflect this.

Fixes # 597

#### Type of Change

Please delete options that are not relevant.

- [x] Update README (non-breaking change which fixes an issue)

### How Has This Been Tested?

Test with a simple app 

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
