### PR TITLE
Fix slide navigation after coming out of overview mode

### DIFF
--- a/src/components/__snapshots__/manager.test.js.snap
+++ b/src/components/__snapshots__/manager.test.js.snap
@@ -581,6 +581,7 @@ exports[`<Manager /> should render the overview configuration when specified. 1`
         onTouchStart={[Function]}
       >
         <Overview
+          resetViewedIndexes={[Function]}
           route={
             Object {
               "params": Array [

--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -157,6 +157,7 @@ export class Manager extends Component {
     this._goToSlide = this._goToSlide.bind(this);
     this._startAutoplay = this._startAutoplay.bind(this);
     this._stopAutoplay = this._stopAutoplay.bind(this);
+    this._resetViewedIndexes = this._resetViewedIndexes.bind(this);
     this.presentationConnection = null;
 
     this.state = {
@@ -409,6 +410,11 @@ export class Manager extends Component {
       this.context.history.replace(`/${slide}${this._getSuffix()}`);
     }
   }
+
+  _resetViewedIndexes() {
+    this.viewedIndexes = new Set();
+  }
+
   _prevSlide() {
     const slideIndex = this._getSlideIndex();
     this.setState({
@@ -490,7 +496,7 @@ export class Manager extends Component {
         ) {
           const slideData = '{ "slide": "0", "forward": "false" }';
           this._goToSlide({ key: 'spectacle-slide', newValue: slideData });
-          this.viewedIndexes = new Set();
+          this._resetViewedIndexes();
         }
       } else if (slideIndex < slideReference.length - 1) {
         this.viewedIndexes.add(slideIndex);
@@ -813,6 +819,7 @@ export class Manager extends Component {
           slideReference={this.state.slideReference}
           slideIndex={this._getSlideIndex()}
           route={this.props.route}
+          resetViewedIndexes={this._resetViewedIndexes}
         />
       );
     } else {

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -39,6 +39,7 @@ export default class Overview extends Component {
     window.removeEventListener('resize', this.resizeHandler);
   }
   _slideClicked(index) {
+    this.props.resetViewedIndexes();
     this.context.history.replace(`/${this._getHash(index)}`);
   }
   _getHash(slideIndex) {
@@ -86,6 +87,7 @@ export default class Overview extends Component {
 }
 
 Overview.propTypes = {
+  resetViewedIndexes: PropTypes.function,
   route: PropTypes.object,
   slideIndex: PropTypes.number,
   slideReference: PropTypes.array,


### PR DESCRIPTION
### Description

Fixes #559 by resetting viewed items when the user navigates to a slide using the overview feature.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Reproduced the issue using the example deck and the steps outlined in #559, tested manually after making the fix.

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ ***I've updated snapshots to make sure the right props are being passed through, but there are no tests for the Overview component at the moment.***
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] I have performed a self-review of my own code
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
~~- [ ] Any dependent changes have been merged and published in downstream modules~~
