### PR TITLE
Remove specialized zoom handling and margins for slide content

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width initial-scale=1 user-scalable=no" />
+    <meta name="viewport" content="width=device-width initial-scale=1" />
     <title>Spectacle</title>
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">

--- a/one-page.html
+++ b/one-page.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width initial-scale=1 user-scalable=no" />
+    <meta name="viewport" content="width=device-width initial-scale=1" />
     <title>Spectacle</title>
     <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">

--- a/src/components/__snapshots__/slide.test.js.snap
+++ b/src/components/__snapshots__/slide.test.js.snap
@@ -42,7 +42,6 @@ exports[`<Slide /> should render correctly with transitions. 1`] = `
             innerRef={[Function]}
             margin={undefined}
             overviewMode={undefined}
-            scale={1}
             style={Object {}}
             styles={
               Object {
@@ -50,12 +49,10 @@ exports[`<Slide /> should render correctly with transitions. 1`] = `
               }
             }
             width={undefined}
-            zoom={0.6}
           >
             <div
-              className=" spectacle-content css-1wqnfch e1s7evq12"
+              className=" spectacle-content css-121oawa e1s7evq12"
               height={undefined}
-              scale={1}
               style={Object {}}
               width={undefined}
             >
@@ -107,7 +104,6 @@ exports[`<Slide /> should render correctly without transitions. 1`] = `
             innerRef={[Function]}
             margin={undefined}
             overviewMode={undefined}
-            scale={1}
             style={Object {}}
             styles={
               Object {
@@ -115,12 +111,10 @@ exports[`<Slide /> should render correctly without transitions. 1`] = `
               }
             }
             width={undefined}
-            zoom={0.6}
           >
             <div
-              className=" spectacle-content css-1wqnfch e1s7evq12"
+              className=" spectacle-content css-121oawa e1s7evq12"
               height={undefined}
-              scale={1}
               style={Object {}}
               width={undefined}
             >

--- a/src/components/slide-components.js
+++ b/src/components/slide-components.js
@@ -46,11 +46,7 @@ export const SlideContent = styled.div(props => {
       return 0;
     }
 
-    if (!margin) {
-      return 40;
-    }
-
-    return margin;
+    return 40;
   };
 
   const contentStyles = {

--- a/src/components/slide-components.js
+++ b/src/components/slide-components.js
@@ -40,15 +40,6 @@ export const SlideContentWrapper = styled.div(({ align, overviewMode }) => {
 export const SlideContent = styled.div(props => {
   const { overviewMode, width, height, styles } = props;
 
-  // const getMargin = () => {
-  //   // ensure a "falsy" value of 0 still gets applied
-  //   if (margin === 0) {
-  //     return 0;
-  //   }
-
-  //   return;
-  // };
-
   const contentStyles = {
     flex: 1,
     maxHeight: height || 700,

--- a/src/components/slide-components.js
+++ b/src/components/slide-components.js
@@ -38,23 +38,22 @@ export const SlideContentWrapper = styled.div(({ align, overviewMode }) => {
 });
 
 export const SlideContent = styled.div(props => {
-  const { overviewMode, scale, zoom, margin, width, height, styles } = props;
+  const { overviewMode, width, height, styles } = props;
 
-  const getMargin = () => {
-    // ensure a "falsy" value of 0 still gets applied
-    if (margin === 0) {
-      return 0;
-    }
+  // const getMargin = () => {
+  //   // ensure a "falsy" value of 0 still gets applied
+  //   if (margin === 0) {
+  //     return 0;
+  //   }
 
-    return 40;
-  };
+  //   return;
+  // };
 
   const contentStyles = {
     flex: 1,
     maxHeight: height || 700,
     maxWidth: width || 1000,
-    transform: `scale(${scale})`,
-    padding: zoom > 0.6 ? getMargin() : 10
+    padding: 10
   };
   const overviewStyles = {
     width: '100%'

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -19,11 +19,9 @@ class Slide extends React.PureComponent {
   }
 
   state = {
-    contentScale: 1,
     reverse: false,
     transitioning: true,
-    z: 1,
-    zoom: 1
+    z: 1
   };
 
   getChildContext() {
@@ -120,8 +118,6 @@ class Slide extends React.PureComponent {
             overviewMode={this.context.overview}
             width={this.context.contentWidth}
             height={this.context.contentHeight}
-            scale={this.state.contentScale}
-            zoom={this.state.zoom}
             margin={this.props.margin}
             style={{ ...(this.props.contentStyles || {}) }}
             styles={{ context: this.context.styles.components.content }}

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -17,7 +17,7 @@ class Slide extends React.PureComponent {
     super(...arguments);
     this.stepCounter = stepCounter();
 
-    this.setZoom = this.setZoom.bind(this);
+    // this.setZoom = this.setZoom.bind(this);
   }
 
   state = {
@@ -38,7 +38,7 @@ class Slide extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.setZoom();
+    // this.setZoom();
     const slide = this.slideRef;
     const frags = slide.querySelectorAll('.fragment');
     let currentOrder = 0;
@@ -66,8 +66,8 @@ class Slide extends React.PureComponent {
           currentOrder += 1;
         });
     }
-    window.addEventListener('load', this.setZoom);
-    window.addEventListener('resize', this.setZoom);
+    // window.addEventListener('load', this.setZoom);
+    // window.addEventListener('resize', this.setZoom);
 
     if (isFunction(this.props.onActive)) {
       this.props.onActive(this.props.slideIndex);
@@ -82,10 +82,10 @@ class Slide extends React.PureComponent {
     }
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('load', this.setZoom);
-    window.removeEventListener('resize', this.setZoom);
-  }
+  // componentWillUnmount() {
+  //   window.removeEventListener('load', this.setZoom);
+  //   window.removeEventListener('resize', this.setZoom);
+  // }
 
   componentDidUpdate() {
     const { steps, slideIndex } = this.stepCounter.getSteps();
@@ -97,31 +97,31 @@ class Slide extends React.PureComponent {
     }
   }
 
-  setZoom() {
-    const mobile = window.matchMedia('(max-width: 628px)').matches;
-    const content = this.contentRef;
-    if (content) {
-      const zoom = this.props.viewerScaleMode
-        ? 1
-        : content.offsetWidth / this.context.contentWidth;
+  // setZoom() {
+  //   const mobile = window.matchMedia('(max-width: 628px)').matches;
+  //   const content = this.contentRef;
+  //   if (content) {
+  //     const zoom = this.props.viewerScaleMode
+  //       ? 1
+  //       : content.offsetWidth / this.context.contentWidth;
 
-      const contentScaleY =
-        content.parentNode.offsetHeight / this.context.contentHeight;
-      const contentScaleX = this.props.viewerScaleMode
-        ? content.parentNode.offsetWidth / this.context.contentWidth
-        : content.parentNode.offsetWidth / this.context.contentHeight;
-      const minScale = Math.min(contentScaleY, contentScaleX);
+  //     const contentScaleY =
+  //       content.parentNode.offsetHeight / this.context.contentHeight;
+  //     const contentScaleX = this.props.viewerScaleMode
+  //       ? content.parentNode.offsetWidth / this.context.contentWidth
+  //       : content.parentNode.offsetWidth / this.context.contentHeight;
+  //     const minScale = Math.min(contentScaleY, contentScaleX);
 
-      let contentScale = minScale < 1 ? minScale : 1;
-      if (mobile && this.props.viewerScaleMode !== true) {
-        contentScale = 1;
-      }
-      this.setState({
-        zoom: zoom > 0.6 ? zoom : 0.6,
-        contentScale
-      });
-    }
-  }
+  //     let contentScale = minScale < 1 ? minScale : 1;
+  //     if (mobile && this.props.viewerScaleMode !== true) {
+  //       contentScale = 1;
+  //     }
+  //     this.setState({
+  //       zoom,
+  //       contentScale
+  //     });
+  //   }
+  // }
 
   render() {
     const { presenterStyle, children } = this.props;

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -16,8 +16,6 @@ class Slide extends React.PureComponent {
   constructor() {
     super(...arguments);
     this.stepCounter = stepCounter();
-
-    // this.setZoom = this.setZoom.bind(this);
   }
 
   state = {
@@ -38,7 +36,6 @@ class Slide extends React.PureComponent {
   }
 
   componentDidMount() {
-    // this.setZoom();
     const slide = this.slideRef;
     const frags = slide.querySelectorAll('.fragment');
     let currentOrder = 0;
@@ -66,8 +63,6 @@ class Slide extends React.PureComponent {
           currentOrder += 1;
         });
     }
-    // window.addEventListener('load', this.setZoom);
-    // window.addEventListener('resize', this.setZoom);
 
     if (isFunction(this.props.onActive)) {
       this.props.onActive(this.props.slideIndex);
@@ -82,11 +77,6 @@ class Slide extends React.PureComponent {
     }
   }
 
-  // componentWillUnmount() {
-  //   window.removeEventListener('load', this.setZoom);
-  //   window.removeEventListener('resize', this.setZoom);
-  // }
-
   componentDidUpdate() {
     const { steps, slideIndex } = this.stepCounter.getSteps();
     const stepFunc = this.props.getAnimStep || this.props.getAppearStep;
@@ -96,32 +86,6 @@ class Slide extends React.PureComponent {
       }
     }
   }
-
-  // setZoom() {
-  //   const mobile = window.matchMedia('(max-width: 628px)').matches;
-  //   const content = this.contentRef;
-  //   if (content) {
-  //     const zoom = this.props.viewerScaleMode
-  //       ? 1
-  //       : content.offsetWidth / this.context.contentWidth;
-
-  //     const contentScaleY =
-  //       content.parentNode.offsetHeight / this.context.contentHeight;
-  //     const contentScaleX = this.props.viewerScaleMode
-  //       ? content.parentNode.offsetWidth / this.context.contentWidth
-  //       : content.parentNode.offsetWidth / this.context.contentHeight;
-  //     const minScale = Math.min(contentScaleY, contentScaleX);
-
-  //     let contentScale = minScale < 1 ? minScale : 1;
-  //     if (mobile && this.props.viewerScaleMode !== true) {
-  //       contentScale = 1;
-  //     }
-  //     this.setState({
-  //       zoom,
-  //       contentScale
-  //     });
-  //   }
-  // }
 
   render() {
     const { presenterStyle, children } = this.props;
@@ -181,6 +145,7 @@ Slide.propTypes = {
   align: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  contentStyles: PropTypes.object,
   dispatch: PropTypes.func,
   export: PropTypes.bool,
   getAnimStep: PropTypes.func,


### PR DESCRIPTION
This removes custom zoom handling and reverts to using default browser zoom for more predictable behavior and better accessibility. Can discuss later if this change causes lots of issues for people.

Also uses a standard single margin for slide content instead of calculating based on margin/zoom level, as that was creating weird zoom issues and often doubling the amount of padding/margin. 
