### PR TITLE
Make sure hidden <Appear />s ignore mouse events

### DIFF
--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -29,8 +29,8 @@ class Appear extends Component {
 
 Appear.defaultProps = {
   transitionDuration: 300,
-  startValue: { opacity: 0 },
-  endValue: { opacity: 1 },
+  startValue: { opacity: 0, pointerEvents: 'none' },
+  endValue: { opacity: 1, pointerEvents: 'auto' },
   easing: 'quadInOut'
 };
 


### PR DESCRIPTION
### Description

The default props for `<Appear />` makes untransitioned elements invisible, but they still register pointer-events (e.g., a `<Link />`). This just adds `pointerEvents: "none"` to the starting state so invisible elements do not register clicks.

Fixes #397 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manually through spectacle-boiler-plate.

```jsx
export default class Presentation extends React.Component {
  render() {
    return (
      <Deck
        showFullscreenControl={true}
        transition={["zoom", "slide"]}
        transitionDuration={500}
      >
        <Slide
          transition={["slide"]}
          bgImage={
            "https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/city.jpg"
          }
          bgDarken={0.75}
        >
          <Appear fid="1">
            <Heading size={1} caps fit textColor="primary">
              Test Slide
            </Heading>
          </Appear>
          <Appear fid="2">
            <Link
              href="#link"
              textColor="primary"
              style={{ textDecoration: "underline" }}
            >
              Some Link
            </Link>
          </Appear>
        </Slide>
      </Deck>
    );
  }
```
