### PR TITLE
Update docs to reference local type definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Thanks for taking the time to help us make Spectacle even better! Before you go 
 
 - Run the tests using `yarn run test`.
 - Run lint and flow using `yarn run lint`
-- Open a PR in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/spectacle/index.d.ts) for anything that modifies the Spectacle API, like breaking changes or new features.
+- Update the [type definitions](./index.d.ts) for anything that modifies the Spectacle API, like breaking changes or new features.
 - Everything else included in our [pull request checklist](https://github.com/FormidableLabs/spectacle/blob/master/.github/PULL_REQUEST_TEMPLATE.md#checklist-feel-free-to-delete-this-section-upon-completion)
 
 ## Releasing a new version to NPM (only for project administrators)

--- a/README.md
+++ b/README.md
@@ -453,11 +453,9 @@ const CustomHeading = styled(Heading)`
 
 **_Can I write my presentation in TypeScript?_**
 
-Yes, you can! Updated type definitions for the Spectacle API can be found within [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/spectacle/index.d.ts). You can bring them into your project using `yarn` or `npm`:
+Yes, you can! Type definitions are shipped with the library, so you can import Spectacle components into any `.tsx` presentation without additional installation steps.
 
-```sh
-npm i --save @types/spectacle
-```
+Updated type definitions for the Spectacle API can be found [at the root of this repository](./index.d.ts).
 
 ## Tag API
 


### PR DESCRIPTION
### Description

Rel https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31744 and #630, we want our docs to point to the local type definitions instead of the now-removed DefinitelyTyped file.

#### Type of Change

- [X] This change ~requires~ _is_ a documentation update

### How Has This Been Tested?

Installation steps were tested manually with a sample TypeScript presentation.
