### PR TITLE
Fix #base-props anchor link for Table header in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ The `S` tag is used to add styling to a piece of text, such as underline or stri
 
 <a name="table-tablerow-tableheaderitem-and-tableitem-base"></a>
 
-#### Table, TableRow, TableHeaderItem and TableItem ([Base](base-propse))
+#### Table, TableRow, TableHeaderItem and TableItem ([Base](#base-props))
 
 The `Table` tag is used to add table to your slide. It is used with `TableHeader`, `TableBody`, `TableRow`, `TableHeaderItem` and `TableItem`. Use them as follows:
 


### PR DESCRIPTION
### Description

Readme `#base-props` link was incorrect for the `Table, TableRow, TableHeaderItem and TableItem` entry.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)