### PR TITLE
Include index.d.ts in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ __mocks__
 !LICENSE
 !README.md
 !package.json
+!index.d.ts


### PR DESCRIPTION
### Description

Typescript type definitions were excluded from the built package via`.npmignore`. This PR adds an exception for the file so that the type definitions are installed correctly.

Fixes #646

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran `npm pack && tar --list --file spectacle-5.3.0.tgz | grep index.d.ts` to verify that the `index.d.ts` file is included in the tarball.
