### PR TITLE
Fixes no slide separation with Windows line endings

### DIFF
--- a/src/components/markdown-slides.js
+++ b/src/components/markdown-slides.js
@@ -3,7 +3,7 @@ import Slide from './slide';
 import Markdown from './markdown';
 
 const transformStringsIntoJSX = function(strings) {
-  return strings.split(/\n---\n/).map((markdown, index) => (
+  return strings.split(/\r?\n---\r?\n/).map((markdown, index) => (
     <Slide key={`md-slide-${index}`}>
       <Markdown>{markdown}</Markdown>
     </Slide>


### PR DESCRIPTION
### Description

When using markdown files saved on windows as slides everything appeared as a single slide. This patch fixes it so '.md' files with both UNIX and Windows line endings are rendered properly.

#### Type of Change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested locally with an `.md` file saved with Windows line endings
