### PR TITLE
Custom listItem enumerators with unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,12 +879,13 @@ The link tag is used to render `<a>` tags. It accepts an `href` prop:
 
 #### List & ListItem ([Base](#base-props))
 
-| Name     | PropType         | Description                  | Default |
-| -------- | ---------------- | ---------------------------- | ------- |
-| ordered  | PropTypes.bool   | Render as `<ol>` tag         |         |
-| reversed | PropTypes.bool   | Set the `reversed` attribute |         |
-| start    | PropTypes.number | Set the `start` attribute.   | `1`     |
-| type     | PropTypes.string | Set the `type` attribute.    | `"1"`   |
+| Name        | PropType         | Description                                                                                                                                                                                                                                                                                                                                                                | Default |
+| ----------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| ordered     | PropTypes.bool   | Render as `<ol>` tag                                                                                                                                                                                                                                                                                                                                                       |         |
+| reversed    | PropTypes.bool   | Set the `reversed` attribute                                                                                                                                                                                                                                                                                                                                               |         |
+| start       | PropTypes.number | Set the `start` attribute.                                                                                                                                                                                                                                                                                                                                                 | `1`     |
+| type        | PropTypes.string | Set the `type` attribute.                                                                                                                                                                                                                                                                                                                                                  | `"1"`   |
+| bulletStyle | PropTypes.string | Allows to customize list bullets for unordered-list. You can set `bulletStyle="star"` both in `List` and `ListItem` components. When `ListItem` prop is set it will overwrite the `List` styling only for the specific `ListItem`. You can either use built-in strings: `star`, `classicCheck`, `greenCheck`, `arrow`, `cross`, or any unicode number `bulletStyle="274C"` |
 
 These tags create lists. Use them as follows:
 
@@ -904,7 +905,7 @@ Unordered lists:
 ```jsx
 <List>
   <ListItem>Item 1</ListItem>
-  <ListItem>Item 2</ListItem>
+  <ListItem bulletStyle="arrow">Item 2</ListItem>
   <ListItem>Item 3</ListItem>
   <ListItem>Item 4</ListItem>
 </List>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -137,7 +137,7 @@ export default class Presentation extends Component {
             <List>
               <ListItem>talk about that</ListItem>
               <ListItem>and that</ListItem>
-              <ListItem bulletStyle="greenCheck">and then this</ListItem>
+              <ListItem>and then this</ListItem>
             </List>
           </Notes>
         </Slide>
@@ -380,6 +380,9 @@ const myCode = (is, great) => 'for' + 'sharing';
               </Appear>
               <Appear>
                 <ListItem>PDF export</ListItem>
+              </Appear>
+              <Appear>
+                <ListItem bulletStyle="greenCheck">Customized bullets</ListItem>
               </Appear>
               <Appear>
                 <ListItem>And...</ListItem>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -134,9 +134,9 @@ export default class Presentation extends Component {
             overflow="overflow"
           />
           <Notes>
-            <List bulletStyle="arrow">
+            <List>
               <ListItem>talk about that</ListItem>
-              <ListItem bulletStyle="star">and that</ListItem>
+              <ListItem>and that</ListItem>
               <ListItem bulletStyle="greenCheck">and then this</ListItem>
             </List>
           </Notes>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -134,11 +134,11 @@ export default class Presentation extends Component {
             overflow="overflow"
           />
           <Notes>
-            <ul>
-              <li>talk about that</li>
-              <li>and that</li>
-              <li>and then this</li>
-            </ul>
+            <List bulletStyle="arrow">
+              <ListItem>talk about that</ListItem>
+              <ListItem bulletStyle="star">and that</ListItem>
+              <ListItem bulletStyle="greenCheck">and then this</ListItem>
+            </List>
           </Notes>
         </Slide>
         <Slide goTo={3}>

--- a/src/components/__snapshots__/list-item.test.js.snap
+++ b/src/components/__snapshots__/list-item.test.js.snap
@@ -11,6 +11,7 @@ exports[`<ListItem /> should render correctly 1`] = `
         Object {},
         Object {},
         undefined,
+        Array [],
       ]
     }
   >

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -3,7 +3,30 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-const StyledListItem = styled.li(props => props.styles);
+const bulletStyles = {
+  star: '\\2605',
+  classicCheck: '\\2713',
+  greenCheck: '\\2705',
+  arrow: '\\27a4',
+  cross: '\\274C'
+};
+const getListStyle = props => {
+  if (props.bulletStyle) {
+    return [
+      { listStyleType: 'none' },
+      `&::before {
+        content: '${bulletStyles[props.bulletStyle]}';
+        margin: 0 25px;
+    }`
+    ];
+  }
+  return undefined;
+};
+
+const StyledListItem = styled.li(
+  props => props.styles,
+  props => getListStyle(props)
+);
 
 export default class ListItem extends Component {
   render() {
@@ -11,6 +34,7 @@ export default class ListItem extends Component {
     return (
       <StyledListItem
         className={this.props.className}
+        bulletStyle={this.props.bulletStyle}
         styles={[
           this.context.styles.components.listItem,
           getStyles.call(this),
@@ -25,6 +49,7 @@ export default class ListItem extends Component {
 }
 
 ListItem.propTypes = {
+  bulletStyle: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   style: PropTypes.object

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -12,7 +12,6 @@ export default class ListItem extends Component {
     return (
       <StyledListItem
         className={this.props.className}
-        bulletStyle={this.props.bulletStyle}
         styles={[
           this.context.styles.components.listItem,
           getStyles.call(this),

--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -2,31 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
+import { getBulletStyle } from './list.js';
 
-const bulletStyles = {
-  star: '\\2605',
-  classicCheck: '\\2713',
-  greenCheck: '\\2705',
-  arrow: '\\27a4',
-  cross: '\\274C'
-};
-const getListStyle = props => {
-  if (props.bulletStyle) {
-    return [
-      { listStyleType: 'none' },
-      `&::before {
-        content: '${bulletStyles[props.bulletStyle]}';
-        margin: 0 25px;
-    }`
-    ];
-  }
-  return undefined;
-};
-
-const StyledListItem = styled.li(
-  props => props.styles,
-  props => getListStyle(props)
-);
+const StyledListItem = styled.li(props => props.styles);
 
 export default class ListItem extends Component {
   render() {
@@ -39,7 +17,8 @@ export default class ListItem extends Component {
           this.context.styles.components.listItem,
           getStyles.call(this),
           typefaceStyle,
-          this.props.style
+          this.props.style,
+          getBulletStyle(this.props.bulletStyle, true)
         ]}
       >
         {this.props.children}

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -3,8 +3,31 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
+const bulletStyles = {
+  star: '\\2605',
+  classicCheck: '\\2713',
+  greenCheck: '\\2705',
+  arrow: '\\219d',
+  cross: '\\274C'
+};
+const getListStyle = props => {
+  if (props.bulletStyle) {
+    return [
+      { listStyleType: 'none' },
+      `li::before {
+        content: '${bulletStyles[props.bulletStyle]}';
+        margin: 0 25px
+    }`
+    ];
+  }
+  return undefined;
+};
+
 const StyledOrderedList = styled.ol(props => props.styles);
-const StyledList = styled.ul(props => props.styles);
+const StyledList = styled.ul(
+  props => props.styles,
+  props => getListStyle(props)
+);
 
 export default class List extends Component {
   render() {
@@ -24,6 +47,7 @@ export default class List extends Component {
       </StyledOrderedList>
     ) : (
       <StyledList
+        bulletStyle={this.props.bulletStyle}
         className={this.props.className}
         styles={[
           this.context.styles.components.list,
@@ -38,6 +62,7 @@ export default class List extends Component {
 }
 
 List.propTypes = {
+  bulletStyle: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   ordered: PropTypes.bool,

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -15,11 +15,10 @@ export const getBulletStyle = (bulletStyle, isListItemStyle) => {
   if (bulletStyle) {
     const content = bulletStyles[bulletStyle] || `\\${bulletStyle}`;
 
-    if (isListItemStyle === true) {
-      return [
-        { listStyleType: 'none' },
-        `&::before {
-          content: '${content}' !important;
+    return [
+      { listStyleType: 'none' },
+      `${isListItemStyle ? '&' : 'li'}::before {
+          content: '${content}' ${isListItemStyle ? '!important' : ''};
           display: inline-block;
           margin-right: 40px;
           width: 20px;
@@ -27,21 +26,7 @@ export const getBulletStyle = (bulletStyle, isListItemStyle) => {
           text-align: center;
           vertical-align: middle;
         }`
-      ];
-    } else {
-      return [
-        { listStyleType: 'none' },
-        `li::before {
-          content: '${content}';
-          display: inline-block;
-          margin-right: 40px;
-          width: 20px;
-          font-size: 20px;
-          text-align: center;
-          vertical-align: middle;
-        }`
-      ];
-    }
+    ];
   }
 
   return [];

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-// Is it okay to export from here?  Should they go in different files?
 export const bulletStyles = {
   star: '\\2605',
   classicCheck: '\\2713',
@@ -33,14 +32,14 @@ export const getBulletStyle = (bulletStyle, isListItemStyle) => {
       return [
         { listStyleType: 'none' },
         `li::before {
-        content: '${content}';
-        display: inline-block;
-        margin-right: 40px;
-        width: 20px;
-        font-size: 20px;
-        text-align: center;
-        vertical-align: middle;
-      }`
+          content: '${content}';
+          display: inline-block;
+          margin-right: 40px;
+          width: 20px;
+          font-size: 20px;
+          text-align: center;
+          vertical-align: middle;
+        }`
       ];
     }
   }

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -3,31 +3,53 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-const bulletStyles = {
+// Is it okay to export from here?  Should they go in different files?
+export const bulletStyles = {
   star: '\\2605',
   classicCheck: '\\2713',
   greenCheck: '\\2705',
   arrow: '\\219d',
   cross: '\\274C'
 };
-const getListStyle = props => {
-  if (props.bulletStyle) {
-    return [
-      { listStyleType: 'none' },
-      `li::before {
-        content: '${bulletStyles[props.bulletStyle]}';
-        margin: 0 25px
-    }`
-    ];
+
+export const getBulletStyle = (bulletStyle, isListItemStyle) => {
+  if (bulletStyle) {
+    const content = bulletStyles[bulletStyle] || `\\${bulletStyle}`;
+
+    if (isListItemStyle === true) {
+      return [
+        { listStyleType: 'none' },
+        `&::before {
+          content: '${content}' !important;
+          display: inline-block;
+          margin-right: 40px;
+          width: 20px;
+          font-size: 20px;
+          text-align: center;
+          vertical-align: middle;
+        }`
+      ];
+    } else {
+      return [
+        { listStyleType: 'none' },
+        `li::before {
+        content: '${content}';
+        display: inline-block;
+        margin-right: 40px;
+        width: 20px;
+        font-size: 20px;
+        text-align: center;
+        vertical-align: middle;
+      }`
+      ];
+    }
   }
-  return undefined;
+
+  return [];
 };
 
 const StyledOrderedList = styled.ol(props => props.styles);
-const StyledList = styled.ul(
-  props => props.styles,
-  props => getListStyle(props)
-);
+const StyledList = styled.ul(props => props.styles);
 
 export default class List extends Component {
   render() {
@@ -47,12 +69,12 @@ export default class List extends Component {
       </StyledOrderedList>
     ) : (
       <StyledList
-        bulletStyle={this.props.bulletStyle}
         className={this.props.className}
         styles={[
           this.context.styles.components.list,
           getStyles.call(this),
-          this.props.style
+          this.props.style,
+          getBulletStyle(this.props.bulletStyle, false)
         ]}
       >
         {this.props.children}

--- a/src/components/list.test.js
+++ b/src/components/list.test.js
@@ -32,7 +32,8 @@ describe('<List />', () => {
     expect(wrapper.prop('styles')).toEqual([
       context.styles.components.list,
       {},
-      { fontWeight: 'bold' }
+      { fontWeight: 'bold' },
+      []
     ]);
   });
 });

--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -57,11 +57,13 @@ export const transformBold = ({ bold }) => {
     return { fontWeight: bold ? 'bold' : 'normal' };
   }
 };
+
 export const transformCaps = ({ caps }) => {
   if (typeof caps === 'boolean') {
     return { textTransform: caps ? 'uppercase' : 'none' };
   }
 };
+
 export const transformBgColor = ({ bgColor }, context) => {
   if (bgColor) {
     let backgroundColor = '';


### PR DESCRIPTION
### Description

This feature allows adding custom bullets to `List` and `ListItem` elements. If the `bulletStyle` prop is passed to `List` component it changes the default enumerators styling for all `List` elements unless `bulletStyle` prop for `ListItem` is passed at the same time, which overwrites the styling of the parent element for particular `ListItem` only.
The user can either pass any Unicode number or use a few pre-defined strings to execute the new styling.

Fixes #437

#### Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

