### PR TITLE
Update docs to include hashroute for query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ If you want to export your slides with your [notes](#notes) included, repeat the
 
 #### Query Parameters
 
-Here is a list of all valid query parameters that can be placed after `\` on the URL.
+Here is a list of all valid query parameters that can be placed after `/#/` on the URL.
 
 | Query               | Description                                                                                                          |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### Description

This PR clears up the query param prefix in our docs. We weren't very explicit about including the hashroute when using those query params, now we are.

Rel [this tweet](https://twitter.com/k1sul1/status/1101124868060446722), kind of.

#### Type of Change

- [X] This change ~requires~ **is** a documentation update