### PR TITLE
Fix: ``createHashHistory`` import syntax

### DIFF
--- a/src/utils/controller.js
+++ b/src/utils/controller.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import createHistory from 'history/createHashHistory';
+import { createHashHistory } from 'history';
 import PropTypes from 'prop-types';
 import { updateRoute } from '../actions';
 import { countSlides } from './slides';
@@ -7,7 +7,7 @@ import { countSlides } from './slides';
 import theme from '../themes/default';
 import Context from './context';
 
-const history = createHistory();
+const history = createHashHistory();
 
 export default class Controller extends Component {
   static propTypes = {


### PR DESCRIPTION
### Description

This change fixes the following warning raised by ``history`` in the browsers :
```
Warning: Please use `require("history").createHashHistory` instead of `require("history/createHashHistory")`. Support for the latter will be removed in the next major release.
```

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
