### PR TITLE
add live demo link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ ReactJS based Presentation Library
 [Spectacle Boilerplate MDX](https://github.com/FormidableLabs/spectacle-boilerplate-mdx/)
 [Spectacle Boilerplate](https://github.com/FormidableLabs/spectacle-boilerplate/)
 
+Looking for a quick preview of what you can do with Spectacle? Check out our live Demo Deck [here](https://raw.githack.com/FormidableLabs/spectacle/master/one-page.html#/).
+
 Have a question about Spectacle? Submit an issue in this repository using the "Question" template.
 
 ## Contents


### PR DESCRIPTION
### Description

Add a link to the live demo deck at the top of the README file. 

Fixes Issue #671, user requested a link to a live demo to quickly see what Spectacle looks like and is capable of. 

### How Has This Been Tested?

Ran prettier and linter, no other tests performed as this is only an update to the docs. 

