### PR TITLE
Update one-page.html to use spectacle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ We can start with this project's sample at [`one-page.html`](./one-page.html). I
     <script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.js"></script>
-    <script src="https://unpkg.com/spectacle@^4/dist/spectacle.js"></script>
-    <script src="https://unpkg.com/spectacle@^4/lib/one-page.js"></script>
+    <script src="https://unpkg.com/spectacle@^5/dist/spectacle.js"></script>
+    <script src="https://unpkg.com/spectacle@^5/lib/one-page.js"></script>
     <script type="text/spectacle">
       () => {
         // Your JS Code goes here

--- a/one-page.html
+++ b/one-page.html
@@ -29,276 +29,276 @@
     <script src="https://unpkg.com/spectacle@^5/dist/spectacle.js"></script>
     <script src="https://unpkg.com/spectacle@^5/lib/one-page.js"></script>
     <script type="text/spectacle">
-            () => {
-              // --------------------------------------------------------------------
-              // Code stuff to use in the presentation.
-              // (We can't link in / require files, but we can approximate here.)
-              // --------------------------------------------------------------------
-              // Customize the default theme.
-              const { themes: { defaultTheme } } = Spectacle;
-              const theme = defaultTheme({
-                primary: "#ff4081"
-              });
+      () => {
+        // --------------------------------------------------------------------
+        // Code stuff to use in the presentation.
+        // (We can't link in / require files, but we can approximate here.)
+        // --------------------------------------------------------------------
+        // Customize the default theme.
+        const { themes: { defaultTheme } } = Spectacle;
+        const theme = defaultTheme({
+          primary: "#ff4081"
+        });
 
-              // Example source code for a source code slide.
-              const exampleDeck = `
-      return (
-        <Deck transition={['zoom','slide']} transitionDuration={800}>
-          <Slide bgColor="primary">
-            <Heading size={1} fit caps>
-              React Presentations
-            </Heading>
-            <Heading size={2} fit caps>
-              Written In React
-            </Heading>
-          </Slide>
-          <Slide bgColor="black">
-            <Heading size={1} fit textColor="primary" textFont="secondary">
-              Wait What?
-            </Heading>
-          </Slide>
-          <Slide bgColor="primary" textColor="black" align="center top">
-            <Heading size={1} textColor="black" textFont="primary">
-              Thats right
-            </Heading>
-            <List>
-              <ListItem>Inline style based theme system</ListItem>
-              <ListItem>Autofit Text</ListItem>
-              <ListItem>PDF Export</ListItem>
-            </List>
-          </Slide>
-        </Deck>
-      )
-              `.trim();
+        // Example source code for a source code slide.
+        const exampleDeck = `
+return (
+  <Deck transition={['zoom','slide']} transitionDuration={800}>
+    <Slide bgColor="primary">
+      <Heading size={1} fit caps>
+        React Presentations
+      </Heading>
+      <Heading size={2} fit caps>
+        Written In React
+      </Heading>
+    </Slide>
+    <Slide bgColor="black">
+      <Heading size={1} fit textColor="primary" textFont="secondary">
+        Wait What?
+      </Heading>
+    </Slide>
+    <Slide bgColor="primary" textColor="black" align="center top">
+      <Heading size={1} textColor="black" textFont="primary">
+        Thats right
+      </Heading>
+      <List>
+        <ListItem>Inline style based theme system</ListItem>
+        <ListItem>Autofit Text</ListItem>
+        <ListItem>PDF Export</ListItem>
+      </List>
+    </Slide>
+  </Deck>
+)
+        `.trim();
 
-              // Interactive code.
-              const { Component } = React;
-              const { Heading } = Spectacle;
+        // Interactive code.
+        const { Component } = React;
+        const { Heading } = Spectacle;
 
-              class Interactive extends Component {
-                constructor() {
-                  super();
-                  this.state = {
-                    count: 0
-                  };
-                  this.handleClick = this.handleClick.bind(this);
+        class Interactive extends Component {
+          constructor() {
+            super();
+            this.state = {
+              count: 0
+            };
+            this.handleClick = this.handleClick.bind(this);
+          }
+          handleClick() {
+            this.setState({
+              count: this.state.count + 1
+            });
+          }
+          render() {
+            const styles = {
+              padding: 20,
+              background: "black",
+              minWidth: 300,
+              marginTop: 20,
+              textTransform: "uppercase",
+              border: "none",
+              color: "white",
+              outline: "none",
+              fontWeight: "bold",
+              fontSize: "2em"
+            };
+            return (
+              <div>
+              {this.state.count < 5 ?
+                <div>
+                  <Heading size={5} textColor="black">
+                    The button has been clicked {this.state.count} times
+                  </Heading>
+                  <button style={styles} type="button" onClick={this.handleClick}>Click Me</button>
+                </div> :
+                  <Heading size={5} fit caps textColor="black">Easy there pal</Heading>
                 }
-                handleClick() {
-                  this.setState({
-                    count: this.state.count + 1
-                  });
-                }
-                render() {
-                  const styles = {
-                    padding: 20,
-                    background: "black",
-                    minWidth: 300,
-                    marginTop: 20,
-                    textTransform: "uppercase",
-                    border: "none",
-                    color: "white",
-                    outline: "none",
-                    fontWeight: "bold",
-                    fontSize: "2em"
-                  };
-                  return (
-                    <div>
-                    {this.state.count < 5 ?
-                      <div>
-                        <Heading size={5} textColor="black">
-                          The button has been clicked {this.state.count} times
-                        </Heading>
-                        <button style={styles} type="button" onClick={this.handleClick}>Click Me</button>
-                      </div> :
-                        <Heading size={5} fit caps textColor="black">Easy there pal</Heading>
-                      }
-                    </div>
-                  );
-                }
-              }
+              </div>
+            );
+          }
+        }
 
-              // --------------------------------------------------------------------
-              // The presentation!
-              // --------------------------------------------------------------------
-              return (
-                <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
-                  <Slide transition={["zoom"]} bgColor="primary">
-                    <Heading size={1} fit caps lineHeight={1} textColor="black">
-                      Spectacle
-                    </Heading>
-                    <Heading size={1} fit caps>
-                      A ReactJS Presentation Library
-                    </Heading>
-                    <Heading size={1} fit caps textColor="black">
-                      Where You Can Write Your Decks In JSX
-                    </Heading>
-                    <Link href="https://github.com/FormidableLabs/spectacle">
-                      <Text bold caps textColor="tertiary">View on Github</Text>
-                    </Link>
-                    <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
-                  </Slide>
-                  <Slide id="wait-what" transition={["slide"]} bgColor="black" notes="You can even put notes on your slide. How awesome is that?">
-                    <Image src={"https://github.com/FormidableLabs/spectacle/raw/master/example/assets/kat.png"} margin="0px auto 40px" height="293px"/>
-                    <Heading size={2} caps fit textColor="primary" textFont="primary">
-                      Wait what?
-                    </Heading>
-                  </Slide>
-                  <Slide transition={["zoom", "fade"]} bgColor="primary" notes="<ul><li>talk about that</li><li>and that</li></ul>">
-                    <CodePane
-                      lang="jsx"
-                      source={exampleDeck}
-                      margin="20px auto"
-                    />
-                  </Slide>
-                  <Slide>
-                    <ComponentPlayground
-                      theme="dark"
-                    />
-                  </Slide>
-                  <Slide transition={["slide"]} bgImage={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/city.jpg"} bgDarken={0.75}>
-                    <Appear fid="1">
-                      <Heading size={1} caps fit textColor="primary">
-                        Full Width
-                      </Heading>
-                    </Appear>
-                    <Appear fid="2">
-                      <Heading size={1} caps fit textColor="tertiary">
-                        Adjustable Darkness
-                      </Heading>
-                    </Appear>
-                    <Appear fid="3">
-                      <Heading size={1} caps fit textColor="primary">
-                        Background Imagery
-                      </Heading>
-                    </Appear>
-                  </Slide>
-                  <Slide transition={["zoom", "fade"]} bgColor="primary">
-                    <Heading caps fit>Flexible Layouts</Heading>
-                    <Layout>
-                      <Fill>
-                        <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                          Left
-                        </Heading>
-                      </Fill>
-                      <Fill>
-                        <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                          Right
-                        </Heading>
-                      </Fill>
-                    </Layout>
-                  </Slide>
-                  <Slide transition={["slide"]} bgColor="black">
-                    <BlockQuote>
-                      <Quote>Wonderfully formatted quotes</Quote>
-                      <Cite>Ken Wheeler</Cite>
-                    </BlockQuote>
-                  </Slide>
-                  <Slide transition={["spin", "zoom"]} bgColor="tertiary">
-                    <Heading caps fit size={1} textColor="primary">
-                      Inline Markdown
-                    </Heading>
-                    <Markdown>
-                      {`
+        // --------------------------------------------------------------------
+        // The presentation!
+        // --------------------------------------------------------------------
+        return (
+          <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
+            <Slide transition={["zoom"]} bgColor="primary">
+              <Heading size={1} fit caps lineHeight={1} textColor="black">
+                Spectacle
+              </Heading>
+              <Heading size={1} fit caps>
+                A ReactJS Presentation Library
+              </Heading>
+              <Heading size={1} fit caps textColor="black">
+                Where You Can Write Your Decks In JSX
+              </Heading>
+              <Link href="https://github.com/FormidableLabs/spectacle">
+                <Text bold caps textColor="tertiary">View on Github</Text>
+              </Link>
+              <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
+            </Slide>
+            <Slide id="wait-what" transition={["slide"]} bgColor="black" notes="You can even put notes on your slide. How awesome is that?">
+              <Image src={"https://github.com/FormidableLabs/spectacle/raw/master/example/assets/kat.png"} margin="0px auto 40px" height="293px"/>
+              <Heading size={2} caps fit textColor="primary" textFont="primary">
+                Wait what?
+              </Heading>
+            </Slide>
+            <Slide transition={["zoom", "fade"]} bgColor="primary" notes="<ul><li>talk about that</li><li>and that</li></ul>">
+              <CodePane
+                lang="jsx"
+                source={exampleDeck}
+                margin="20px auto"
+              />
+            </Slide>
+            <Slide>
+              <ComponentPlayground
+                theme="dark"
+              />
+            </Slide>
+            <Slide transition={["slide"]} bgImage={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/city.jpg"} bgDarken={0.75}>
+              <Appear fid="1">
+                <Heading size={1} caps fit textColor="primary">
+                  Full Width
+                </Heading>
+              </Appear>
+              <Appear fid="2">
+                <Heading size={1} caps fit textColor="tertiary">
+                  Adjustable Darkness
+                </Heading>
+              </Appear>
+              <Appear fid="3">
+                <Heading size={1} caps fit textColor="primary">
+                  Background Imagery
+                </Heading>
+              </Appear>
+            </Slide>
+            <Slide transition={["zoom", "fade"]} bgColor="primary">
+              <Heading caps fit>Flexible Layouts</Heading>
+              <Layout>
+                <Fill>
+                  <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                    Left
+                  </Heading>
+                </Fill>
+                <Fill>
+                  <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                    Right
+                  </Heading>
+                </Fill>
+              </Layout>
+            </Slide>
+            <Slide transition={["slide"]} bgColor="black">
+              <BlockQuote>
+                <Quote>Wonderfully formatted quotes</Quote>
+                <Cite>Ken Wheeler</Cite>
+              </BlockQuote>
+            </Slide>
+            <Slide transition={["spin", "zoom"]} bgColor="tertiary">
+              <Heading caps fit size={1} textColor="primary">
+                Inline Markdown
+              </Heading>
+              <Markdown>
+                {`
 ![Markdown Logo](https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/markdown.png)
 
 You can write inline images, [Markdown Links](http://commonmark.org), paragraph text and most other markdown syntax
 * Lists too!
 * With ~~strikethrough~~ and _italic_
 * And let's not forget **bold**
-                      `}
-                    </Markdown>
-                  </Slide>
-                  {
-                    MarkdownSlides(`
+                `}
+              </Markdown>
+            </Slide>
+            {
+              MarkdownSlides`
 #### Create Multiple Slides in Markdown
 All the same tags and elements supported in <Markdown /> are supported in MarkdownSlides.
 ---
 Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
 * A Tagged Template Literal
 * Imported Markdown from another file
-                    `)
-                  }
-                  <Slide transition={["slide", "spin"]} bgColor="primary">
-                    <Heading caps fit size={1} textColor="tertiary">
-                      Smooth
-                    </Heading>
-                    <Heading caps fit size={1} textColor="secondary">
-                      Combinable Transitions
-                    </Heading>
-                  </Slide>
-                  <SlideSet>
-                    <Slide transition={["fade"]} bgColor="secondary" textColor="primary">
-                      <List>
-                        <Appear><ListItem>Inline style based theme system</ListItem></Appear>
-                        <Appear><ListItem>Autofit text</ListItem></Appear>
-                        <Appear><ListItem>Flexbox layout system</ListItem></Appear>
-                        <Appear><ListItem>PDF export</ListItem></Appear>
-                        <Appear><ListItem>And...</ListItem></Appear>
-                      </List>
-                    </Slide>
-                    <Slide transition={["slide"]} bgColor="primary">
-                      <Heading size={1} caps fit textColor="tertiary">
-                        Your presentations are interactive
-                      </Heading>
-                      <Interactive/>
-                    </Slide>
-                  </SlideSet>
-                  <Slide transition={["slide"]} bgColor="primary"
-                    notes="Hard to find cities without any pizza"
-                  >
-                    <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                      Pizza Toppings
-                    </Heading>
-                    <Layout>
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHeaderItem/>
-                            <TableHeaderItem>2011</TableHeaderItem>
-                            <TableHeaderItem>2013</TableHeaderItem>
-                            <TableHeaderItem>2015</TableHeaderItem>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          <TableRow>
-                            <TableItem>None</TableItem>
-                            <TableItem>61.8%</TableItem>
-                            <TableItem>39.6%</TableItem>
-                            <TableItem>35.0%</TableItem>
-                          </TableRow>
-                          <TableRow>
-                            <TableItem>Pineapple</TableItem>
-                            <TableItem>28.3%</TableItem>
-                            <TableItem>54.5%</TableItem>
-                            <TableItem>61.5%</TableItem>
-                          </TableRow>
-                          <TableRow>
-                            <TableItem>Pepperoni</TableItem>
-                            <TableItem/>
-                            <TableItem>50.2%</TableItem>
-                            <TableItem>77.2%</TableItem>
-                          </TableRow>
-                          <TableRow>
-                            <TableItem>Olives</TableItem>
-                            <TableItem/>
-                            <TableItem>24.9%</TableItem>
-                            <TableItem>55.9%</TableItem>
-                          </TableRow>
-                        </TableBody>
-                      </Table>
-                    </Layout>
-                  </Slide>
-                  <Slide transition={["spin", "slide"]} bgColor="tertiary">
-                    <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
-                      Made with love in Seattle by
-                    </Heading>
-                    <Link href="http://www.formidable.com">
-                      <Image width="100%" src={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/formidable-logo.svg"}/>
-                    </Link>
-                  </Slide>
-                </Deck>
-              );
+              `
             }
+            <Slide transition={["slide", "spin"]} bgColor="primary">
+              <Heading caps fit size={1} textColor="tertiary">
+                Smooth
+              </Heading>
+              <Heading caps fit size={1} textColor="secondary">
+                Combinable Transitions
+              </Heading>
+            </Slide>
+            <SlideSet>
+              <Slide transition={["fade"]} bgColor="secondary" textColor="primary">
+                <List>
+                  <Appear><ListItem>Inline style based theme system</ListItem></Appear>
+                  <Appear><ListItem>Autofit text</ListItem></Appear>
+                  <Appear><ListItem>Flexbox layout system</ListItem></Appear>
+                  <Appear><ListItem>PDF export</ListItem></Appear>
+                  <Appear><ListItem>And...</ListItem></Appear>
+                </List>
+              </Slide>
+              <Slide transition={["slide"]} bgColor="primary">
+                <Heading size={1} caps fit textColor="tertiary">
+                  Your presentations are interactive
+                </Heading>
+                <Interactive/>
+              </Slide>
+            </SlideSet>
+            <Slide transition={["slide"]} bgColor="primary"
+              notes="Hard to find cities without any pizza"
+            >
+              <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                Pizza Toppings
+              </Heading>
+              <Layout>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHeaderItem/>
+                      <TableHeaderItem>2011</TableHeaderItem>
+                      <TableHeaderItem>2013</TableHeaderItem>
+                      <TableHeaderItem>2015</TableHeaderItem>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    <TableRow>
+                      <TableItem>None</TableItem>
+                      <TableItem>61.8%</TableItem>
+                      <TableItem>39.6%</TableItem>
+                      <TableItem>35.0%</TableItem>
+                    </TableRow>
+                    <TableRow>
+                      <TableItem>Pineapple</TableItem>
+                      <TableItem>28.3%</TableItem>
+                      <TableItem>54.5%</TableItem>
+                      <TableItem>61.5%</TableItem>
+                    </TableRow>
+                    <TableRow>
+                      <TableItem>Pepperoni</TableItem>
+                      <TableItem/>
+                      <TableItem>50.2%</TableItem>
+                      <TableItem>77.2%</TableItem>
+                    </TableRow>
+                    <TableRow>
+                      <TableItem>Olives</TableItem>
+                      <TableItem/>
+                      <TableItem>24.9%</TableItem>
+                      <TableItem>55.9%</TableItem>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </Layout>
+            </Slide>
+            <Slide transition={["spin", "slide"]} bgColor="tertiary">
+              <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
+                Made with love in Seattle by
+              </Heading>
+              <Link href="http://www.formidable.com">
+                <Image width="100%" src={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/formidable-logo.svg"}/>
+              </Link>
+            </Slide>
+          </Deck>
+        );
+      }
     </script>
   </body>
 </html>

--- a/one-page.html
+++ b/one-page.html
@@ -1,292 +1,304 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width initial-scale=1" />
     <title>Spectacle</title>
-    <link href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700" rel="stylesheet" type="text/css">
-    <link href="https://unpkg.com/normalize.css@7/normalize.css" rel="stylesheet" type="text/css">
-</head>
-<body>
+    <link
+      href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      href="https://unpkg.com/normalize.css@7/normalize.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+  <body>
     <div id="root"></div>
     <script src="https://unpkg.com/prop-types@15/prop-types.js"></script>
     <script src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.js"></script>
-    <script src="https://unpkg.com/spectacle@^4/dist/spectacle.js"></script>
-    <script src="https://unpkg.com/spectacle@^4/lib/one-page.js"></script>
+    <script src="https://unpkg.com/spectacle@^5/dist/spectacle.js"></script>
+    <script src="https://unpkg.com/spectacle@^5/lib/one-page.js"></script>
     <script type="text/spectacle">
-      () => {
-        // --------------------------------------------------------------------
-        // Code stuff to use in the presentation.
-        // (We can't link in / require files, but we can approximate here.)
-        // --------------------------------------------------------------------
-        // Customize the default theme.
-        const { themes: { defaultTheme } } = Spectacle;
-        const theme = defaultTheme({
-          primary: "#ff4081"
-        });
+            () => {
+              // --------------------------------------------------------------------
+              // Code stuff to use in the presentation.
+              // (We can't link in / require files, but we can approximate here.)
+              // --------------------------------------------------------------------
+              // Customize the default theme.
+              const { themes: { defaultTheme } } = Spectacle;
+              const theme = defaultTheme({
+                primary: "#ff4081"
+              });
 
-        // Example source code for a source code slide.
-        const exampleDeck = `
-return (
-  <Deck transition={['zoom','slide']} transitionDuration={800}>
-    <Slide bgColor="primary">
-      <Heading size={1} fit caps>
-        React Presentations
-      </Heading>
-      <Heading size={2} fit caps>
-        Written In React
-      </Heading>
-    </Slide>
-    <Slide bgColor="black">
-      <Heading size={1} fit textColor="primary" textFont="secondary">
-        Wait What?
-      </Heading>
-    </Slide>
-    <Slide bgColor="primary" textColor="black" align="center top">
-      <Heading size={1} textColor="black" textFont="primary">
-        Thats right
-      </Heading>
-      <List>
-        <ListItem>Inline style based theme system</ListItem>
-        <ListItem>Autofit Text</ListItem>
-        <ListItem>PDF Export</ListItem>
-      </List>
-    </Slide>
-  </Deck>
-)
-        `.trim();
+              // Example source code for a source code slide.
+              const exampleDeck = `
+      return (
+        <Deck transition={['zoom','slide']} transitionDuration={800}>
+          <Slide bgColor="primary">
+            <Heading size={1} fit caps>
+              React Presentations
+            </Heading>
+            <Heading size={2} fit caps>
+              Written In React
+            </Heading>
+          </Slide>
+          <Slide bgColor="black">
+            <Heading size={1} fit textColor="primary" textFont="secondary">
+              Wait What?
+            </Heading>
+          </Slide>
+          <Slide bgColor="primary" textColor="black" align="center top">
+            <Heading size={1} textColor="black" textFont="primary">
+              Thats right
+            </Heading>
+            <List>
+              <ListItem>Inline style based theme system</ListItem>
+              <ListItem>Autofit Text</ListItem>
+              <ListItem>PDF Export</ListItem>
+            </List>
+          </Slide>
+        </Deck>
+      )
+              `.trim();
 
-        // Interactive code.
-        const { Component } = React;
-        const { Heading } = Spectacle;
+              // Interactive code.
+              const { Component } = React;
+              const { Heading } = Spectacle;
 
-        class Interactive extends Component {
-          constructor() {
-            super();
-            this.state = {
-              count: 0
-            };
-            this.handleClick = this.handleClick.bind(this);
-          }
-          handleClick() {
-            this.setState({
-              count: this.state.count + 1
-            });
-          }
-          render() {
-            const styles = {
-              padding: 20,
-              background: "black",
-              minWidth: 300,
-              marginTop: 20,
-              textTransform: "uppercase",
-              border: "none",
-              color: "white",
-              outline: "none",
-              fontWeight: "bold",
-              fontSize: "2em"
-            };
-            return (
-              <div>
-              {this.state.count < 5 ?
-                <div>
-                  <Heading size={5} textColor="black">
-                    The button has been clicked {this.state.count} times
-                  </Heading>
-                  <button style={styles} type="button" onClick={this.handleClick}>Click Me</button>
-                </div> :
-                  <Heading size={5} fit caps textColor="black">Easy there pal</Heading>
+              class Interactive extends Component {
+                constructor() {
+                  super();
+                  this.state = {
+                    count: 0
+                  };
+                  this.handleClick = this.handleClick.bind(this);
                 }
-              </div>
-            );
-          }
-        }
+                handleClick() {
+                  this.setState({
+                    count: this.state.count + 1
+                  });
+                }
+                render() {
+                  const styles = {
+                    padding: 20,
+                    background: "black",
+                    minWidth: 300,
+                    marginTop: 20,
+                    textTransform: "uppercase",
+                    border: "none",
+                    color: "white",
+                    outline: "none",
+                    fontWeight: "bold",
+                    fontSize: "2em"
+                  };
+                  return (
+                    <div>
+                    {this.state.count < 5 ?
+                      <div>
+                        <Heading size={5} textColor="black">
+                          The button has been clicked {this.state.count} times
+                        </Heading>
+                        <button style={styles} type="button" onClick={this.handleClick}>Click Me</button>
+                      </div> :
+                        <Heading size={5} fit caps textColor="black">Easy there pal</Heading>
+                      }
+                    </div>
+                  );
+                }
+              }
 
-        // --------------------------------------------------------------------
-        // The presentation!
-        // --------------------------------------------------------------------
-        return (
-          <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
-            <Slide transition={["zoom"]} bgColor="primary">
-              <Heading size={1} fit caps lineHeight={1} textColor="black">
-                Spectacle
-              </Heading>
-              <Heading size={1} fit caps>
-                A ReactJS Presentation Library
-              </Heading>
-              <Heading size={1} fit caps textColor="black">
-                Where You Can Write Your Decks In JSX
-              </Heading>
-              <Link href="https://github.com/FormidableLabs/spectacle">
-                <Text bold caps textColor="tertiary">View on Github</Text>
-              </Link>
-              <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
-            </Slide>
-            <Slide id="wait-what" transition={["slide"]} bgColor="black" notes="You can even put notes on your slide. How awesome is that?">
-              <Image src={"https://github.com/FormidableLabs/spectacle/raw/master/example/assets/kat.png"} margin="0px auto 40px" height="293px"/>
-              <Heading size={2} caps fit textColor="primary" textFont="primary">
-                Wait what?
-              </Heading>
-            </Slide>
-            <Slide transition={["zoom", "fade"]} bgColor="primary" notes="<ul><li>talk about that</li><li>and that</li></ul>">
-              <CodePane
-                lang="jsx"
-                source={exampleDeck}
-                margin="20px auto"
-              />
-            </Slide>
-            <Slide>
-              <ComponentPlayground
-                theme="dark"
-              />
-            </Slide>
-            <Slide transition={["slide"]} bgImage={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/city.jpg"} bgDarken={0.75}>
-              <Appear fid="1">
-                <Heading size={1} caps fit textColor="primary">
-                  Full Width
-                </Heading>
-              </Appear>
-              <Appear fid="2">
-                <Heading size={1} caps fit textColor="tertiary">
-                  Adjustable Darkness
-                </Heading>
-              </Appear>
-              <Appear fid="3">
-                <Heading size={1} caps fit textColor="primary">
-                  Background Imagery
-                </Heading>
-              </Appear>
-            </Slide>
-            <Slide transition={["zoom", "fade"]} bgColor="primary">
-              <Heading caps fit>Flexible Layouts</Heading>
-              <Layout>
-                <Fill>
-                  <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                    Left
-                  </Heading>
-                </Fill>
-                <Fill>
-                  <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                    Right
-                  </Heading>
-                </Fill>
-              </Layout>
-            </Slide>
-            <Slide transition={["slide"]} bgColor="black">
-              <BlockQuote>
-                <Quote>Wonderfully formatted quotes</Quote>
-                <Cite>Ken Wheeler</Cite>
-              </BlockQuote>
-            </Slide>
-            <Slide transition={["spin", "zoom"]} bgColor="tertiary">
-              <Heading caps fit size={1} textColor="primary">
-                Inline Markdown
-              </Heading>
-              <Markdown>
-                {`
-![Markdown Logo](https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/markdown.png)
+              // --------------------------------------------------------------------
+              // The presentation!
+              // --------------------------------------------------------------------
+              return (
+                <Deck transition={["zoom", "slide"]} theme={theme} transitionDuration={500}>
+                  <Slide transition={["zoom"]} bgColor="primary">
+                    <Heading size={1} fit caps lineHeight={1} textColor="black">
+                      Spectacle
+                    </Heading>
+                    <Heading size={1} fit caps>
+                      A ReactJS Presentation Library
+                    </Heading>
+                    <Heading size={1} fit caps textColor="black">
+                      Where You Can Write Your Decks In JSX
+                    </Heading>
+                    <Link href="https://github.com/FormidableLabs/spectacle">
+                      <Text bold caps textColor="tertiary">View on Github</Text>
+                    </Link>
+                    <Text textSize="1.5em" margin="20px 0px 0px" bold>Hit Your Right Arrow To Begin!</Text>
+                  </Slide>
+                  <Slide id="wait-what" transition={["slide"]} bgColor="black" notes="You can even put notes on your slide. How awesome is that?">
+                    <Image src={"https://github.com/FormidableLabs/spectacle/raw/master/example/assets/kat.png"} margin="0px auto 40px" height="293px"/>
+                    <Heading size={2} caps fit textColor="primary" textFont="primary">
+                      Wait what?
+                    </Heading>
+                  </Slide>
+                  <Slide transition={["zoom", "fade"]} bgColor="primary" notes="<ul><li>talk about that</li><li>and that</li></ul>">
+                    <CodePane
+                      lang="jsx"
+                      source={exampleDeck}
+                      margin="20px auto"
+                    />
+                  </Slide>
+                  <Slide>
+                    <ComponentPlayground
+                      theme="dark"
+                    />
+                  </Slide>
+                  <Slide transition={["slide"]} bgImage={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/city.jpg"} bgDarken={0.75}>
+                    <Appear fid="1">
+                      <Heading size={1} caps fit textColor="primary">
+                        Full Width
+                      </Heading>
+                    </Appear>
+                    <Appear fid="2">
+                      <Heading size={1} caps fit textColor="tertiary">
+                        Adjustable Darkness
+                      </Heading>
+                    </Appear>
+                    <Appear fid="3">
+                      <Heading size={1} caps fit textColor="primary">
+                        Background Imagery
+                      </Heading>
+                    </Appear>
+                  </Slide>
+                  <Slide transition={["zoom", "fade"]} bgColor="primary">
+                    <Heading caps fit>Flexible Layouts</Heading>
+                    <Layout>
+                      <Fill>
+                        <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                          Left
+                        </Heading>
+                      </Fill>
+                      <Fill>
+                        <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                          Right
+                        </Heading>
+                      </Fill>
+                    </Layout>
+                  </Slide>
+                  <Slide transition={["slide"]} bgColor="black">
+                    <BlockQuote>
+                      <Quote>Wonderfully formatted quotes</Quote>
+                      <Cite>Ken Wheeler</Cite>
+                    </BlockQuote>
+                  </Slide>
+                  <Slide transition={["spin", "zoom"]} bgColor="tertiary">
+                    <Heading caps fit size={1} textColor="primary">
+                      Inline Markdown
+                    </Heading>
+                    <Markdown>
+                      {`
+      ![Markdown Logo](https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/markdown.png)
 
-You can write inline images, [Markdown Links](http://commonmark.org), paragraph text and most other markdown syntax
-* Lists too!
-* With ~~strikethrough~~ and _italic_
-* And let's not forget **bold**
-                `}
-              </Markdown>
-            </Slide>
-            {
-              MarkdownSlides`
-#### Create Multiple Slides in Markdown
-All the same tags and elements supported in <Markdown /> are supported in MarkdownSlides.
----
-Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
-* A Tagged Template Literal
-* Imported Markdown from another file
-              `
+      You can write inline images, [Markdown Links](http://commonmark.org), paragraph text and most other markdown syntax
+      * Lists too!
+      * With ~~strikethrough~~ and _italic_
+      * And let's not forget **bold**
+                      `}
+                    </Markdown>
+                  </Slide>
+                  {
+                    MarkdownSlides`
+      #### Create Multiple Slides in Markdown
+      All the same tags and elements supported in <Markdown /> are supported in MarkdownSlides.
+      ---
+      Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
+      * A Tagged Template Literal
+      * Imported Markdown from another file
+                    `
+                  }
+                  <Slide transition={["slide", "spin"]} bgColor="primary">
+                    <Heading caps fit size={1} textColor="tertiary">
+                      Smooth
+                    </Heading>
+                    <Heading caps fit size={1} textColor="secondary">
+                      Combinable Transitions
+                    </Heading>
+                  </Slide>
+                  <SlideSet>
+                    <Slide transition={["fade"]} bgColor="secondary" textColor="primary">
+                      <List>
+                        <Appear><ListItem>Inline style based theme system</ListItem></Appear>
+                        <Appear><ListItem>Autofit text</ListItem></Appear>
+                        <Appear><ListItem>Flexbox layout system</ListItem></Appear>
+                        <Appear><ListItem>PDF export</ListItem></Appear>
+                        <Appear><ListItem>And...</ListItem></Appear>
+                      </List>
+                    </Slide>
+                    <Slide transition={["slide"]} bgColor="primary">
+                      <Heading size={1} caps fit textColor="tertiary">
+                        Your presentations are interactive
+                      </Heading>
+                      <Interactive/>
+                    </Slide>
+                  </SlideSet>
+                  <Slide transition={["slide"]} bgColor="primary"
+                    notes="Hard to find cities without any pizza"
+                  >
+                    <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
+                      Pizza Toppings
+                    </Heading>
+                    <Layout>
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHeaderItem/>
+                            <TableHeaderItem>2011</TableHeaderItem>
+                            <TableHeaderItem>2013</TableHeaderItem>
+                            <TableHeaderItem>2015</TableHeaderItem>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          <TableRow>
+                            <TableItem>None</TableItem>
+                            <TableItem>61.8%</TableItem>
+                            <TableItem>39.6%</TableItem>
+                            <TableItem>35.0%</TableItem>
+                          </TableRow>
+                          <TableRow>
+                            <TableItem>Pineapple</TableItem>
+                            <TableItem>28.3%</TableItem>
+                            <TableItem>54.5%</TableItem>
+                            <TableItem>61.5%</TableItem>
+                          </TableRow>
+                          <TableRow>
+                            <TableItem>Pepperoni</TableItem>
+                            <TableItem/>
+                            <TableItem>50.2%</TableItem>
+                            <TableItem>77.2%</TableItem>
+                          </TableRow>
+                          <TableRow>
+                            <TableItem>Olives</TableItem>
+                            <TableItem/>
+                            <TableItem>24.9%</TableItem>
+                            <TableItem>55.9%</TableItem>
+                          </TableRow>
+                        </TableBody>
+                      </Table>
+                    </Layout>
+                  </Slide>
+                  <Slide transition={["spin", "slide"]} bgColor="tertiary">
+                    <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
+                      Made with love in Seattle by
+                    </Heading>
+                    <Link href="http://www.formidable.com">
+                      <Image width="100%" src={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/formidable-logo.svg"}/>
+                    </Link>
+                  </Slide>
+                </Deck>
+              );
             }
-            <Slide transition={["slide", "spin"]} bgColor="primary">
-              <Heading caps fit size={1} textColor="tertiary">
-                Smooth
-              </Heading>
-              <Heading caps fit size={1} textColor="secondary">
-                Combinable Transitions
-              </Heading>
-            </Slide>
-            <SlideSet>
-              <Slide transition={["fade"]} bgColor="secondary" textColor="primary">
-                <List>
-                  <Appear><ListItem>Inline style based theme system</ListItem></Appear>
-                  <Appear><ListItem>Autofit text</ListItem></Appear>
-                  <Appear><ListItem>Flexbox layout system</ListItem></Appear>
-                  <Appear><ListItem>PDF export</ListItem></Appear>
-                  <Appear><ListItem>And...</ListItem></Appear>
-                </List>
-              </Slide>
-              <Slide transition={["slide"]} bgColor="primary">
-                <Heading size={1} caps fit textColor="tertiary">
-                  Your presentations are interactive
-                </Heading>
-                <Interactive/>
-              </Slide>
-            </SlideSet>
-            <Slide transition={["slide"]} bgColor="primary"
-              notes="Hard to find cities without any pizza"
-            >
-              <Heading size={4} caps textColor="secondary" bgColor="white" margin={10}>
-                Pizza Toppings
-              </Heading>
-              <Layout>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHeaderItem/>
-                      <TableHeaderItem>2011</TableHeaderItem>
-                      <TableHeaderItem>2013</TableHeaderItem>
-                      <TableHeaderItem>2015</TableHeaderItem>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    <TableRow>
-                      <TableItem>None</TableItem>
-                      <TableItem>61.8%</TableItem>
-                      <TableItem>39.6%</TableItem>
-                      <TableItem>35.0%</TableItem>
-                    </TableRow>
-                    <TableRow>
-                      <TableItem>Pineapple</TableItem>
-                      <TableItem>28.3%</TableItem>
-                      <TableItem>54.5%</TableItem>
-                      <TableItem>61.5%</TableItem>
-                    </TableRow>
-                    <TableRow>
-                      <TableItem>Pepperoni</TableItem>
-                      <TableItem/>
-                      <TableItem>50.2%</TableItem>
-                      <TableItem>77.2%</TableItem>
-                    </TableRow>
-                    <TableRow>
-                      <TableItem>Olives</TableItem>
-                      <TableItem/>
-                      <TableItem>24.9%</TableItem>
-                      <TableItem>55.9%</TableItem>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </Layout>
-            </Slide>
-            <Slide transition={["spin", "slide"]} bgColor="tertiary">
-              <Heading size={1} caps fit lineHeight={1.5} textColor="primary">
-                Made with love in Seattle by
-              </Heading>
-              <Link href="http://www.formidable.com">
-                <Image width="100%" src={"https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/formidable-logo.svg"}/>
-              </Link>
-            </Slide>
-          </Deck>
-        );
-      }
     </script>
-</body>
+  </body>
 </html>

--- a/one-page.html
+++ b/one-page.html
@@ -199,24 +199,24 @@
                     </Heading>
                     <Markdown>
                       {`
-      ![Markdown Logo](https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/markdown.png)
+![Markdown Logo](https://cdn.rawgit.com/FormidableLabs/spectacle/master/example/assets/markdown.png)
 
-      You can write inline images, [Markdown Links](http://commonmark.org), paragraph text and most other markdown syntax
-      * Lists too!
-      * With ~~strikethrough~~ and _italic_
-      * And let's not forget **bold**
+You can write inline images, [Markdown Links](http://commonmark.org), paragraph text and most other markdown syntax
+* Lists too!
+* With ~~strikethrough~~ and _italic_
+* And let's not forget **bold**
                       `}
                     </Markdown>
                   </Slide>
                   {
-                    MarkdownSlides`
-      #### Create Multiple Slides in Markdown
-      All the same tags and elements supported in <Markdown /> are supported in MarkdownSlides.
-      ---
-      Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
-      * A Tagged Template Literal
-      * Imported Markdown from another file
-                    `
+                    MarkdownSlides(`
+#### Create Multiple Slides in Markdown
+All the same tags and elements supported in <Markdown /> are supported in MarkdownSlides.
+---
+Slides are separated with **three dashes** and can be used _anywhere_ in the deck. The markdown can either be:
+* A Tagged Template Literal
+* Imported Markdown from another file
+                    `)
                   }
                   <Slide transition={["slide", "spin"]} bgColor="primary">
                     <Heading caps fit size={1} textColor="tertiary">


### PR DESCRIPTION
### Description

- Fixes CSSStyleDeclaration index property setter error.
- Runs prettier on `one-page.html`, too.

Loosely relates to issue #55 - primarily the last comment on there (from @ebello on 17 Apr)

I feel the original bug in that issue has likely been resolved by the latest version (not directly confirmed), but the issue raised in the comment is fixed by this.

#### Type of Change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tried `one-page.html` before and after: 

- Before, the error occurs on `one-page.html#/12` on Chrome 74\* & Firefox 67\*\*
  - Error doesn't occur on Safari
- After, the error doesn't occur on any slide on Chrome, Firefox, Safari.
  - Works fine with both the `one-page.js` from versions `^4` and `^5` as they are identical, but have updated this to version 5 for consistency

\* Error: `TypeError: Failed to set an indexed property on 'CSSStyleDeclaration': Index property setter is not supported.`
\*\* Error: `TypeError: "CSS2Properties doesn't have an indexed property setter for '0'"`


Checklist: complete