### PR TITLE
htm-branch

### DIFF
--- a/src/one-page/index.html
+++ b/src/one-page/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width initial-scale=1" />
+    <title>Spectacle</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Lobster+Two:400,700"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://unpkg.com/prop-types@15/prop-types.js"></script>
+
+    <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+    ></script>
+
+    <script src="index.js" type="module"></script>
+    <div class="app"></div>
+  </body>
+</html>

--- a/src/one-page/index.js
+++ b/src/one-page/index.js
@@ -1,0 +1,30 @@
+// eslint-disable-next-line import/no-unresolved
+import htm from 'https://unpkg.com/htm?module';
+
+import {
+  Deck,
+  Slide,
+  Heading // eslint-disable-next-line import/no-unresolved
+} from 'https://unpkg.com/spectacle@5.5.0/es/index.js?module';
+
+// eslint-disable-next-line no-undef
+const html = htm.bind(React.createElement);
+
+const Pres = () =>
+  html`
+    <${Deck} >
+        <${Slide} bgColor="offwhite"> 
+            <${Heading}>
+                1
+            </${Heading}> 
+        </${Slide}>
+    </${Deck}>
+  `;
+
+// eslint-disable-next-line no-undef
+ReactDOM.render(
+  html`
+    <${Pres} />
+  `,
+  document.querySelector('.app')
+);


### PR DESCRIPTION
Attempted to create branch that used HTM to load spectacle this should allow us to remove dependency on Babel runtime.

<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist: (Feel free to delete this section upon completion)

- [ ] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have updated type definitions in `index.d.ts` for any breaking API changes
