### PR TITLE
Fix transitionDuration prop for Slide component

### DIFF
--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -8,6 +8,7 @@ import filter from 'lodash/filter';
 import size from 'lodash/size';
 import findIndex from 'lodash/findIndex';
 import get from 'lodash/get';
+import isNil from 'lodash/isNil';
 import { connect } from 'react-redux';
 import { setGlobalStyle, updateFragment } from '../actions';
 import Typeface from './typeface';
@@ -755,7 +756,7 @@ export class Manager extends Component {
       transition: (slide.props.transition || {}).length
         ? slide.props.transition
         : this.props.transition,
-      transitionDuration: (slide.props.transition || {}).transitionDuration
+      transitionDuration: !isNil(slide.props.transitionDuration)
         ? slide.props.transitionDuration
         : this.props.transitionDuration,
       slideReference: this.state.slideReference


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR is a one liner fix for the Issue #685. This line of code (758 in `Manager.js`) was wrong
```
(slide.props.transition || {}).transitionDuration
```
`slide.props.transition` is of type array so this is always `undefined`.

Fixes #685 

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I added a `transitionDuration` prop to `example/src/index.js` and checked that it worked locally.

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)

I'm not sure how to add tests for this. I could do something like...
```
    const wrapper = mount(
      <Manager transitionDuration={111}>
        <MockSlide transitionDuration={222} />
        <MockSlide />
      </Manager>,
      { context: _mockContext(1, []), childContextTypes: _mockChildContext() }
    );
```
But this doesn't quite work because MockSlide should get props added to it via `cloneElement` (line 747 of `Manager.js`) but those added props don't show up in the object returned from `mount`.

Would appreciate some advice.