### PR TITLE
Bug/issue 661 unmounting bug

### DIFF
--- a/src/components/manager.js
+++ b/src/components/manager.js
@@ -213,6 +213,9 @@ export class Manager extends Component {
 
   componentWillUnmount() {
     this._detachEvents();
+    if (this.autoplayInterval) {
+      clearInterval(this.autoplayInterval);
+    }
   }
 
   _attachEvents() {

--- a/src/components/manager.test.js
+++ b/src/components/manager.test.js
@@ -14,6 +14,9 @@ const _mockContext = function(slide, routeParams) {
       controls: {},
       progress: {
         pacman: []
+      },
+      autoplay: {
+        pause: {}
       }
     },
     store: {
@@ -198,5 +201,23 @@ describe('<Manager />', () => {
     // We are at slide 2 (index 1) which directs us to go to
     // slide 4 (index 3) the delta should be 3 - 1, thus 2.
     expect(managerInstance._getOffset(1)).toEqual(2);
+  });
+
+  test('should cancel autoplay when component unmounts', () => {
+    const setIntervalSpy = jest.spyOn(window, 'setInterval');
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+    const wrapper = mount(
+      <Manager autoplay autoplayOnStart>
+        <MockSlide />
+        <MockSlide />
+        <MockSlide />
+      </Manager>,
+      { context: _mockContext(1, []), childContextTypes: _mockChildContext() }
+    );
+    expect(setIntervalSpy.mock.calls.length).toBe(1);
+    wrapper.unmount();
+    // Called once in `Manager._startAutoplay`
+    // and again in `Manager.componentWillUnmount`
+    expect(clearIntervalSpy.mock.calls.length).toBe(2);
   });
 });


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Another one liner fix. We use `setInterval` to pan through the slides automatically (if the user sets the `autoplay` and `autoplayOnStart` props). We just forgot to run `clearInterval` if the component unmounts. Consequently, `_nextSlide` keeps getting run even when the Deck is unmounted, leading to some weird behavior if Deck gets mounted again.

Fixes #661

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

You can reproduce the problem here: https://github.com/FormidableLabs/spectacle/issues/661
To prove the fix worked I did the following:
- cd into `spectacle-bug-demo`
- change the package.json to `"spectacle": "FormidableLabs/spectacle#bug/issue-661-unmounting-bug"`
- cd into `node_modules/spectacle`
- `yarn install` && `yarn build`
- startup the demo and the bug is fixed

I also added a test to Manager.js 