### PR TITLE
Add contentWidth and contentHeight to DeckProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,6 +167,8 @@ declare module 'spectacle' {
     theme?: Theme;
     transition?: transitionType[];
     transitionDuration?: number;
+    contentWidth?: string;
+    contentHeight?: string;
   }
 
   interface FillProps {


### PR DESCRIPTION


<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

The docs call for a number but strings (i.e. 95vw) seem to work fine.  #361 suggested a problem but that code doesn't seem to exist anymore.

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

manually checked that it worked

### Checklist: (Feel free to delete this section upon completion)

- [x] My code follows the style guidelines of this project (I have run `yarn prettier-fix && yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have updated type definitions in `index.d.ts` for any breaking API changes
