### PR TITLE
Fix margin overflow, add line numbers

### DIFF
--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -4,8 +4,7 @@ import Slide from '../../src/components/slide.js';
 import SlideElementWrapper from '../../src/components/slide-element-wrapper';
 import CodePane from '../../src/components/code-pane';
 
-const reactJSCodeBlock = `
-export default function CodePane(props) {
+const reactJSCodeBlock = `export default function CodePane(props) {
   return (
     <Highlight
       {...defaultProps}
@@ -26,24 +25,19 @@ export default function CodePane(props) {
       )}
     </Highlight>
   );
-}
-`;
+}`;
 
-const cppCodeBlock = `
-#include <iostream>
+const cppCodeBlock = `#include <iostream>
 
 int main()
 {
-  auto curried_add = [](int x) -> function<int(int)> {
-    return [=](int y) { return x + y; };
-  };
+  auto curried_add = [](int x) -> function<int(int)> { return [=](int y) { return x + y; }; };
   
   auto answer = curried_add(7)(8);
   std::cout << answer << std::endl;
   
   return 0;
-}
-`;
+}`;
 
 const TestJs = () => (
   <Deck>
@@ -51,7 +45,7 @@ const TestJs = () => (
       <CodePane language="jsx">{reactJSCodeBlock}</CodePane>
     </Slide>
     <Slide slideNum={2}>
-      <CodePane googleFont="Space Mono" fontSize={20} language="cpp">
+      <CodePane fontSize={18} language="cpp">
         {cppCodeBlock}
       </CodePane>
     </Slide>

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -2,34 +2,63 @@ import * as React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import propTypes from 'prop-types';
 import theme from 'prism-react-renderer/themes/vsDark';
-import { GoogleFont } from 'react-typography';
+
+const spaceSearch = /\S|$/;
 
 export default function CodePane(props) {
-  const typography = React.useMemo(
-    () => ({
-      options: {
-        googleFonts: [
-          {
-            name: props.googleFont,
-            styles: ['400']
-          }
-        ]
-      }
-    }),
-    [props.googleFont]
-  );
+  const canvas = React.useRef(document.createElement('canvas'));
+  const context = React.useRef(canvas.current.getContext('2d'));
+
+  const font = React.useMemo(() => {
+    if (props.font && props.font.trim().length > 0) {
+      return props.font;
+    }
+    const { platform } = navigator;
+    if (platform.toLowerCase().search('win') !== -1) {
+      return 'Consolas';
+    } else if (platform.toLowerCase().search('mac') !== -1) {
+      return 'Menlo';
+    } else {
+      return 'monospace';
+    }
+  }, [props.font]);
+
   const preStyles = React.useMemo(
     () => ({
-      fontFamily: `"${props.googleFont}", monospace`,
+      fontFamily: font,
       fontSize: props.fontSize,
       margin: 0,
-      padding: '0 1em'
+      padding: '0 1em 0 0'
     }),
-    [props.googleFont, props.fontSize]
+    [font, props.fontSize]
   );
+
+  const lineNumberStyles = React.useMemo(
+    () => ({
+      padding: '0 1em',
+      borderRight: '1px solid hsla(0, 0%, 0%, 0.25)',
+      background: 'hsla(0, 0%, 0%, 0.1)',
+      flex: '0 1 30px',
+      alignSelf: 'stretch'
+    }),
+    []
+  );
+
+  const measureIndentation = React.useCallback(
+    indentation => {
+      if (indentation === 0) {
+        return 0;
+      }
+      const string = ' '.repeat(indentation);
+      context.current.font = `${props.fontSize}px ${font}`;
+      const measurement = context.current.measureText(string);
+      return measurement.width;
+    },
+    [props.fontSize, font]
+  );
+
   return (
     <>
-      <GoogleFont typography={typography} />
       <Highlight
         {...defaultProps}
         code={props.children}
@@ -38,13 +67,36 @@ export default function CodePane(props) {
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre className={className} style={{ ...style, ...preStyles }}>
-            {tokens.map((line, i) => (
-              <div key={i} {...getLineProps({ line, key: i })}>
-                {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({ token, key })} />
-                ))}
-              </div>
-            ))}
+            {tokens.map((line, i) => {
+              const lineProps = getLineProps({ line, key: i });
+              const lineIndentation = line[0].content.search(spaceSearch);
+              lineProps.style = {
+                ...(lineProps.style || {}),
+                whiteSpace: 'pre-wrap',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-start'
+              };
+              if (line[0].content && !line[0].empty) {
+                line[0].content = line[0].content.trimLeft();
+              }
+              return (
+                <div key={i} {...lineProps}>
+                  <div style={lineNumberStyles}>{i + 1}</div>
+                  <div
+                    style={{
+                      marginLeft: measureIndentation(lineIndentation),
+                      flex: 1,
+                      paddingLeft: '0.25em'
+                    }}
+                  >
+                    {line.map((token, key) => (
+                      <span key={key} {...getTokenProps({ token, key })} />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
           </pre>
         )}
       </Highlight>
@@ -54,8 +106,8 @@ export default function CodePane(props) {
 
 CodePane.propTypes = {
   children: propTypes.string.isRequired,
+  font: propTypes.string,
   fontSize: propTypes.number,
-  googleFont: propTypes.string,
   language: propTypes.string.isRequired,
   theme: propTypes.object
 };
@@ -63,6 +115,5 @@ CodePane.propTypes = {
 CodePane.defaultProps = {
   language: 'javascript',
   theme: theme,
-  fontSize: 15,
-  googleFont: 'Fira Code'
+  fontSize: 15
 };

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -5,6 +5,14 @@ import theme from 'prism-react-renderer/themes/vsDark';
 
 const spaceSearch = /\S|$/;
 
+const lineNumberStyles = {
+  padding: '0 1em',
+  borderRight: '1px solid hsla(0, 0%, 0%, 0.25)',
+  background: 'hsla(0, 0%, 0%, 0.1)',
+  flex: '0 1 30px',
+  alignSelf: 'stretch'
+};
+
 export default function CodePane(props) {
   const canvas = React.useRef(document.createElement('canvas'));
   const context = React.useRef(canvas.current.getContext('2d'));
@@ -31,17 +39,6 @@ export default function CodePane(props) {
       padding: '0 1em 0 0'
     }),
     [font, props.fontSize]
-  );
-
-  const lineNumberStyles = React.useMemo(
-    () => ({
-      padding: '0 1em',
-      borderRight: '1px solid hsla(0, 0%, 0%, 0.25)',
-      background: 'hsla(0, 0%, 0%, 0.1)',
-      flex: '0 1 30px',
-      alignSelf: 'stretch'
-    }),
-    []
   );
 
   const measureIndentation = React.useCallback(


### PR DESCRIPTION
### Description

Previously the Code Slide would cause longer lines of code to go out of bounds on the screen forcing a horizontal scroll. Now we wrap it like an IDE.

*How it used to look*
<img width="1038" alt="Screen Shot 2019-09-02 at 7 48 31 AM" src="https://user-images.githubusercontent.com/1738349/64130909-e0ab1480-cd8a-11e9-8da6-fb2d69d6a3d9.png">


We also add line numbers and support both dark and light themes using transparent backgrounds and lines. The line numbers use the foreground color of the default text in the theme, so there should be no color collisions.

This also fixes the default fonts for each platform and removes the Google Font feature. To get the correct calculation using Canvas Context, the fonts need to exist on the system. Code Panel will now support any _installed_ font and have fallbacks for common monospace fonts on macOS and Windows.

We calculate the size of the spaces for indentation and trim whitespace. This lets us pad the entire line so the margins are correct for wrapped lines. It also lets us attach line numbers and a gutter for the entire line.

### How Has This Been Tested?

<img width="888" alt="Screen Shot 2019-09-02 at 1 30 11 PM" src="https://user-images.githubusercontent.com/1738349/64130596-fb7c8980-cd88-11e9-93a8-fd817414303e.png">

<img width="891" alt="Screen Shot 2019-09-02 at 1 29 55 PM" src="https://user-images.githubusercontent.com/1738349/64130598-fddee380-cd88-11e9-99a2-d216e84b5eb5.png">

<img width="891" alt="Screen Shot 2019-09-02 at 1 30 17 PM" src="https://user-images.githubusercontent.com/1738349/64130599-ffa8a700-cd88-11e9-866b-e3a39c6889e3.png">

