### PR TITLE
Override theme via CLI

### DIFF
--- a/bin/actions.js
+++ b/bin/actions.js
@@ -21,7 +21,7 @@ const launchServer = (configUpdates = {}) => {
   });
 };
 
-const launchMDXServer = mdxFilePath => {
+const launchMDXServer = (mdxFilePath, themeFilePath) => {
   if (!mdxFilePath) {
     // developer error - must supply an entry file path
     throw new Error('MDX file path must be provided.');
@@ -31,14 +31,20 @@ const launchMDXServer = mdxFilePath => {
   const absoluteMdxFilePath = path.resolve(mdxFilePath);
   const nodeModules = path.resolve(__dirname, '../node_modules');
 
+  const alias = {
+    'spectacle-user-mdx': absoluteMdxFilePath
+  };
+  if (themeFilePath) {
+    const absoluteThemeFilePath = path.resolve(themeFilePath);
+    alias['spectacle-user-theme'] = absoluteThemeFilePath;
+  }
+
   const configUpdates = {
     mode: 'development',
     context: cliRoot,
     entry: './mdx-slides/index.js',
     resolve: {
-      alias: {
-        'spectacle-user-mdx': absoluteMdxFilePath
-      },
+      alias,
       modules: [nodeModules]
     }
   };

--- a/bin/args.js
+++ b/bin/args.js
@@ -3,9 +3,9 @@ const validatePresentationMode = require('./validate/presentation-mode');
 
 const validate = async parser => {
   const { argv } = parser;
-  const { src } = argv;
+  const { src, theme } = argv;
 
-  return await validatePresentationMode(src);
+  return await validatePresentationMode(src, theme);
 };
 
 const args = () =>
@@ -17,6 +17,11 @@ const args = () =>
       alias: 's',
       describe: 'Path to a file from which a presentation will be generated.',
       default: 'slides.mdx',
+      type: 'string'
+    })
+    .option('theme', {
+      alias: 't',
+      describe: 'Path to a JS file that contains theme overrides.',
       type: 'string'
     })
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,8 +9,9 @@ const main = () =>
     .then(args.parse)
     .then(parsedInput => {
       const mdxFilePath = parsedInput.mdx;
+      const themeFilePath = parsedInput.theme;
       if (mdxFilePath) {
-        actions.launchMDXServer(mdxFilePath);
+        actions.launchMDXServer(mdxFilePath, themeFilePath);
       }
       // add future actions here
       else {

--- a/bin/validate/presentation-mode.js
+++ b/bin/validate/presentation-mode.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 
 const isMDXFileType = extension => extension === '.mdx' || extension === '.md';
+const isJSFileType = extension => extension === '.js';
 
 const fileExists = srcPath => {
   const absSrcPath = path.resolve(srcPath);
@@ -12,29 +13,48 @@ const fileExists = srcPath => {
   });
 };
 
-const validatePresentationMode = async src => {
+const validatePresentationMode = async (src, theme) => {
   /* - the default action of the CLI is to boot up a presentation from a file
    * - src defaults to `slides.mdx`
+   * - theme has no default
    * - first, check to see if the file type is supported
    * - then check to see if the default or provided file exists
    */
 
   const validatedValue = {};
-  const extension = path.extname(src);
+  const srcExtension = path.extname(src);
 
-  if (isMDXFileType(extension)) {
+  if (isMDXFileType(srcExtension)) {
     validatedValue['mdx'] = src;
   }
   // support other file types here
   else {
-    throw new Error(`The file type ${extension} is not currently supported.`);
+    throw new Error(
+      `The file type "${srcExtension}" is not currently supported for MDX presentations.`
+    );
   }
 
-  const exists = await fileExists(src);
-  if (!exists) {
+  const mdxExists = await fileExists(src);
+  if (!mdxExists) {
     throw new Error(
-      `A file cannot be found at the path "${src}". Remember that the default file is ./slides.mdx`
+      `A md(x) file cannot be found at the path "${src}". Remember that the default file is ./slides.mdx`
     );
+  }
+
+  if (theme) {
+    const themeExtension = path.extname(theme);
+    if (isJSFileType(themeExtension)) {
+      validatedValue['theme'] = theme;
+    } else {
+      throw new Error(
+        `The file type "${themeExtension}" is not currently supported for theme extensions.`
+      );
+    }
+
+    const themeExists = await fileExists(theme);
+    if (!themeExists) {
+      throw new Error(`A theme file cannot be found at the path "${src}".`);
+    }
   }
 
   return validatedValue;

--- a/mdx-slides/index.js
+++ b/mdx-slides/index.js
@@ -12,7 +12,7 @@ import {
 } from '../src/components';
 const formidableLogo = require('../examples/js/formidable.png');
 
-// See the webpack config to see how this import alias is made
+// See the cli actions.js to see how this import alias is made
 import slides, { notes } from 'spectacle-user-mdx';
 import mdxComponentMap from '../src/utils/mdx-component-mapper';
 

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -7,7 +7,7 @@ import isComponentType from '../../utils/is-component-type';
 import useUrlRouting from '../../hooks/use-url-routing';
 import PresenterDeck from './presenter-deck';
 import AudienceDeck from './audience-deck';
-import defaultTheme from '../../theme/default-theme';
+import theme from '../../theme';
 import { animated, useTransition } from 'react-spring';
 import {
   TransitionPipeContext,
@@ -239,7 +239,7 @@ Deck.propTypes = {
 };
 
 const ConnectedDeck = props => (
-  <ThemeProvider theme={defaultTheme}>
+  <ThemeProvider theme={theme}>
     <TransitionPipeProvider>
       <Deck {...props} />
     </TransitionPipeProvider>

--- a/src/components/deck/presenter-deck.js
+++ b/src/components/deck/presenter-deck.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DeckContext } from '../../hooks/use-deck';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { compose, color, typography } from 'styled-system';
 import { Heading, Text } from '../typography';
-import defaultTheme from '../../theme/default-theme';
 import * as queryString from 'query-string';
 
 const PresenterDeckContainer = styled('div')`
@@ -45,15 +45,23 @@ const SlideDivider = styled('div')`
   height: 2em;
 `;
 
-const Button = styled('button')`
-  border: 0;
-  width: 250px;
-  padding: 1em;
-  margin-bottom: 1em;
-  background-color: ${defaultTheme.colors.secondary};
-  color: ${defaultTheme.colors.primary};
-  font-size: ${defaultTheme.fontSizes.text};
-`;
+const Button = styled('button')(
+  compose(
+    color,
+    typography
+  ),
+  css`
+    border: 0;
+    width: 300px;
+    padding: 1em;
+    margin-bottom: 1em;
+  `
+);
+Button.defaultProps = {
+  backgroundColor: 'secondary',
+  color: 'primary',
+  fontSize: 'text'
+};
 
 const PresenterDeck = props => {
   const {

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,22 @@
+import defaultTheme from './default-theme';
+let userTheme;
+try {
+  // see cli actions.js to understand this import
+  // if the user doesn't specify a theme, this require will throw
+  userTheme = require('spectacle-user-theme').default;
+} catch (e) {
+  userTheme = {};
+}
+
+const mergedTheme = { ...defaultTheme };
+if (userTheme && Object.keys(userTheme).length > 0) {
+  for (const key in defaultTheme) {
+    const userThemeCategory = userTheme[key];
+    const defaultThemeCategory = defaultTheme[key];
+    if (userThemeCategory) {
+      mergedTheme[key] = { ...defaultThemeCategory, ...userThemeCategory };
+    }
+  }
+}
+
+export default mergedTheme;


### PR DESCRIPTION
### Description
This PR introduces the ability to override the default theme when starting a presentation from the CLI. The user can override portions or all of the default theme. **The theme file must be a JavaScript file.**

To understand how to override the theme, first look at the default theme: https://github.com/FormidableLabs/spectacle/blob/task/rewrite/src/theme/default-theme.js.

Notice that there are categories within the theme, e.g. `colors`, `space`, etc. Your theme override JS file must follow the same structure. If you want to override the secondary color and header margin, then your theme file would look like this:
```
export default {
  colors: {
    secondary: 'blue',
  },
  space: {
    headerMargin: '30px 20px',
  }
};
```

### How to Test
1. ensure that spectacle is linked (`npm link` from the root of spectacle project)
2. navigate to the directory where your md(x) and theme files exist
3. run `spectacle -s <mdx-file-path> -t <theme-file-path>`

Note that the file paths provided to the CLI are relative, so those files don't necessary _have_ to be colocated.