### PR TITLE
better solution for aliasing user theme

### DIFF
--- a/bin/actions.js
+++ b/bin/actions.js
@@ -37,6 +37,12 @@ const launchMDXServer = (mdxFilePath, themeFilePath) => {
   if (themeFilePath) {
     const absoluteThemeFilePath = path.resolve(themeFilePath);
     alias['spectacle-user-theme'] = absoluteThemeFilePath;
+  } else {
+    const backupTheme = path.resolve(
+      __dirname,
+      '../src/theme/backup-user-theme'
+    );
+    alias['spectacle-user-theme'] = backupTheme;
   }
 
   const configUpdates = {

--- a/src/theme/backup-user-theme.js
+++ b/src/theme/backup-user-theme.js
@@ -1,0 +1,2 @@
+// if the user does not specify a theme, we still need our alias to point somewhere
+module.exports = {};

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,12 +1,6 @@
 import defaultTheme from './default-theme';
-let userTheme;
-try {
-  // see cli actions.js to understand this import
-  // if the user doesn't specify a theme, this require will throw
-  userTheme = require('spectacle-user-theme').default;
-} catch (e) {
-  userTheme = {};
-}
+// see cli actions.js to understand this import
+let userTheme = require('spectacle-user-theme').default;
 
 const mergedTheme = { ...defaultTheme };
 if (userTheme && Object.keys(userTheme).length > 0) {


### PR DESCRIPTION
### Description

Instead of try/catch-ing a faulty alias for user-supplied theme, this PR provides a backup file for the alias. Test it the same way you might test [this PR](https://github.com/FormidableLabs/spectacle/pull/727).