### PR TITLE
Add Alias for default theme when none is supplied in JSX mode

### DIFF
--- a/bin/actions.js
+++ b/bin/actions.js
@@ -35,14 +35,9 @@ const launchMDXServer = (mdxFilePath, themeFilePath) => {
     'spectacle-user-mdx': absoluteMdxFilePath
   };
   if (themeFilePath) {
-    const absoluteThemeFilePath = path.resolve(themeFilePath);
-    alias['spectacle-user-theme'] = absoluteThemeFilePath;
+    alias['spectacle-user-theme'] = path.resolve(themeFilePath);
   } else {
-    const backupTheme = path.resolve(
-      __dirname,
-      '../src/theme/backup-user-theme'
-    );
-    alias['spectacle-user-theme'] = backupTheme;
+    alias['spectacle-user-theme'] = config.resolve.alias['spectacle-user-theme'];
   }
 
   const configUpdates = {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^16.7.0",
     "tslint": "^5.12.1",
     "typescript": "^3.2.2",
-    "webpack": "^4.33.0",
+    "webpack": "^4.40.2",
     "webpack-cli": "^3.3.4",
     "webpack-dev-server": "^3.7.1"
   },

--- a/src/theme/backup-user-theme.js
+++ b/src/theme/backup-user-theme.js
@@ -1,2 +1,3 @@
 // if the user does not specify a theme, we still need our alias to point somewhere
-module.exports = {};
+export default {};
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,5 +72,13 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: `./index.html`
     })
-  ]
+  ],
+  resolve: {
+    alias: {
+      'spectacle-user-theme': path.resolve(
+        __dirname,
+        './src/theme/backup-user-theme'
+      )
+    }
+  }
 };


### PR DESCRIPTION
Fixes the use theme alias for JSX-mode. Confirmed still works for MDX/CLI-mode!

<img width="997" alt="Screen Shot 2019-09-23 at 4 33 23 PM" src="https://user-images.githubusercontent.com/1738349/65464774-4df91500-de20-11e9-80f2-0c72a5c28bcb.png">
<img width="266" alt="Screen Shot 2019-09-23 at 4 33 30 PM" src="https://user-images.githubusercontent.com/1738349/65464775-4df91500-de20-11e9-8b18-a81e9ae9495b.png">

