### PR TITLE
Document creating slide templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ const theme = createTheme(
 
 The returned theme object can then be passed to the `Deck` tag via the `theme` prop, and will override the default styles.
 
+#### Slide Templates
+
+GitHub user [@boardfish](https://github.com/boardfish) has documented an approach to using [higher-order components](https://reactjs.org/docs/higher-order-components.html) to create slide templates at [this repository](https://github.com/boardfish/spectacle-slide-templates).
+
 <a name="faq"></a>
 
 ## FAQ


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Adds a link to my repo that demonstrates a method of creating slide
templates. As explained on the original issue, this could change
entirely when the Spectacle API changes, but for now it's good to have
documented.

Closes #655

#### Type of Change

- [x] This change requires a documentation update

### How Has This Been Tested?

I haven't tried this since originally having worked on it with the
Spectacle release that was available at the time, but if comments on the
issue are anything to go by, it's still up to scratch. I may have the
time to do this at some point if necessary.