### PR TITLE
Added new Markdown Component

### DIFF
--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -16,7 +16,8 @@ import {
   Grid,
   Notes,
   FullScreen,
-  Progress
+  Progress,
+  Markdown
 } from '../../src/';
 
 const formidableLogo = require('./formidable.png');
@@ -135,6 +136,29 @@ const TestJs = () => (
           ))}
       </Grid>
     </Slide>
+    <Slide>
+      <Markdown>
+        {`
+          ### Paying for too much Lambda memory?
+          - Yes you are!
+          
+          \`\`\`js
+          fields @timestamp, res.duration
+          | filter res.duration > 0
+          | sort @timestamp desc
+          | limit 20
+          | stats min(res.duration), avg(res.duration), max(res.duration) by bin(30m)
+          \`\`\`
+        `}
+      </Markdown>
+    </Slide>
+    <Markdown containsSlides>
+      {`
+        ### First MD generated Slide
+        ---
+        ### Second MD Generated Slide
+      `}
+    </Markdown>
   </Deck>
 );
 

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -39,7 +39,8 @@
         Text,
         UnorderedList,
         Grid,
-        Notes
+        Notes,
+        Markdown
       } = Spectacle;
       import htm from 'https://unpkg.com/htm@2.2.1?module';
       const html = htm.bind(React.createElement);
@@ -161,6 +162,33 @@
                     `
                 )}
             <//>
+          <//>
+          <${Slide}>
+            <${Markdown}>
+              ${`
+                ### Paying for too much Lambda memory?
+                - Yes you are!
+
+                \`\`\`js
+                fields @timestamp, res.duration
+                | filter res.duration > 0
+                | sort @timestamp desc
+                | limit 20
+                | stats min(res.duration), avg(res.duration), max(res.duration) by bin(30m)
+                \`\`\`
+              `}
+            <//>
+          <//>
+          <${Markdown} containsSlides>
+            ${`
+              ### First MD Generated Slide
+              - A list item
+              - Another
+              ---
+              ### Second MD Generated Slide
+              1. An ordered list item
+              2. Second
+            `}
           <//>
         <//>
       `;

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "gray-matter": "^4.0.2",
     "history": "^4.9.0",
     "loader-utils": "^1.2.3",
+    "marksy": "^8.0.0",
     "normalize-newline": "^3.0.0",
     "prism-react-renderer": "^0.1.7",
     "query-string": "^6.8.2",

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -23,6 +23,8 @@ import {
 } from '../../utils/constants';
 import searchChildrenForAppear from '../../utils/search-children-appear';
 import OverviewDeck from './overview-deck';
+import { Markdown, Slide } from '../../index';
+import indentNormalizer from '../../utils/indent-normalizer';
 
 const AnimatedDeckDiv = styled(animated.div)`
   height: 100vh;
@@ -71,6 +73,13 @@ const initialState = {
   resolvedInitialUrl: false
 };
 
+const splitMarkdownIntoSlides = md =>
+  md.split(/\n\s*---\n/).map((markdown, index) => (
+    <Slide key={`md-slide-${index}`}>
+      <Markdown>{markdown}</Markdown>
+    </Slide>
+  ));
+
 const Deck = ({
   children,
   loop,
@@ -79,8 +88,20 @@ const Deck = ({
   ...rest
 }) => {
   // Check for slides and then number slides.
+
   const filteredChildren = Array.isArray(children)
-    ? children.filter(x => isComponentType(x, 'Slide'))
+    ? children
+        .map(x => {
+          if (
+            isComponentType(x, 'Markdown') &&
+            Boolean(x.props.containsSlides)
+          ) {
+            return splitMarkdownIntoSlides(x.props.children);
+          }
+          return x;
+        })
+        .flat(1)
+        .filter(x => isComponentType(x, 'Slide'))
     : console.error('No children passed') || [];
 
   const numberOfSlides = filteredChildren.length;

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import propTypes from 'prop-types';
+import marksy from 'marksy';
+import mdxComponentMap from '../utils/mdx-component-mapper';
+import indentNormalizer from '../utils/indent-normalizer';
+import { CodePane, Slide } from '../index';
+
+const _CodePane = ({ language, code }) => (
+  <CodePane language={language}>{code}</CodePane>
+);
+
+const compile = marksy({
+  createElement: React.createElement,
+  elements: {
+    ...mdxComponentMap,
+    codeblock: _CodePane,
+    code: _CodePane
+  }
+});
+
+const Markdown = props => {
+  return <>{compile(indentNormalizer(props.children)).tree}</>;
+};
+
+Markdown.propTypes = {
+  children: propTypes.string.isRequired,
+  containsSlides: propTypes.bool
+};
+
+export default Markdown;

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { Image, FullSizeImage } from './components/image';
 import Notes from './components/notes';
 import Progress from './components/progress';
 import FullScreen from './components/fullscreen';
+import Markdown from './components/markdown';
 
 export {
   Deck,
@@ -38,5 +39,6 @@ export {
   CodeSpan,
   Notes,
   Progress,
-  FullScreen
+  FullScreen,
+  Markdown
 };

--- a/src/utils/indent-normalizer.js
+++ b/src/utils/indent-normalizer.js
@@ -1,0 +1,18 @@
+// Indent to smallest non-empty whitespace level and trim start / end of string.
+const indentNormalizer = val => {
+  let prefix = null;
+  return (val || '')
+    .split('\n')
+    .filter(line => {
+      const [cur, remainder] = (line.match(/^([ ]*)([^ ]+)/) || []).slice(1);
+      return remainder
+        ? ((prefix =
+            null === prefix || cur.length < prefix.length ? cur : prefix),
+          !0)
+        : null !== prefix;
+    })
+    .map(line => (prefix ? line.replace(prefix, '') : line))
+    .join('\n')
+    .trimRight();
+};
+export default indentNormalizer;


### PR DESCRIPTION
Adds new Markdown Component to Spectacle

The new Markdown component can either be used to add content within a slide or be used top-level under `<Deck />` to add 1...n slides using the `---` delimiter. 

Example Usages:

```jsx
<Deck>
  <Slide>
      <Markdown>
        {`
          ### Paying for too much Lambda memory?
          - Yes you are!
          
          \`\`\`js
          fields @timestamp, res.duration
          | filter res.duration > 0
          | sort @timestamp desc
          | limit 20
          | stats min(res.duration), avg(res.duration), max(res.duration) by bin(30m)
          \`\`\`
        `}
      </Markdown>
    </Slide>
    <Markdown containsSlides>
      {`
        ### First MD generated Slide
        ---
        ### Second MD Generated Slide
      `}
    </Markdown>
  </Deck>
```

Tested in regular, overview, and presentation modes:

<img width="554" alt="Screen Shot 2019-10-23 at 7 30 32 AM" src="https://user-images.githubusercontent.com/1738349/67393148-66676700-f567-11e9-8376-ce4ad0f02988.png">
<img width="1044" alt="Screen Shot 2019-10-23 at 7 31 04 AM" src="https://user-images.githubusercontent.com/1738349/67393149-66676700-f567-11e9-8de7-4ecfc089061d.png">
