### PR TITLE
Add base JS-based auto sizing

### DIFF
--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -26,13 +26,13 @@ const cppCodeBlock = `#include <iostream>
 #include <sstream>
 #include <pthread.h>
 
-struct thread_data_t 
+struct thread_data_t
 {
    int  thread_id;
    std::string message;
 };
 
-void *print_thread_message(void *thread_arg) 
+void *print_thread_message(void *thread_arg)
 {
    struct thread_data_t *thread_data;
    thread_data = (struct thread_data_t *) thread_arg;
@@ -47,19 +47,19 @@ int main()
 {
   pthread_t threads[NUM_THREADS];
   struct thread_data_t thread_data[NUM_THREADS];
-  
-  for (int i = 0; i < NUM_THREADS; i++) 
+
+  for (int i = 0; i < NUM_THREADS; i++)
   {
     auto curried_add = [](int x) -> function<int(int)> { return [=](int y) { return x + y; }; };
     auto answer = curried_add(i)(5);
-    
+
     std::stringstream message;
     message << "The math result is " << answer << "!";
     thread_data.thread_id = i;
     thread_data.message = message.str();
     int err = pthread_create(&threads, NULL, print_thread_message, (void *)&thread_data[i]);
-    
-    if (err) 
+
+    if (err)
     {
       exit(-1)
     }
@@ -111,7 +111,6 @@ const TestJs = () => (
     </Slide>
     <Slide>
       <Text>Multithreading in C++</Text>
-
       <CodePane fontSize={18} language="cpp" autoFillHeight>
         {cppCodeBlock}
       </CodePane>
@@ -179,7 +178,7 @@ const TestJs = () => (
         {`
           ### Paying for too much Lambda memory?
           - Yes you are!
-          
+
           \`\`\`js
           fields @timestamp, res.duration
           | filter res.duration > 0

--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -110,7 +110,7 @@ const TestJs = () => (
       </Notes>
     </Slide>
     <Slide>
-      <Text>Multithreading in C++</Text>
+      <Heading>Hi There</Heading>
       <CodePane fontSize={18} language="cpp" autoFillHeight>
         {cppCodeBlock}
       </CodePane>

--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -22,13 +22,48 @@ import {
 
 const formidableLogo = require('./formidable.png');
 const cppCodeBlock = `#include <iostream>
+#include <cstdlib>
+#include <sstream>
+#include <pthread.h>
+
+struct thread_data_t 
+{
+   int  thread_id;
+   std::string message;
+};
+
+void *print_thread_message(void *thread_arg) 
+{
+   struct thread_data_t *thread_data;
+   thread_data = (struct thread_data_t *) thread_arg;
+
+   cout << "Thread ID: " << thread_data->thread_id;
+   cout << "Message: " << thread_data->message << endl;
+
+   pthread_exit(NULL);
+}
 
 int main()
 {
-  auto curried_add = [](int x) -> function<int(int)> { return [=](int y) { return x + y; }; };
-
-  auto answer = curried_add(7)(8);
-  std::cout << answer << std::endl;
+  pthread_t threads[NUM_THREADS];
+  struct thread_data_t thread_data[NUM_THREADS];
+  
+  for (int i = 0; i < NUM_THREADS; i++) 
+  {
+    auto curried_add = [](int x) -> function<int(int)> { return [=](int y) { return x + y; }; };
+    auto answer = curried_add(i)(5);
+    
+    std::stringstream message;
+    message << "The math result is " << answer << "!";
+    thread_data.thread_id = i;
+    thread_data.message = message.str();
+    int err = pthread_create(&threads, NULL, print_thread_message, (void *)&thread_data[i]);
+    
+    if (err) 
+    {
+      exit(-1)
+    }
+  }
 
   return 0;
 }`;
@@ -75,9 +110,12 @@ const TestJs = () => (
       </Notes>
     </Slide>
     <Slide>
-      <CodePane fontSize={18} language="cpp">
+      <Text>Multithreading in C++</Text>
+
+      <CodePane fontSize={18} language="cpp" autoFillHeight>
         {cppCodeBlock}
       </CodePane>
+      <Text>Lots of pointers!</Text>
       <Notes>
         <p>
           This is a code pane! It can support multiple programming languages.

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -47,7 +47,7 @@ export default function CodePane(props) {
     () => ({
       fontFamily: font,
       fontSize: fontSize,
-      maxHeight: themeContext.size.maxCodePaneHeight || 300,
+      maxHeight: themeContext.size.maxCodePaneHeight || 200,
       overflow: 'scroll',
       margin: 0,
       padding: '0.5em 1em 0.5em 0'
@@ -77,7 +77,11 @@ export default function CodePane(props) {
         theme={theme}
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
-          <pre className={className} style={{ ...style, ...preStyles }}>
+          <pre
+            className={`${className} ${props.autoFillHeight &&
+              'spectacle-auto-height-fill'}`}
+            style={{ ...style, ...preStyles }}
+          >
             {tokens.map((line, i) => {
               const lineProps = getLineProps({ line, key: i });
               const lineIndentation = line[0].content.search(spaceSearch);
@@ -116,6 +120,7 @@ export default function CodePane(props) {
 }
 
 CodePane.propTypes = {
+  autoFillHeight: propTypes.bool,
   children: propTypes.string.isRequired,
   fontSize: propTypes.number,
   language: propTypes.string.isRequired,

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -3,10 +3,12 @@ import propTypes from 'prop-types';
 import marksy from 'marksy';
 import mdxComponentMap from '../utils/mdx-component-mapper';
 import indentNormalizer from '../utils/indent-normalizer';
-import { CodePane, Slide } from '../index';
+import { CodePane } from '../index';
 
 const _CodePane = ({ language, code }) => (
-  <CodePane language={language}>{code}</CodePane>
+  <CodePane autoFillHeight language={language}>
+    {code}
+  </CodePane>
 );
 
 const compile = marksy({

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -24,6 +24,15 @@ const TemplateWrapper = styled('div')`
   z-index: -1;
 `;
 
+const getNodeFullHeight = node => {
+  const style = getComputedStyle(node);
+  return (
+    node.offsetHeight +
+    parseFloat(style.marginTop) +
+    parseFloat(style.marginBottom)
+  );
+};
+
 /**
  * Slide component wraps anything going in a slide and maintains
  * the slides' internal state through useSlide.
@@ -98,15 +107,11 @@ const Slide = props => {
         const currentNodeIsAutoFill = current.classList.contains(
           'spectacle-auto-height-fill'
         );
-        const style = getComputedStyle(current);
-        const nodeHeight =
-          current.offsetHeight +
-          parseFloat(style.marginTop) +
-          parseFloat(style.marginBottom);
+        const nodeHeight = getNodeFullHeight(current);
         return {
           totalHeight: nodeHeight + memo.totalHeight,
           autoFillsHeight: currentNodeIsAutoFill
-            ? current.clientHeight + memo.autoFillsHeight
+            ? nodeHeight + memo.autoFillsHeight
             : memo.autoFillsHeight,
           numberAutoFills: currentNodeIsAutoFill
             ? memo.numberAutoFills + 1
@@ -119,20 +124,19 @@ const Slide = props => {
     if (templateRef.current.hasChildNodes()) {
       const templateChildNodes = [].slice.call(templateRef.current.childNodes);
       metrics.templateHeight = templateChildNodes.reduce((memo, current) => {
-        const style = getComputedStyle(current);
-        const nodeHeight =
-          current.offsetHeight +
-          parseFloat(style.marginTop) +
-          parseFloat(style.marginBottom);
+        const nodeHeight = getNodeFullHeight(current);
+        console.log(nodeHeight);
         return (memo += nodeHeight);
       }, 0);
     } else {
       metrics.templateHeight = 0;
     }
 
-    const emptySpace =
-      slideHeight -
-      (metrics.totalHeight - metrics.autoFillsHeight + metrics.templateHeight);
+    console.log(metrics);
+
+    const emptySpace = 0;
+
+    console.log(emptySpace);
 
     childNodes.forEach(node => {
       const currentNodeIsAutoFill = node.classList.contains(

--- a/src/components/typography.js
+++ b/src/components/typography.js
@@ -110,7 +110,7 @@ const ListItem = styled('li')(
 
 ListItem.defaultProps = {
   margin: 'listMargin'
-}
+};
 
 export {
   Text,

--- a/src/hooks/use-autofill-height.js
+++ b/src/hooks/use-autofill-height.js
@@ -1,0 +1,77 @@
+import * as React from 'react';
+
+const getNodeFullHeight = node => {
+  const style = getComputedStyle(node);
+  let nextSiblingMarginTop = 0;
+  if (node.nextSibling) {
+    nextSiblingMarginTop = parseFloat(
+      getComputedStyle(node.nextSibling).marginTop
+    );
+  }
+  return (
+    node.offsetHeight +
+    parseFloat(style.marginTop) -
+    nextSiblingMarginTop +
+    parseFloat(style.marginBottom)
+  );
+};
+
+export default function useAutofillHeight({
+  slideWrapperRef,
+  contentRef,
+  templateRef,
+  slideHeight
+}) {
+  React.useLayoutEffect(() => {
+    if (!contentRef.current.hasChildNodes()) {
+      return;
+    }
+    const childNodes = [].slice.call(contentRef.current.childNodes);
+    const metrics = childNodes.reduce(
+      (memo, current) => {
+        const currentNodeIsAutoFill = current.classList.contains(
+          'spectacle-auto-height-fill'
+        );
+        const nodeHeight = currentNodeIsAutoFill
+          ? 0
+          : getNodeFullHeight(current);
+        return {
+          totalHeight: nodeHeight + memo.totalHeight,
+          numberAutoFills: currentNodeIsAutoFill
+            ? memo.numberAutoFills + 1
+            : memo.numberAutoFills
+        };
+      },
+      { totalHeight: 0, autoFillsHeight: 0, numberAutoFills: 0 }
+    );
+
+    if (templateRef.current.hasChildNodes()) {
+      const templateChildNodes = [].slice.call(templateRef.current.childNodes);
+      metrics.templateHeight = templateChildNodes.reduce((memo, current) => {
+        const nodeHeight = getNodeFullHeight(current);
+        return memo + nodeHeight;
+      }, 0);
+    } else {
+      metrics.templateHeight = 0;
+    }
+
+    const slideWrapperStyle = getComputedStyle(slideWrapperRef.current);
+    const totalSlideSpace =
+      slideHeight -
+      (parseFloat(slideWrapperStyle.paddingTop) +
+        parseFloat(slideWrapperStyle.paddingBottom));
+
+    const emptySpace =
+      totalSlideSpace - (metrics.totalHeight + metrics.templateHeight);
+
+    childNodes.forEach(node => {
+      const currentNodeIsAutoFill = node.classList.contains(
+        'spectacle-auto-height-fill'
+      );
+      if (!currentNodeIsAutoFill) {
+        return;
+      }
+      node.style.maxHeight = `${emptySpace / metrics.numberAutoFills}px`;
+    });
+  }, [slideWrapperRef, contentRef, templateRef, slideHeight]);
+}

--- a/src/theme/default-theme.js
+++ b/src/theme/default-theme.js
@@ -2,7 +2,7 @@ export default {
   size: {
     width: 1366,
     height: 768,
-    maxCodePaneHeight: 520
+    maxCodePaneHeight: 200
   },
   colors: {
     primary: '#ebe5da',

--- a/src/utils/mdx-component-mapper.js
+++ b/src/utils/mdx-component-mapper.js
@@ -25,8 +25,8 @@ const mdxComponentMap = {
   li: ListItem,
   img: Image,
   a: Link,
-  codeblock: CodePane,
-  code: CodePane,
+  codeblock: props => <CodePane autoFillHeight {...props} />,
+  code: props => <CodePane autoFillHeight {...props} />,
   inlineCode: CodeSpan
 };
 


### PR DESCRIPTION
The idea is to allow for CodePane to consume the empty space around the footer and elements automatically with an opt-in prop. Prior, the user would have to either calculate or best-guess the max-height value to do so. This applies for CodePanes with lots of content. This full-height calculation can be extended to other components down the road.

<img width="943" alt="Screen Shot 2019-10-25 at 12 17 28 PM" src="https://user-images.githubusercontent.com/1738349/67590917-c0ac2780-f721-11e9-8e6b-c7f36ae51b74.png">
