### PR TITLE
Use th for TableHeader

### DIFF
--- a/src/components/__snapshots__/table-header-item.test.js.snap
+++ b/src/components/__snapshots__/table-header-item.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<TableHeaderItem /> should render correctly 1`] = `
 <TableHeaderItem>
-  <Styled(td)
+  <Styled(th)
     styles={
       Array [
         Object {
@@ -14,11 +14,11 @@ exports[`<TableHeaderItem /> should render correctly 1`] = `
       ]
     }
   >
-    <td
+    <th
       className="css-4x5e e51bxha0"
     >
       Header Text
-    </td>
-  </Styled(td)>
+    </th>
+  </Styled(th)>
 </TableHeaderItem>
 `;

--- a/src/components/table-header-item.js
+++ b/src/components/table-header-item.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { getStyles } from '../utils/base';
 import styled from 'react-emotion';
 
-const StyledTableHeaderItem = styled.td(props => props.styles);
+const StyledTableHeaderItem = styled.th(props => props.styles);
 
 export default class TableHeaderItem extends Component {
   render() {


### PR DESCRIPTION
### Description

Fixes #743 by using `th` for the TableHeader component instead of `td`

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Snapshots have been updated to match the new element rendered, but nothing else changed 🙂 