### PR TITLE
Table component branch bug

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ package.json
 node_modules
 es
 lib
+dist

--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -87,18 +87,6 @@ const TestJs = () => (
     )}
   >
     <Slide>
-      <Slide>
-        <Markdown>{`
-        # hello there
-        
-        | hi   | Supported | Versions |
-|-----------|-----------|----------|
-| Chrome          | Yes       | Last 2   |
-| Firefox         | Yes       | Last 2   |
-| Opera           | Yes       | Last 2   |
-| Edge (EdgeHTML) | No        |          |
-| IE 11           | No        |          |`}</Markdown>
-      </Slide>
       <Heading>Spectacle</Heading>
       <Text>Hello There 🤗</Text>
       <Quote>This is a Formidaquote!</Quote>
@@ -184,6 +172,21 @@ const TestJs = () => (
             </FlexBox>
           ))}
       </Grid>
+    </Slide>
+    <Slide>
+      <Markdown>
+        {`
+          # hello there
+
+          | hi              | Supported | Versions |
+          |-----------------|-----------|----------|
+          | Chrome          | Yes       | Last 2   |
+          | Firefox         | Yes       | Last 2   |
+          | Opera           | Yes       | Last 2   |
+          | Edge (EdgeHTML) | No        |          |
+          | IE 11           | No        |          |
+        `}
+      </Markdown>
     </Slide>
     <Slide>
       <Markdown>

--- a/examples/js/test-js.js
+++ b/examples/js/test-js.js
@@ -87,6 +87,18 @@ const TestJs = () => (
     )}
   >
     <Slide>
+      <Slide>
+        <Markdown>{`
+        # hello there
+        
+        | hi   | Supported | Versions |
+|-----------|-----------|----------|
+| Chrome          | Yes       | Last 2   |
+| Firefox         | Yes       | Last 2   |
+| Opera           | Yes       | Last 2   |
+| Edge (EdgeHTML) | No        |          |
+| IE 11           | No        |          |`}</Markdown>
+      </Slide>
       <Heading>Spectacle</Heading>
       <Text>Hello There 🤗</Text>
       <Quote>This is a Formidaquote!</Quote>

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -166,6 +166,21 @@
           <${Slide}>
             <${Markdown}>
               ${`
+                # hello there
+
+                | hi              | Supported | Versions |
+                |-----------------|-----------|----------|
+                | Chrome          | Yes       | Last 2   |
+                | Firefox         | Yes       | Last 2   |
+                | Opera           | Yes       | Last 2   |
+                | Edge (EdgeHTML) | No        |          |
+                | IE 11           | No        |          |
+              `}
+            <//>
+          <//>
+          <${Slide}>
+            <${Markdown}>
+              ${`
                 ### Paying for too much Lambda memory?
                 - Yes you are!
 

--- a/src/components/typography.js
+++ b/src/components/typography.js
@@ -112,6 +112,54 @@ ListItem.defaultProps = {
   margin: 'listMargin'
 };
 
+const Table = styled('table')(
+  compose(
+    color,
+    typography,
+    space
+  )
+);
+
+Table.defaultProps = {
+  color: 'primary',
+  fontFamily: 'text',
+  fontSize: 'text',
+  textAlign: 'left',
+  margin: 'listMargin'
+};
+
+const TableRow = styled('tr')(
+  compose(
+    color,
+    typography,
+    space
+  )
+);
+
+TableRow.defaultProps = {
+  color: 'primary',
+  fontFamily: 'text',
+  fontSize: 'text',
+  textAlign: 'left',
+  margin: 'listMargin'
+};
+
+const TableCell = styled('td')(
+  compose(
+    color,
+    typography,
+    space
+  )
+);
+
+TableCell.defaultProps = {
+  color: 'primary',
+  fontFamily: 'text',
+  fontSize: 'text',
+  textAlign: 'left',
+  margin: 'listMargin'
+};
+
 export {
   Text,
   Heading,
@@ -120,5 +168,8 @@ export {
   UnorderedList,
   ListItem,
   Link,
-  CodeSpan
+  CodeSpan,
+  Table,
+  TableCell,
+  TableRow
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,10 @@ import {
   UnorderedList,
   Text,
   Link,
-  CodeSpan
+  CodeSpan,
+  Table,
+  TableCell,
+  TableRow
 } from './components/typography';
 import { FlexBox, Grid, Box } from './components/layout';
 import { Image, FullSizeImage } from './components/image';
@@ -40,5 +43,8 @@ export {
   Notes,
   Progress,
   FullScreen,
-  Markdown
+  Markdown,
+  Table,
+  TableCell,
+  TableRow
 };

--- a/src/theme/backup-user-theme.js
+++ b/src/theme/backup-user-theme.js
@@ -1,3 +1,2 @@
 // if the user does not specify a theme, we still need our alias to point somewhere
 export default {};
-

--- a/src/utils/mdx-component-mapper.js
+++ b/src/utils/mdx-component-mapper.js
@@ -10,7 +10,10 @@ import {
   Text,
   ListItem,
   Link,
-  CodeSpan
+  CodeSpan,
+  Table,
+  TableRow,
+  TableCell
 } from '../';
 
 const mdxComponentMap = {
@@ -27,7 +30,10 @@ const mdxComponentMap = {
   a: Link,
   codeblock: props => <CodePane autoFillHeight {...props} />,
   code: props => <CodePane autoFillHeight {...props} />,
-  inlineCode: CodeSpan
+  inlineCode: CodeSpan,
+  table: Table,
+  tr: TableRow,
+  td: TableCell
 };
 
 export default mdxComponentMap;


### PR DESCRIPTION
Markdown example to demonstratte indentation problem with prettier and marksy.

In this [case](https://github.com/FormidableLabs/spectacle/pull/746/files#diff-27d1398137d07ae13f238fccada6a73fR90-R101) marksy interprets the code as a codepane, not a table. After having it explained by Carlos, this makes sense but this is probably a sub-optimal user experience and we should think about how to solve this. 