### PR TITLE
Fix typo in Component Playground prop

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -539,7 +539,7 @@ To use a `ComponentPlayground`, you'll want to provide the code sample to the co
 
 ```js
 <Slide>
-  <ComponentPlayground code={code.deckSample} theme={dark} />
+  <ComponentPlayground source={code.deckSample} theme={dark} />
 </Slide>
 ```
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

The prop in the Component playground reading `code` should read `source`.

#### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

No testing needed, just a quick typo fix.
