### PR TITLE
Add Template CLI option

### DIFF
--- a/bin/actions.js
+++ b/bin/actions.js
@@ -4,6 +4,33 @@ const path = require('path');
 const config = require('../webpack.config');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const spectacleComponents = [
+  'Deck',
+  'Slide',
+  'Appear',
+  'CodePane',
+  'Box',
+  'FlexBox',
+  'Grid',
+  'Image',
+  'FullSizeImage',
+  'OrderedList',
+  'Quote',
+  'Heading',
+  'ListItem',
+  'UnorderedList',
+  'Text',
+  'Link',
+  'CodeSpan',
+  'Notes',
+  'Progress',
+  'FullScreen',
+  'Markdown',
+  'Table',
+  'TableCell',
+  'TableRow'
+]
+
 const options = {
   hot: true
 };
@@ -33,6 +60,12 @@ const launchMDXServer = (mdxFilePath, themeFilePath, templateFilePath, title, po
   const alias = {
     'spectacle-user-mdx': absoluteMdxFilePath
   };
+  const plugins = [
+    new HtmlWebpackPlugin({
+      template: `./index.html`,
+      title: title || 'Spectacle - Getting Started'
+    })
+  ]
 
   if (themeFilePath) {
     alias['spectacle-user-theme'] = path.resolve(themeFilePath);
@@ -42,6 +75,14 @@ const launchMDXServer = (mdxFilePath, themeFilePath, templateFilePath, title, po
   }
 
   if (templateFilePath) {
+    const componentMap = spectacleComponents.reduce((acc, comp) => {
+      acc[comp] = [path.resolve(path.join(__dirname, '../', 'src')), comp];
+      return acc;
+    }, {});
+    plugins.push(
+      new webpack.ProvidePlugin(componentMap)
+    )
+
     alias['spectacle-user-template'] = path.resolve(templateFilePath);
   } else {
     alias['spectacle-user-template'] = config.resolve.alias['spectacle-user-template'];
@@ -59,12 +100,7 @@ const launchMDXServer = (mdxFilePath, themeFilePath, templateFilePath, title, po
       modules: [nodeModules]
     },
     externals: {},
-    plugins: [
-      new HtmlWebpackPlugin({
-        template: `./index.html`,
-        title: title || 'Spectacle – Getting Started'
-      })
-    ]
+    plugins
   };
 
   launchServer(configUpdates, port);

--- a/bin/actions.js
+++ b/bin/actions.js
@@ -12,7 +12,7 @@ const launchServer = (configUpdates = {}, port) => {
   const customConfig = { ...config, ...configUpdates };
   const server = new WebpackDevServer(webpack(customConfig), options);
 
-  server.listen(port, 'localhost', function(err) {
+  server.listen(port, 'localhost', function (err) {
     if (err) {
       console.log(err);
     }
@@ -20,7 +20,7 @@ const launchServer = (configUpdates = {}, port) => {
   });
 };
 
-const launchMDXServer = (mdxFilePath, themeFilePath, title, port = 3000) => {
+const launchMDXServer = (mdxFilePath, themeFilePath, templateFilePath, title, port = 3000) => {
   if (!mdxFilePath) {
     // developer error - must supply an entry file path
     throw new Error('MDX file path must be provided.');
@@ -33,11 +33,18 @@ const launchMDXServer = (mdxFilePath, themeFilePath, title, port = 3000) => {
   const alias = {
     'spectacle-user-mdx': absoluteMdxFilePath
   };
+
   if (themeFilePath) {
     alias['spectacle-user-theme'] = path.resolve(themeFilePath);
   } else {
     alias['spectacle-user-theme'] =
       config.resolve.alias['spectacle-user-theme'];
+  }
+
+  if (templateFilePath) {
+    alias['spectacle-user-template'] = path.resolve(templateFilePath);
+  } else {
+    alias['spectacle-user-template'] = config.resolve.alias['spectacle-user-template'];
   }
 
   const configUpdates = {

--- a/bin/args.js
+++ b/bin/args.js
@@ -3,9 +3,9 @@ const validatePresentationMode = require('./validate/presentation-mode');
 
 const validate = async parser => {
   const { argv } = parser;
-  const { src, theme, port, title } = argv;
+  const { src, theme, port, title, template } = argv;
 
-  return await validatePresentationMode(src, theme, port, title);
+  return await validatePresentationMode(src, theme, port, title, template);
 };
 
 const args = () =>
@@ -22,6 +22,11 @@ const args = () =>
     .option('theme', {
       alias: 't',
       describe: 'Path to a JS file that contains theme overrides.',
+      type: 'string'
+    })
+    .option('template', {
+      alias: 'm',
+      describe: 'Path to a JS file that contains a slide template',
       type: 'string'
     })
     .option('title', {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,10 +10,11 @@ const main = () =>
     .then(parsedInput => {
       const mdxFilePath = parsedInput.mdx;
       const themeFilePath = parsedInput.theme;
+      const templateFilePath = parsedInput.template;
       const title = parsedInput.title;
       const port = parsedInput.port;
       if (mdxFilePath) {
-        actions.launchMDXServer(mdxFilePath, themeFilePath, title, port);
+        actions.launchMDXServer(mdxFilePath, themeFilePath, templateFilePath, title, port);
       }
       // add future actions here
       else {

--- a/bin/validate/presentation-mode.js
+++ b/bin/validate/presentation-mode.js
@@ -13,7 +13,7 @@ const fileExists = srcPath => {
   });
 };
 
-const validatePresentationMode = async (src, theme, port, title) => {
+const validatePresentationMode = async (src, theme, port, title, template) => {
   /* - the default action of the CLI is to boot up a presentation from a file
    * - src defaults to `slides.mdx`
    * - theme has no default
@@ -55,6 +55,15 @@ const validatePresentationMode = async (src, theme, port, title) => {
     if (!themeExists) {
       throw new Error(`A theme file cannot be found at the path "${src}".`);
     }
+  }
+
+  if (template) {
+    const templateExists = await fileExists(template);
+    if (!templateExists) {
+      throw new Error(`A template file cannot be found at the path "${template}"`);
+    }
+
+    validatedValue['template'] = template;
   }
 
   return validatedValue;

--- a/examples/mdx/test-template.js
+++ b/examples/mdx/test-template.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Template = ({ numberOfSlides, slideNumber }) => (
+  <div>hello</div>
+)
+
+export default Template;

--- a/examples/mdx/test-template.js
+++ b/examples/mdx/test-template.js
@@ -1,7 +1,16 @@
 import React from 'react';
 
 const Template = ({ numberOfSlides, slideNumber }) => (
-  <div>hello</div>
+  <FlexBox
+    justifyContent="space-between"
+    position="absolute"
+    bottom={0}
+    width={1}
+  >
+    <Text fontSize={16} color="quinary" fontWeight="bold">
+      Slide {slideNumber} of {numberOfSlides - 1}
+    </Text>
+  </FlexBox>
 )
 
 export default Template;

--- a/mdx-slides/backup-user-template.js
+++ b/mdx-slides/backup-user-template.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { FlexBox, Text, Box, Image } from '../src/';
+
+const formidableLogo = require('../examples/js/formidable.png');
+
+const Template = ({ numberOfSlides, slideNumber }) => (
+  <FlexBox
+    justifyContent="space-between"
+    position="absolute"
+    bottom={0}
+    width={1}
+  >
+    <Text fontSize={16} color="quinary" fontWeight="bold">
+      Slide {slideNumber} of {numberOfSlides - 1}
+    </Text>
+    <Box padding={10}>
+      <Image src={formidableLogo} width={100} />
+    </Box>
+  </FlexBox>
+);
+
+export default Template;

--- a/mdx-slides/backup-user-template.js
+++ b/mdx-slides/backup-user-template.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { FlexBox, Text, Box, Image } from '../src/';
-
-const formidableLogo = require('../examples/js/formidable.png');
+import { FlexBox, Text } from '../src/';
 
 const Template = ({ numberOfSlides, slideNumber }) => (
   <FlexBox
@@ -14,9 +12,6 @@ const Template = ({ numberOfSlides, slideNumber }) => (
     <Text fontSize={16} color="quinary" fontWeight="bold">
       Slide {slideNumber} of {numberOfSlides - 1}
     </Text>
-    <Box padding={10}>
-      <Image src={formidableLogo} width={100} />
-    </Box>
   </FlexBox>
 );
 

--- a/mdx-slides/index.js
+++ b/mdx-slides/index.js
@@ -1,31 +1,18 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { MDXProvider } from '@mdx-js/react';
-import { Deck, Slide, Notes, FlexBox, Text, Box, Image } from '../src/';
-const formidableLogo = require('../examples/js/formidable.png');
+import { Deck, Slide, Notes } from '../src/';
 
 // See the cli actions.js to see how this import alias is made
 import slides, { notes } from 'spectacle-user-mdx';
+import template from 'spectacle-user-template';
+
 import mdxComponentMap from '../src/utils/mdx-component-mapper';
 
 const MDXSlides = () => (
   <Deck
     loop
-    template={({ numberOfSlides, slideNumber }) => (
-      <FlexBox
-        justifyContent="space-between"
-        position="absolute"
-        bottom={0}
-        width={1}
-      >
-        <Text fontSize={16} color="quinary" fontWeight="bold">
-          Slide {slideNumber} of {numberOfSlides - 1}
-        </Text>
-        <Box padding={10}>
-          <Image src={formidableLogo} width={100} />
-        </Box>
-      </FlexBox>
-    )}
+    template={template}
   >
     {slides.map((MDXSlide, i) => {
       const NotesForSlide = notes[i];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,6 +94,10 @@ module.exports = {
       'spectacle-user-theme': path.resolve(
         __dirname,
         './src/theme/backup-user-theme'
+      ),
+      'spectacle-user-template': path.resolve(
+        __dirname,
+        './mdx-slides/backup-user-template'
       )
     }
   }


### PR DESCRIPTION
- Adds `--template`/`-m` CLI option to specify a custom template file location
- Uses the theme import alias logic to use the given user template
- Uses webpack's `ProvidePlugin` to allow access to Spectacle elements in the template file