### PR TITLE
Remove spectacle-user-theme webpack alias strategy.

### DIFF
--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -9,14 +9,6 @@
   <body>
     <div id="root"></div>
 
-    <script>
-      window.userTheme = {
-        colors: {
-          secondary: 'hotpink'
-        }
-      };
-    </script>
-
     <script src="https://unpkg.com/react@16.10.1/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@16.10.1/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/react-is@16.10.1/umd/react-is.production.min.js"></script>
@@ -56,6 +48,11 @@
       }`.replace(/      /gm, '');
       const deck = html`
         <${Deck}
+          theme=${{
+            colors: {
+              secondary: 'hotpink'
+            }
+          }}
           template=${({ numberOfSlides, slideNumber }) =>
             html`
               <${FlexBox}
@@ -154,7 +151,6 @@
                 .fill('')
                 .map(
                   (_, index) =>
-                    // TODO(ONE-PAGE): I don't see anything in dev or one-page (???)
                     html`
                       <${FlexBox} key="formidable-logo-${index}">
                         <${Image} src=${formidableLogo} width=${100} />

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -7,7 +7,7 @@ import isComponentType from '../../utils/is-component-type';
 import useUrlRouting from '../../hooks/use-url-routing';
 import PresenterDeck from './presenter-deck';
 import AudienceDeck from './audience-deck';
-import theme from '../../theme';
+import { mergeTheme } from '../../theme';
 import { animated, useTransition } from 'react-spring';
 import {
   TransitionPipeContext,
@@ -273,7 +273,7 @@ Deck.propTypes = {
 };
 
 const ConnectedDeck = props => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={mergeTheme(props.theme)}>
     <TransitionPipeProvider>
       <Deck {...props} />
     </TransitionPipeProvider>

--- a/src/theme/backup-user-theme.js
+++ b/src/theme/backup-user-theme.js
@@ -1,2 +1,0 @@
-// if the user does not specify a theme, we still need our alias to point somewhere
-export default {};

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,16 +1,14 @@
 import defaultTheme from './default-theme';
-// see cli actions.js to understand this import
-let userTheme = require('spectacle-user-theme').default;
 
-const mergedTheme = { ...defaultTheme };
-if (userTheme && Object.keys(userTheme).length > 0) {
-  for (const key in defaultTheme) {
-    const userThemeCategory = userTheme[key];
-    const defaultThemeCategory = defaultTheme[key];
-    if (userThemeCategory) {
-      mergedTheme[key] = { ...defaultThemeCategory, ...userThemeCategory };
-    }
-  }
-}
+// A naive, but fast deep object copy.
+const deepCopy = obj => JSON.parse(JSON.stringify(obj));
 
-export default mergedTheme;
+// Merge a user-provided theme in with defaults.
+// **Note**: Assumes theme objects only go 2 levels deep.
+export const mergeTheme = theme =>
+  Object.keys(theme || {}).reduce((merged, key) => {
+    merged[key] = { ...merged[key], ...theme[key] };
+    return merged;
+  }, deepCopy(defaultTheme));
+
+export default defaultTheme;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,13 +38,5 @@ module.exports = {
         use: ['file-loader']
       }
     ]
-  },
-  resolve: {
-    alias: {
-      'spectacle-user-theme': path.resolve(
-        __dirname,
-        'src/theme/backup-user-theme'
-      )
-    }
   }
 };


### PR DESCRIPTION
As discussed internally, we don't need to webpack alias a made up `spectacle-user-theme` thing to allow user-provided theme overrides via manual `Deck` or the CLI. We can just pass them as props to the top level exported deck and much more simply have it all work out.

Work:

- Removed unneeded files and webpack alias.
- Add override example in `one-page.html`

Example:

```js
<Deck
    theme={{
      colors: {
        secondary: 'yellow'
      }
    }}
  >
    <Slide>
```

To test out:

```sh
$ git checkout chore/remove-theme-alias
$ yarn build
$ open examples/one-page.html
```

You should see a pink heading (colored `secondary`) on the first page instead of default theme color. Try out other theme overrides in `examples/one-page.html` and refresh to see in action!