### PR TITLE
Kara/print and export

### DIFF
--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -2,7 +2,9 @@ import * as React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import propTypes from 'prop-types';
 import theme from 'prism-react-renderer/themes/vsDark';
+import lightTheme from 'prism-react-renderer/themes/nightOwlLight';
 import { ThemeContext } from 'styled-components';
+import { DeckContext } from '../hooks/use-deck';
 
 const spaceSearch = /\S|$/;
 
@@ -17,7 +19,9 @@ export default function CodePane(props) {
   const canvas = React.useRef(document.createElement('canvas'));
   const context = React.useRef(canvas.current.getContext('2d'));
   const themeContext = React.useContext(ThemeContext);
-
+  const {
+    state: { printMode }
+  } = React.useContext(DeckContext);
   const font = React.useMemo(() => {
     if (themeContext && themeContext.fonts && themeContext.fonts.monospace) {
       return themeContext.fonts.monospace;
@@ -74,7 +78,7 @@ export default function CodePane(props) {
         {...defaultProps}
         code={props.children}
         language={props.language}
-        theme={theme}
+        theme={printMode ? lightTheme : theme}
       >
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -8,6 +8,8 @@ import useUrlRouting from '../../hooks/use-url-routing';
 import PresenterDeck from './presenter-deck';
 import AudienceDeck from './audience-deck';
 import { mergeTheme } from '../../theme';
+import { PrintDeck } from './print-deck';
+import theme from '../../theme';
 import { animated, useTransition } from 'react-spring';
 import {
   TransitionPipeContext,
@@ -206,6 +208,14 @@ const Deck = ({
       content = (
         <OverviewDeck goToSlide={goToSlide}>{staticSlides}</OverviewDeck>
       );
+    } else if (state.exportMode) {
+      const staticSlides = filteredChildren.map((slide, index) =>
+        React.cloneElement(slide, {
+          slideNum: index,
+          template: rest.template
+        })
+      );
+      content = <PrintDeck>{staticSlides}</PrintDeck>;
     } else if (state.presenterMode) {
       const staticSlides = filteredChildren.map((slide, index) =>
         React.cloneElement(slide, {

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -9,7 +9,6 @@ import PresenterDeck from './presenter-deck';
 import AudienceDeck from './audience-deck';
 import { mergeTheme } from '../../theme';
 import { PrintDeck } from './print-deck';
-import theme from '../../theme';
 import { animated, useTransition } from 'react-spring';
 import {
   TransitionPipeContext,

--- a/src/components/deck/print-deck.js
+++ b/src/components/deck/print-deck.js
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const SlidesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const PrintDeck = ({ children }) => (
+  <SlidesContainer>{children}</SlidesContainer>
+);
+
+PrintDeck.propTypes = {
+  children: PropTypes.node.isRequired
+};

--- a/src/components/fullscreen.js
+++ b/src/components/fullscreen.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import propTypes from 'prop-types';
+import styled from 'styled-components';
 
 const FullScreen = props => {
   const toggleFullScreen = React.useCallback(() => {
@@ -11,8 +12,14 @@ const FullScreen = props => {
       }
     }
   }, []);
+
+  const Container = styled('div')`
+    @media print {
+      display: none;
+    }
+  `;
   return (
-    <div
+    <Container
       className="spectacle-fullscreen-button"
       onClick={toggleFullScreen}
       style={{ pointerEvents: 'all' }}
@@ -27,7 +34,7 @@ const FullScreen = props => {
           }
         />
       </svg>
-    </div>
+    </Container>
   );
 };
 

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -15,10 +15,16 @@ const Circle = styled('div')`
   cursor: pointer;
 `;
 
+const Container = styled('div')`
+  @media print {
+    display: none;
+  }
+`;
+
 const Progress = props => {
   const { numberOfSlides, state, goToSlide } = React.useContext(DeckContext);
   return (
-    <div className="spectacle-progress-indicator">
+    <Container className="spectacle-progress-indicator">
       {Array(numberOfSlides)
         .fill(0)
         .map((_, idx) => (
@@ -30,7 +36,7 @@ const Progress = props => {
             onClick={() => goToSlide(idx)}
           />
         ))}
-    </div>
+    </Container>
   );
 };
 

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -94,6 +94,17 @@ const Slide = props => {
     };
   }, [transformForWindowSize, scaleRatio]);
 
+  const transforms = React.useMemo(
+    () =>
+      state.exportMode
+        ? {}
+        : {
+            transform: `scale(${ratio})`,
+            transformOrigin: `${origin.x} ${origin.y}`
+          },
+    [state.exportMode, origin, ratio]
+  );
+
   const value = useSlide(slideNum);
   const { numberOfSlides } = value.state;
 
@@ -102,17 +113,8 @@ const Slide = props => {
   return (
     <SlideContainer
       ref={slideRef}
-      backgroundColor={
-        window.location.search.includes('print') ? '#ffffff' : backgroundColor
-      }
-      style={
-        state.exportMode
-          ? {}
-          : {
-              transform: `scale(${ratio})`,
-              transformOrigin: `${origin.x} ${origin.y}`
-            }
-      }
+      backgroundColor={state.printMode ? '#ffffff' : backgroundColor}
+      style={transforms}
     >
       <TemplateWrapper ref={templateRef}>
         {typeof template === 'function' &&

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -95,7 +95,9 @@ const Slide = props => {
   return (
     <SlideContainer
       ref={slideRef}
-      backgroundColor={backgroundColor}
+      backgroundColor={
+        window.location.search.includes('print') ? '#ffffff' : backgroundColor
+      }
       style={{
         transform: `scale(${ratio})`,
         transformOrigin: `${origin.x} ${origin.y}`

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -10,6 +10,11 @@ const SlideContainer = styled('div')`
   width: ${({ theme }) => theme.size.width || 1366}px;
   height: ${({ theme }) => theme.size.height || 768}px;
   overflow: hidden;
+  @media print {
+    page-break-before: always;
+    height: 100vh;
+    width: 100vw;
+  }
 `;
 const SlideWrapper = styled('div')`
   ${color};

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -4,6 +4,7 @@ import useSlide, { SlideContext } from '../hooks/use-slide';
 import styled, { ThemeContext } from 'styled-components';
 import { color, space } from 'styled-system';
 import useAutofillHeight from '../hooks/use-autofill-height';
+import { DeckContext } from '../hooks/use-deck';
 
 const SlideContainer = styled('div')`
   ${color};
@@ -45,6 +46,7 @@ const Slide = props => {
     scaleRatio
   } = props;
   const theme = React.useContext(ThemeContext);
+  const { state } = React.useContext(DeckContext);
   const [ratio, setRatio] = React.useState(scaleRatio || 1);
   const [origin, setOrigin] = React.useState({ x: 0, y: 0 });
   const slideRef = React.useRef(null);
@@ -103,10 +105,14 @@ const Slide = props => {
       backgroundColor={
         window.location.search.includes('print') ? '#ffffff' : backgroundColor
       }
-      style={{
-        transform: `scale(${ratio})`,
-        transformOrigin: `${origin.x} ${origin.y}`
-      }}
+      style={
+        state.exportMode
+          ? {}
+          : {
+              transform: `scale(${ratio})`,
+              transformOrigin: `${origin.x} ${origin.y}`
+            }
+      }
     >
       <TemplateWrapper ref={templateRef}>
         {typeof template === 'function' &&

--- a/src/hooks/use-deck.js
+++ b/src/hooks/use-deck.js
@@ -21,6 +21,7 @@ function useDeck(initialState) {
           presenterMode: action.payload.presenterMode,
           overviewMode: action.payload.overviewMode,
           exportMode: action.payload.exportMode,
+          printMode: action.payload.printMode,
           resolvedInitialUrl: true
         };
         return newState;

--- a/src/hooks/use-deck.js
+++ b/src/hooks/use-deck.js
@@ -20,6 +20,7 @@ function useDeck(initialState) {
           reverseDirection: action.payload.reverseDirection,
           presenterMode: action.payload.presenterMode,
           overviewMode: action.payload.overviewMode,
+          exportMode: action.payload.exportMode,
           resolvedInitialUrl: true
         };
         return newState;

--- a/src/hooks/use-url-routing.js
+++ b/src/hooks/use-url-routing.js
@@ -15,6 +15,7 @@ export default function useUrlRouting(options) {
     currentPresenterMode,
     currentOverviewMode,
     currentExportMode,
+    currentPrintMode,
     loop,
     animationsWhenGoingBack,
     onUrlChange
@@ -58,6 +59,7 @@ export default function useUrlRouting(options) {
       const immediate = Boolean(query.immediate);
       const presenterMode = Boolean(query.presenterMode);
       const exportMode = Boolean(query.exportMode);
+      const printMode = Boolean(query.printMode);
       const overviewMode = Boolean(query.overviewMode);
       const proposedSlideNumber = parseInt(query.slide, 10);
       const proposedSlideElementNumber = parseInt(query.slideElement, 10);
@@ -86,7 +88,8 @@ export default function useUrlRouting(options) {
         proposedSlideElementNumber,
         slideNumber,
         slideElementNumber,
-        exportMode
+        exportMode,
+        printMode
       };
     },
     [countSlideElements, isSlideElementOutOfBounds, isSlideOutOfBounds]
@@ -100,11 +103,17 @@ export default function useUrlRouting(options) {
         exportMode: currentExportMode || undefined,
         immediate: true,
         slide: slideNumber,
-        slideElement: DEFAULT_SLIDE_ELEMENT_INDEX
+        slideElement: DEFAULT_SLIDE_ELEMENT_INDEX,
+        printMode: currentPrintMode || undefined
       });
       history.current.push(`?${qs}`);
     },
-    [currentPresenterMode, currentOverviewMode, currentExportMode]
+    [
+      currentPresenterMode,
+      currentOverviewMode,
+      currentExportMode,
+      currentPrintMode
+    ]
   );
 
   const onHistoryChange = React.useCallback(() => {
@@ -116,7 +125,8 @@ export default function useUrlRouting(options) {
       presenterMode,
       overviewMode,
       immediate,
-      exportMode
+      exportMode,
+      printMode
     } = stateFromUrl(window.location.search);
     /**
      * If the proposed URL slide index is out-of-bounds or is not a valid
@@ -133,7 +143,8 @@ export default function useUrlRouting(options) {
         immediate: immediate || undefined,
         presenterMode: presenterMode || undefined,
         overviewMode: overviewMode || undefined,
-        exportMode: exportMode || undefined
+        exportMode: exportMode || undefined,
+        printMode: printMode || undefined
       });
       history.current.replace(`?${qs}`);
       return;
@@ -152,7 +163,8 @@ export default function useUrlRouting(options) {
         ...update,
         presenterMode,
         overviewMode,
-        exportMode
+        exportMode,
+        printMode
       }
     });
     onUrlChange(update);
@@ -197,7 +209,8 @@ export default function useUrlRouting(options) {
         immediate: immediate || undefined,
         presenterMode: currentPresenterMode || undefined,
         overviewMode: currentOverviewMode || undefined,
-        exportMode: currentExportMode || undefined
+        exportMode: currentExportMode || undefined,
+        printMode: currentPrintMode || undefined
       });
       history.current.push(`?${qs}`);
     },
@@ -209,6 +222,7 @@ export default function useUrlRouting(options) {
       currentPresenterMode,
       currentOverviewMode,
       currentExportMode,
+      currentPrintMode,
       loop,
       nextSafeSlide
     ]
@@ -252,18 +266,20 @@ export default function useUrlRouting(options) {
       slideElement: previousSafeSlideElementIndex,
       immediate: immediate || undefined,
       presenterMode: currentPresenterMode || undefined,
-      overviewMode: currentOverviewMode || undefined
+      overviewMode: currentOverviewMode || undefined,
+      exportMode: currentExportMode || undefined
     });
     history.current.push(`?${qs}`);
   }, [
     animationsWhenGoingBack,
     countSlideElements,
-    currentPresenterMode,
-    currentOverviewMode,
     currentSlide,
     currentSlideElement,
-    loop,
     numberOfSlides,
+    currentPresenterMode,
+    currentOverviewMode,
+    currentExportMode,
+    loop,
     previousSafeSlide
   ]);
 

--- a/src/hooks/use-url-routing.js
+++ b/src/hooks/use-url-routing.js
@@ -14,6 +14,7 @@ export default function useUrlRouting(options) {
     currentSlideElement,
     currentPresenterMode,
     currentOverviewMode,
+    currentExportMode,
     loop,
     animationsWhenGoingBack,
     onUrlChange
@@ -56,6 +57,7 @@ export default function useUrlRouting(options) {
       const query = queryString.parse(url);
       const immediate = Boolean(query.immediate);
       const presenterMode = Boolean(query.presenterMode);
+      const exportMode = Boolean(query.exportMode);
       const overviewMode = Boolean(query.overviewMode);
       const proposedSlideNumber = parseInt(query.slide, 10);
       const proposedSlideElementNumber = parseInt(query.slideElement, 10);
@@ -83,7 +85,8 @@ export default function useUrlRouting(options) {
         proposedSlideNumber,
         proposedSlideElementNumber,
         slideNumber,
-        slideElementNumber
+        slideElementNumber,
+        exportMode
       };
     },
     [countSlideElements, isSlideElementOutOfBounds, isSlideOutOfBounds]
@@ -94,13 +97,14 @@ export default function useUrlRouting(options) {
       const qs = queryString.stringify({
         presenterMode: currentPresenterMode || undefined,
         overviewMode: currentOverviewMode || undefined,
+        exportMode: currentExportMode || undefined,
         immediate: true,
         slide: slideNumber,
         slideElement: DEFAULT_SLIDE_ELEMENT_INDEX
       });
       history.current.push(`?${qs}`);
     },
-    [currentPresenterMode, currentOverviewMode]
+    [currentPresenterMode, currentOverviewMode, currentExportMode]
   );
 
   const onHistoryChange = React.useCallback(() => {
@@ -111,7 +115,8 @@ export default function useUrlRouting(options) {
       proposedSlideElementNumber,
       presenterMode,
       overviewMode,
-      immediate
+      immediate,
+      exportMode
     } = stateFromUrl(window.location.search);
     /**
      * If the proposed URL slide index is out-of-bounds or is not a valid
@@ -127,7 +132,8 @@ export default function useUrlRouting(options) {
         slideElement: slideElementNumber,
         immediate: immediate || undefined,
         presenterMode: presenterMode || undefined,
-        overviewMode: overviewMode || undefined
+        overviewMode: overviewMode || undefined,
+        exportMode: exportMode || undefined
       });
       history.current.replace(`?${qs}`);
       return;
@@ -145,7 +151,8 @@ export default function useUrlRouting(options) {
       payload: {
         ...update,
         presenterMode,
-        overviewMode
+        overviewMode,
+        exportMode
       }
     });
     onUrlChange(update);
@@ -189,19 +196,21 @@ export default function useUrlRouting(options) {
         slideElement: nextSafeSlideElementIndex,
         immediate: immediate || undefined,
         presenterMode: currentPresenterMode || undefined,
-        overviewMode: currentOverviewMode || undefined
+        overviewMode: currentOverviewMode || undefined,
+        exportMode: currentExportMode || undefined
       });
       history.current.push(`?${qs}`);
     },
     [
       countSlideElements,
-      currentPresenterMode,
-      currentOverviewMode,
       currentSlide,
       currentSlideElement,
+      numberOfSlides,
+      currentPresenterMode,
+      currentOverviewMode,
+      currentExportMode,
       loop,
-      nextSafeSlide,
-      numberOfSlides
+      nextSafeSlide
     ]
   );
 

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,21 +1,32 @@
 import defaultTheme from './default-theme';
 import printTheme from './print-theme';
 
-// A naive, but fast deep object copy.
-const deepCopy = obj => JSON.parse(JSON.stringify(obj));
-
 // Merge a user-provided theme in with defaults.
 // **Note**: Assumes theme objects only go 2 levels deep.
-export const mergeTheme = (theme, printMode) => {
-  const merged = Object.keys(theme || {}).reduce((merged, key) => {
-    merged[key] = { ...merged[key], ...theme[key] };
-    return merged;
-  }, deepCopy(defaultTheme));
-
-  return printMode
+export const mergeTheme = theme => {
+  const isPrintMode = window.location.search.includes('printMode');
+  const merged = Object.keys(theme || {}).reduce(
+    (mergedTheme, key) => ({
+      ...mergedTheme,
+      [key]: {
+        ...mergedTheme[key],
+        ...theme[key]
+      }
+    }),
+    defaultTheme
+  );
+  // if is print mode then do the above for printTheme else return the
+  // above merged themes
+  return isPrintMode
     ? Object.keys(printTheme || {}).reduce(
-        (merged, key) => (merged[key] = { ...merged[key], ...printTheme[key] }),
-        deepCopy(merged)
+        (mergedTheme, key) => ({
+          ...mergedTheme,
+          [key]: {
+            ...mergedTheme[key],
+            ...printTheme[key]
+          }
+        }),
+        merged
       )
     : merged;
 };

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,33 +1,20 @@
 import defaultTheme from './default-theme';
 import printTheme from './print-theme';
 
-// Merge a user-provided theme in with defaults.
-// **Note**: Assumes theme objects only go 2 levels deep.
+const mergeKeys = (base, override) =>
+  Object.keys(override || {}).reduce(
+    (merged, key) => {
+      merged[key] = { ...merged[key], ...override[key] };
+      return merged;
+    },
+    { ...base }
+  );
+
 export const mergeTheme = theme => {
   const isPrintMode = window.location.search.includes('printMode');
-  const merged = Object.keys(theme || {}).reduce(
-    (mergedTheme, key) => ({
-      ...mergedTheme,
-      [key]: {
-        ...mergedTheme[key],
-        ...theme[key]
-      }
-    }),
-    defaultTheme
-  );
+  const merged = mergeKeys(defaultTheme, theme);
+
   // if is print mode then do the above for printTheme else return the
   // above merged themes
-  return isPrintMode
-    ? Object.keys(printTheme || {}).reduce(
-        (mergedTheme, key) => ({
-          ...mergedTheme,
-          [key]: {
-            ...mergedTheme[key],
-            ...printTheme[key]
-          }
-        }),
-        merged
-      )
-    : merged;
+  return isPrintMode ? mergeKeys(merged, printTheme) : merged;
 };
-export default defaultTheme;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,14 +1,22 @@
 import defaultTheme from './default-theme';
+import printTheme from './print-theme';
 
 // A naive, but fast deep object copy.
 const deepCopy = obj => JSON.parse(JSON.stringify(obj));
 
 // Merge a user-provided theme in with defaults.
 // **Note**: Assumes theme objects only go 2 levels deep.
-export const mergeTheme = theme =>
-  Object.keys(theme || {}).reduce((merged, key) => {
+export const mergeTheme = (theme, printMode) => {
+  const merged = Object.keys(theme || {}).reduce((merged, key) => {
     merged[key] = { ...merged[key], ...theme[key] };
     return merged;
   }, deepCopy(defaultTheme));
 
+  return printMode
+    ? Object.keys(printTheme || {}).reduce(
+        (merged, key) => (merged[key] = { ...merged[key], ...printTheme[key] }),
+        deepCopy(merged)
+      )
+    : merged;
+};
 export default defaultTheme;

--- a/src/theme/print-theme.js
+++ b/src/theme/print-theme.js
@@ -1,8 +1,8 @@
 export default {
   colors: {
-    primary: '#000000',
-    secondary: '#000000',
-    tertiary: '#000000',
+    primary: '#00000096',
+    secondary: '#00000069',
+    tertiary: '#00000085',
     quaternary: '#000000',
     quinary: '#000000'
   }

--- a/src/theme/print-theme.js
+++ b/src/theme/print-theme.js
@@ -1,0 +1,9 @@
+export default {
+  colors: {
+    primary: '#000000',
+    secondary: '#000000',
+    tertiary: '#000000',
+    quaternary: '#000000',
+    quinary: '#000000'
+  }
+};


### PR DESCRIPTION
This ticket implements the export and print functionality that was in original Spectacle.

When a user uses the `exportMode` flag, when they print it will output each slide as a single page.
![exportmode](https://user-images.githubusercontent.com/21056165/67956673-67923700-fbec-11e9-808b-10f4bc3b3aab.gif)

When a user uses the `printMode` flag, it will apply a print theme and a white background, saving on printing. 

The printTheme has alright contrast at the moment, though am more than happy to take input on it @alex-saunders you're pretty good at this kinda thing. 

I have also added a lightTheme for the codepane when in `printMode`.

![greyexport](https://user-images.githubusercontent.com/21056165/67965956-e68e6c00-fbfa-11e9-8564-efb038d5ad15.gif)

