### PR TITLE
Added support for flex-based AutoLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ✨ A ReactJS based Presentation Library ✨
 
-
 <!-- Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck [here](TODO). -->
 
 Have a question about Spectacle? Submit an issue in this repository using the "Question" template.

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -95,13 +95,17 @@ const mapMarkdownIntoSlides = (child, index) => {
   return child;
 };
 
-const Deck = ({
-  children,
-  loop,
-  keyboardControls,
-  animationsWhenGoingBack,
-  ...rest
-}) => {
+const Deck = props => {
+  const {
+    children,
+    loop,
+    keyboardControls,
+    animationsWhenGoingBack,
+    autoLayout,
+    backgroundColor,
+    textColor,
+    template
+  } = props;
   if (React.Children.count(children) === 0) {
     throw new Error('Spectacle must have at least one slide to run.');
   }
@@ -132,10 +136,10 @@ const Deck = ({
     document.body.style.margin = '0';
     document.body.style.background = '#000';
     document.body.style.color =
-      themeContext.colors[rest.textColor] ||
-      rest.textColor ||
+      themeContext.colors[textColor] ||
+      textColor ||
       themeContext.colors.primary;
-  }, [rest.backgroundColor, rest.textColor, themeContext.colors]);
+  }, [backgroundColor, textColor, themeContext.colors]);
 
   const {
     startConnection,
@@ -215,7 +219,8 @@ const Deck = ({
       const staticSlides = filteredChildren.map((slide, index) =>
         React.cloneElement(slide, {
           slideNum: index,
-          template: rest.template
+          template,
+          autoLayout: Boolean(autoLayout)
         })
       );
       content = (
@@ -233,7 +238,8 @@ const Deck = ({
       const staticSlides = filteredChildren.map((slide, index) =>
         React.cloneElement(slide, {
           slideNum: index,
-          template: rest.template
+          template,
+          autoLayout: Boolean(autoLayout)
         })
       );
       content = (
@@ -247,15 +253,18 @@ const Deck = ({
         </PresenterDeck>
       );
     } else {
-      const animatedSlides = transitions.map(({ item, props, key }) => (
-        <AnimatedDeckDiv style={props} key={key}>
-          {React.cloneElement(filteredChildren[item], {
-            slideNum: item,
-            numberOfSlides,
-            template: rest.template
-          })}
-        </AnimatedDeckDiv>
-      ));
+      const animatedSlides = transitions.map(
+        ({ item, props: animatedStyleProps, key }) => (
+          <AnimatedDeckDiv style={animatedStyleProps} key={key}>
+            {React.cloneElement(filteredChildren[item], {
+              slideNum: item,
+              numberOfSlides,
+              template,
+              autoLayout: Boolean(autoLayout)
+            })}
+          </AnimatedDeckDiv>
+        )
+      );
 
       content = (
         <AudienceDeck addMessageHandler={addMessageHandler}>
@@ -286,6 +295,7 @@ const Deck = ({
 
 Deck.propTypes = {
   animationsWhenGoingBack: PropTypes.bool.isRequired,
+  autoLayout: PropTypes.bool,
   backgroundColor: PropTypes.string,
   children: PropTypes.node.isRequired,
   keyboardControls: PropTypes.oneOf(['arrows', 'space']),

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeContext, ThemeProvider } from 'styled-components';
 import normalize from 'normalize-newline';
@@ -230,7 +230,7 @@ const Deck = props => {
       const staticSlides = filteredChildren.map((slide, index) =>
         React.cloneElement(slide, {
           slideNum: index,
-          template: rest.template
+          template: template
         })
       );
       content = <PrintDeck>{staticSlides}</PrintDeck>;
@@ -275,7 +275,7 @@ const Deck = props => {
   }
 
   return (
-    <>
+    <Fragment>
       <DeckContext.Provider
         value={{
           state,
@@ -289,7 +289,7 @@ const Deck = props => {
       >
         {content}
       </DeckContext.Provider>
-    </>
+    </Fragment>
   );
 };
 

--- a/src/components/progress.test.js
+++ b/src/components/progress.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import useSlide, { SlideContext } from '../hooks/use-slide';
-import styled, { ThemeContext } from 'styled-components';
+import styled, { ThemeContext, css } from 'styled-components';
 import { color, space } from 'styled-system';
 import useAutofillHeight from '../hooks/use-autofill-height';
 import { DeckContext } from '../hooks/use-deck';
@@ -17,22 +17,52 @@ const SlideContainer = styled('div')`
     height: 100vh;
     width: 100vw;
   }
+  ${({ autoLayout }) =>
+    autoLayout &&
+    css`
+      height: 100%;
+      display: flex;
+      flex-direction: column-reverse;
+    `}
 `;
-const SlideWrapper = styled('div')`
-  ${color};
-  ${space};
-  flex: 1;
-  display: flex;
-`;
-const TemplateWrapper = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  pointer-events: none;
-  z-index: -1;
-`;
+
+const SlideWrapper = styled('div')(
+  color,
+  space,
+  ({ autoLayout }) =>
+    autoLayout &&
+    css`
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      > div {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+    `
+);
+
+const TemplateWrapper = styled('div')(({ autoLayout }) =>
+  autoLayout
+    ? css`
+        flex: 0 1 auto;
+        > div {
+          position: relative;
+        }
+      `
+    : css`
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        z-index: -1;
+      `
+);
+
 const InnerSlideRef = styled('div')`
   flex: 1;
 `;
@@ -44,6 +74,7 @@ const InnerSlideRef = styled('div')`
 
 const Slide = props => {
   const {
+    autoLayout,
     children,
     slideNum,
     backgroundColor,
@@ -122,10 +153,11 @@ const Slide = props => {
   return (
     <SlideContainer
       ref={slideRef}
+      autoLayout={autoLayout}
       backgroundColor={state.printMode ? '#ffffff' : backgroundColor}
       style={transforms}
     >
-      <TemplateWrapper ref={templateRef}>
+      <TemplateWrapper ref={templateRef} autoLayout={autoLayout}>
         {typeof template === 'function' &&
           template({
             slideNumber: slideNum,
@@ -136,6 +168,7 @@ const Slide = props => {
         ref={slideWrapperRef}
         padding="slidePadding"
         color={textColor}
+        autoLayout={autoLayout}
       >
         <SlideContext.Provider value={value}>
           <InnerSlideRef ref={contentRef}>{children}</InnerSlideRef>
@@ -146,6 +179,7 @@ const Slide = props => {
 };
 
 Slide.propTypes = {
+  autoLayout: PropTypes.bool,
   backgroundColor: PropTypes.string,
   children: PropTypes.node.isRequired,
   scaleRatio: PropTypes.number,

--- a/src/components/table.test.js
+++ b/src/components/table.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/typography.test.js
+++ b/src/components/typography.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';


### PR DESCRIPTION
The goal is to enable a quick way to enable flex to allow for content to be center positioned in the slide and flex column. This should allow for quicker layout when not wanting to use Box/Flex/Grid components or when using MDX.

This prop does two things

1. Makes the template and slide content flex siblings since you cannot control the template overlapping in MDX mode
2. Center-positions the slide content vertically using flex

<img width="1279" alt="Screen Shot 2019-10-31 at 2 12 10 PM" src="https://user-images.githubusercontent.com/1738349/67980610-d40d3600-fbec-11e9-92c3-0037876e1b06.png">

<img width="738" alt="Screen Shot 2019-10-31 at 2 17 23 PM" src="https://user-images.githubusercontent.com/1738349/67981329-6235ec00-fbee-11e9-9c25-7f124ad63b75.png">


Example showing the layout margins of the flex siblings of slide content and template:
<img width="779" alt="Screen Shot 2019-10-31 at 2 16 55 PM" src="https://user-images.githubusercontent.com/1738349/67980611-d4a5cc80-fbec-11e9-8059-7bbedf734608.png">
<img width="731" alt="Screen Shot 2019-10-31 at 2 17 10 PM" src="https://user-images.githubusercontent.com/1738349/67980612-d4a5cc80-fbec-11e9-82e7-caa1681c0f9b.png">

