### PR TITLE
Bug: Check component name field, not string.

### DIFF
--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -77,7 +77,7 @@ const initialState = {
 
 const mapMarkdownIntoSlides = (child, index) => {
   if (
-    isComponentType(child, 'Markdown') &&
+    isComponentType(child, Markdown.name) &&
     Boolean(child.props.containsSlides)
   ) {
     return child.props.children.split(/\n\s*---\n/).map((markdown, mdIndex) => {
@@ -108,7 +108,7 @@ const Deck = ({
 
   const filteredChildren = React.Children.map(children, mapMarkdownIntoSlides)
     .reduce((acc, slide) => acc.concat(slide), [])
-    .filter(child => isComponentType(child, 'Slide'));
+    .filter(child => isComponentType(child, Slide.name));
 
   const numberOfSlides = filteredChildren.length;
 

--- a/src/utils/is-component-type.js
+++ b/src/utils/is-component-type.js
@@ -4,8 +4,12 @@
  * Turned into a util to avoid having to repeatedly check:
  * mdx or regular component types.
  * May be unnecessary in future, if we treat MDX differently
+ *
+ * **Note**: Make sure to pass `Component.name` instead of a string name as
+ * the `name` parameter or else minification may break functionality.
+ * See: https://github.com/FormidableLabs/spectacle/issues/763
  */
 
 export default (component, name) =>
-  component.props.mdxType === name ||
-  (component.type && component.type.name === name);
+  (component.props || {}).mdxType === name ||
+  (component.type || {}).name === name;

--- a/src/utils/search-children-appear.js
+++ b/src/utils/search-children-appear.js
@@ -1,11 +1,12 @@
 import isComponentType from '../utils/is-component-type';
+import Appear from '../components/appear';
 
 export default function searchChildrenForAppear(children) {
   if (!Array.isArray(children)) {
     return 0;
   }
   return children.reduce((memo, current) => {
-    if (isComponentType(current, 'Appear')) {
+    if (isComponentType(current, Appear.name)) {
       memo += 1;
     } else if (current.props.children && current.props.children.length > 0) {
       memo += searchChildrenForAppear(current.props.children);


### PR DESCRIPTION
Check `Component.name` instead of `'Component'` string as the `name` field is subject to mutation by minification.

Fixes #763 

Validate with a static example in production mode:

```sh
$ yarn build-webpack-examples-js --mode production
$ npx serve examples/js/dist/
```

Navigate to http://127.0.0.1:5000/?slide=0&slideElement=0

Should now have a working presentation page.