### PR TITLE
Infra: deploy spectacle demo!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 branches:
   only:
     - master
-    # TODO: Remove after we release the rewrite.
+    # TODO(REWRITE): Remove after we release the rewrite.
     - task/rewrite
 
 install:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ✨ A ReactJS based Presentation Library ✨
 
-<!-- Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck [here](TODO). -->
+Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck [here](https://spectacle.formidable.com).
 
 Have a question about Spectacle? Submit an issue in this repository using the "Question" template.
 


### PR DESCRIPTION
## Work
- Add minor comments and documentation live link.
- **Netlify**: We have a `spectacle` Netlify user in 1password now and a configured site. We deploy the JS examples `examples/js/dist` as our "website".
- **GitHub**: We have a new `spectacle-ci` GH user in 1password as well for Netlify integration.
- This PR should (hopefully 🤞 ) do a preview deploy then real one to https://spectacle.formidable.com once we merge.

## Later tasks
- Netlify currently is configured to deploy on `task/rewrite` branch. After release, we'll switch to `master`. #777

/cc @kale-stew @boygirl @carlos-kelly 