### PR TITLE
Fix Table and Lists

### DIFF
--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -197,27 +197,28 @@ const TestJs = () => (
       {`
         ### Even write multiple slides in Markdown
         > Wonderfully formatted quotes
-        
+
         1. Even create
         2. Lists in Markdown
-        
+
+
         - Or Unordered Lists
-        - Too!
+        - Too!!
         Notes: These are notes
         ---
         ### This slide was also generated in Markdown!
-        
+
         \`\`\`jsx
         const evenCooler = "is that you can do code in Markdown";
-        // You can even specify the syntax type! 
+        // You can even specify the syntax type!
         \`\`\`
-        
+
         ### A slide can have multiple code blocks too.
-        
+
         \`\`\`c
         char[] someString = "Popular languages like C too!";
         \`\`\`
-        
+
         Notes: These are more notes
       `}
     </Markdown>

--- a/src/components/__snapshots__/table.test.js.snap
+++ b/src/components/__snapshots__/table.test.js.snap
@@ -7,6 +7,7 @@ exports[`<Table /> should render a <table> with a <tr> for each row and a <td> w
   fontSize="text"
   margin="listMargin"
   textAlign="left"
+  width={1}
 >
   <StyledComponent
     color="primary"
@@ -21,12 +22,13 @@ exports[`<Table /> should render a <table> with a <tr> for each row and a <td> w
           "fontSize": "text",
           "margin": "listMargin",
           "textAlign": "left",
+          "width": 1,
         },
         "attrs": Array [],
         "componentStyle": ComponentStyle {
           "componentId": "sc-bdVaJa",
           "isStatic": false,
-          "lastClassName": "durzFL",
+          "lastClassName": "iLHhEe",
           "rules": Array [
             [Function],
           ],
@@ -44,12 +46,14 @@ exports[`<Table /> should render a <table> with a <tr> for each row and a <td> w
     forwardedRef={null}
     margin="listMargin"
     textAlign="left"
+    width={1}
   >
     <table
-      className="sc-bdVaJa durzFL"
+      className="sc-bdVaJa iLHhEe"
       color="primary"
       fontFamily="text"
       fontSize="text"
+      width={1}
     >
       <styled.tbody
         color="primary"
@@ -442,6 +446,7 @@ exports[`<Table /> should render a <table> with bold text for the header row 1`]
   fontSize="text"
   margin="listMargin"
   textAlign="left"
+  width={1}
 >
   <StyledComponent
     color="primary"
@@ -456,12 +461,13 @@ exports[`<Table /> should render a <table> with bold text for the header row 1`]
           "fontSize": "text",
           "margin": "listMargin",
           "textAlign": "left",
+          "width": 1,
         },
         "attrs": Array [],
         "componentStyle": ComponentStyle {
           "componentId": "sc-bdVaJa",
           "isStatic": false,
-          "lastClassName": "durzFL",
+          "lastClassName": "iLHhEe",
           "rules": Array [
             [Function],
           ],
@@ -479,12 +485,14 @@ exports[`<Table /> should render a <table> with bold text for the header row 1`]
     forwardedRef={null}
     margin="listMargin"
     textAlign="left"
+    width={1}
   >
     <table
-      className="sc-bdVaJa durzFL"
+      className="sc-bdVaJa iLHhEe"
       color="primary"
       fontFamily="text"
       fontSize="text"
+      width={1}
     >
       <styled.thead
         color="primary"

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -23,7 +23,8 @@ Table.defaultProps = {
   fontFamily: 'text',
   fontSize: 'text',
   textAlign: 'left',
-  margin: 'listMargin'
+  margin: 'listMargin',
+  width: 1
 };
 
 const TableHeader = styled('thead')(


### PR DESCRIPTION
### Description

Prior Tables did not have full-width and the list in the demo needed extra line breaks for the parser.

<img width="1203" alt="Screen Shot 2020-01-07 at 10 03 30 AM" src="https://user-images.githubusercontent.com/1738349/71909236-39256080-3135-11ea-85d9-d58c0f12b85d.png">
<img width="1202" alt="Screen Shot 2020-01-07 at 10 03 38 AM" src="https://user-images.githubusercontent.com/1738349/71909237-39256080-3135-11ea-9d6d-a8a09d3250ba.png">
