### PR TITLE
Infra: Do real deploy to temp directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,10 @@ jobs:
         - provider: script
           # Build and deploy to production.
           # _Note_: `deploy.script` must be a **single** command string
-          # TODO(docs): Remove `--dryrun` flag to really deploy!
           script: >-
             yarn run clean &&
             yarn run prod:build &&
-            yarn run prod:deploy --dryrun
+            yarn run prod:deploy
           skip_cleanup: true
           on:
             branch: master

--- a/docs/scripts/deploy/aws.js
+++ b/docs/scripts/deploy/aws.js
@@ -27,7 +27,7 @@ const { log } = console;
 const logMsg = msg => log(chalk`[{cyan deploy/surge}] ${msg}`);
 
 const main = async ({ isDryRun }) => {
-  logMsg(`Uploading files to {cyan ${DEST}}`);
+  logMsg(chalk`Uploading files to {cyan ${DEST}}`);
   await execa(
     'aws',
     [


### PR DESCRIPTION
Part of #793

- Upload **for reals** to `open-source/spectacle-TODO-TESTING` production site (but a non-linked directory).

Files should go there but the web app may not correctly work because the url path won't match what it was built against.

/cc @boygirl @kale-stew @carlos-kelly 