### PR TITLE
added Phoenix to the landing page footer description.

### DIFF
--- a/docs/src/components/footer.js
+++ b/docs/src/components/footer.js
@@ -97,7 +97,7 @@ export const Footer = props => (
         </FooterLinks>
       </FooterLeft>
       <FooterDescription>
-        Formidable is a Seattle, Denver, and London-based engineering
+        Formidable is a Seattle, Denver, Phoenix, and London-based engineering
         consultancy and open source software organization, specializing in
         React.js, React Native, GraphQL, Node.js, and the extended JavaScript
         ecosystem. For more information about Formidable, please visit{' '}


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

I was just browsing GitHub and noticed that an issue was opened by @formidableamy a little bit ago [here](https://www.github.com/FormidableLabs/oss-landers/issues/1)  I had some down time to kill and figured I'd do this for you all.  

though, I almost feel as if using a CMS would be much better this way your marketing team could simply go in and author content.  you'd just wrap your documentation in a CMS Context.

have y'all heard of [strapi](https://strapi.io/) before?  I really like it.
[Link to Strapi](https://strapi.io/)

anyways, something like this if you did use a CMS would be dope.

```
<ContentProvider>
	{children}
</ContentProvider>
```

**and inside of the component that was changed**

```
const { footerDescription } = useContext(ContentContext)
...
<FooterDescription>
 {footerDescription}
</FooterDescription>
...
```

you could have a default value be your current footerDescription perhaps.  but I don't know.  just a thought.

Fixes # (issue)
[oss-landers-issue-1](https://www.github.com/FormidableLabs/oss-landers/issues/1)

#### Type of Change

- [x] Chore (Updated landing page description)

### How Has This Been Tested?

I just ran your `yarn run test` script.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
