### PR TITLE
fix tutorial markdown link mismatch

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -41,7 +41,7 @@ There are four ways to get started building your presentation using the classic 
 
 2.  **Option #2:** Using the [Spectacle Boilerplate](https://github.com/FormidableLabs/spectacle-boilerplate).
 
-3.  **Option #3:** Following along the [Spectacle Tutorial](./docs/tutorial.md), which also involves downloading the [Spectacle Boilerplate](https://github.com/FormidableLabs/spectacle-boilerplate).
+3.  **Option #3:** Following along the [Spectacle Tutorial](./tutorial.md), which also involves downloading the [Spectacle Boilerplate](https://github.com/FormidableLabs/spectacle-boilerplate).
 
 All three of the above ways will give you everything you'll need to get started, including a sample presentation in the `presentation` folder. You can change the props and tags as needed for your presentation or delete everything in `presentation/index.js` to start from scratch. From here you can go to [Development](#development) to get started.
 


### PR DESCRIPTION
### Description

A relative path in a link to `tutorial.md` from `getting-started.md` was wrong, which resulted in a dead link to the tutorial.

#### Type of Change

- [x] This change is a documentation error fix

### How Has This Been Tested?

I clicked the link in preview mode, and it works now. :)