### PR TITLE
Docs: Add tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ $ yarn start:one-page
 
 `spectacle-cli` uses our `js,md,one-page` examples in the CLI and boilerplate tools. To check that changes to these files don't break `spectacle-cli` upstream, check with something like the following:
 
-```sh
+```bash
 # In `spectacle` repo
 $ yarn link
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ $ yarn
 
 #### Overview
 
-Our examples are spread out across multiple projects depending on where the core technology lies. We publish most of these to `npm` for use in `spectacle-cli` project to either use with the CLI (`spectacle`) or generate a fresh project boilerplte (`spectacle-boilerplate`).
+Our examples are spread out across multiple projects depending on where the core technology lies. We publish most of these to `npm` for use in `spectacle-cli` project to either use with the CLI (`spectacle`) or generate a fresh project boilerplate (`spectacle-boilerplate`).
 
 - `spectacle`
   - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/task/rewrite/examples/js)

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -57,30 +57,7 @@ The above code gives us a Box component with red text and black background.
 
 ## Build & Deployment
 
-There are a variety of ways to host your Spectacle presentation. Our preferred path is using [gh-pages][], but there are a wide range of options for deploying and hosting your shiny, new Spectacle presentation.
-
-<a name="deploying-with-gh-pages"></a>
-
-### Deploying with Github Pages
-
-[gh-pages][] is a simple way to host a static project directly from your Github profile. It deploys your project to a URL based on your username and repository name (e.g. your-username.github.io/your-repo-name).
-
-1. Add the following keys to your package.json (assumes you have a `create-react-app`-based project):
-
-   ```json
-   "homepage": "<your-username>.github.io/<your-repo-name>",
-   "scripts": {
-    "build": "yarn run clean && react-scripts build",
-    "clean": "rm -rf ./build",
-    "deploy": "yarn run build && gh-pages -d build"
-   }
-   ```
-
-2. Then, `yarn run deploy`
-
-3. Verify that `gh-pages` is the source branch for your Page site in Github (go to `Settings > Options > Github Pages > Source`)
-
-4. Visit your deployment at your-username.github.io/your-repo-name
+There are a variety of ways to host your Spectacle presentation.
 
 <a name="keyboard-controls"></a>
 
@@ -100,9 +77,3 @@ A handful of query parameters are supported within your Spectacle presentation
 | `?print`              | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?export` e.g. `?export&print`                                 |
 | `?presenterMode=true` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](./basic-concepts.md#presenting) in our Basic Concepts doc   |
 | `?timer`              | Displays a timer inside of the [Presenter Mode](./basic-concepts.md#presenting) view. Meant for use concurrently with `?presenterMode=true` e.g. `?presenter&timer` |
-
-<!-- Links -->
-
-[gh-pages]: https://pages.github.com/
-[now]: https://zeit.co/docs
-[surge]: TODO_BROKEN_LINK

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -7,48 +7,6 @@ order: 2
 
 # Advanced Concepts
 
-<a name="themes"></a>
-
-## Themes
-
-Themeing is done using a [styled-system](https://styled-system.com/) theme object, which is passed to the `Deck` component.
-
-Spectacle will then merge your theme with the default theme (all overridden keys will be replaced by user-defined theme).
-
-The `Deck` provides the ThemeContext so the user's only concern is with writing the theme.
-
-You can import theme properties using the styled-system [style functions](https://styled-system.com/getting-started#create-a-component).
-
-If you need to extend layout components, you can use the [extends API](https://www.styled-components.com/docs/basics#extending-styles) from styled-components.
-
-```javascript
-// Example theme object
-const theme = {
-  colors: {
-    primary: 'red',
-    secondary: 'black',
-    tertiary: 'orange',
-    quaternary: 'pink',
-  }
-};
-
-// In our component
-import styled from 'styled-components'
-import { color } from 'styled-system'
-
-const SlideElement = styled.div`
-  ${color}
-`
-
-<SlideElement color="primary" bg="secondary">
-  Tomato
-</SlideElement>
-
-export default SlideElement
-```
-
-The above code gives us a Box component with red text and black background.
-
 <a name="slide-templates"></a>
 
 ## Slide Templates

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -33,5 +33,5 @@ A handful of query parameters are supported within your Spectacle presentation
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `?export`             | For exporting your presentation as a PDF. Add it to your project URL and "Save to PDF" directly from the browser                                                    |
 | `?print`              | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?export` e.g. `?export&print`                                 |
-| `?presenterMode=true` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](./basic-concepts.md#presenting) in our Basic Concepts doc   |
-| `?timer`              | Displays a timer inside of the [Presenter Mode](./basic-concepts.md#presenting) view. Meant for use concurrently with `?presenterMode=true` e.g. `?presenter&timer` |
+| `?presenterMode=true` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](/docs/basic-concepts#presenting) in our Basic Concepts doc   |
+| `?timer`              | Displays a timer inside of the [Presenter Mode](/docs/basic-concepts#presenting) view. Meant for use concurrently with `?presenterMode=true` e.g. `?presenter&timer` |

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -29,9 +29,9 @@ There are a variety of ways to host your Spectacle presentation.
 
 A handful of query parameters are supported within your Spectacle presentation
 
-| Parameter             | Description of Use                                                                                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `?export`             | For exporting your presentation as a PDF. Add it to your project URL and "Save to PDF" directly from the browser                                                    |
-| `?print`              | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?export` e.g. `?export&print`                                 |
+| Parameter             | Description of Use                                                                                                                                                   |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `?export`             | For exporting your presentation as a PDF. Add it to your project URL and "Save to PDF" directly from the browser                                                     |
+| `?print`              | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?export` e.g. `?export&print`                                  |
 | `?presenterMode=true` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](/docs/basic-concepts#presenting) in our Basic Concepts doc   |
 | `?timer`              | Displays a timer inside of the [Presenter Mode](/docs/basic-concepts#presenting) view. Meant for use concurrently with `?presenterMode=true` e.g. `?presenter&timer` |

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -21,7 +21,13 @@ There are a variety of ways to host your Spectacle presentation.
 
 ## Keyboard Controls
 
-<!-- TODO - check out use-keyboard-controls -->
+| Key Combination | Function               |
+| --------------- | ---------------------- |
+| Right Arrow     | Next Slide             |
+| Left Arrow      | Previous Slide         |
+| Alt/Option + O  | Toggle Overview Mode   |
+| Alt/Option + P  | Toggle Presenter Mode  |
+| Alt/Option + F  | Toggle Fullscreen Mode |
 
 <a name="query-parameters"></a>
 

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -17,6 +17,14 @@ order: 2
 
 There are a variety of ways to host your Spectacle presentation.
 
+1. If you are integrating this lib yourself, take your build and follow the linked instructions from any of (but not limited to) this list of providers:
+
+   - [Heroku](https://devcenter.heroku.com/articles/git#deploying-code)
+   - [Zeit](https://zeit.co/docs/v2/platform/deployments)
+   - [Surge](https://surge.sh/help/deploying-continuously-using-git-hooks)
+
+2. If using `spectacle-cli` (either `spectacle --action build` or `spectacle-boilerplate` with `yarn clean && yarn build`) your output is `dist/` and upload that directory to any of the above static hosting providers.
+
 <a name="keyboard-controls"></a>
 
 ## Keyboard Controls

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-order: 4
+order: 5
 ---
 
 <a name="api-reference"></a>

--- a/docs/content/basic-concepts.md
+++ b/docs/content/basic-concepts.md
@@ -66,7 +66,7 @@ To see a more complete examples of a presentation generated with MDX or Markdown
 - [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
 - [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
 
-For a more thorough understanding of the features and flags provided by the CLI, please see its [complete documentation](./extensions#spectacle-cli).
+For a more thorough understanding of the features and flags provided by the CLI, please see its [complete documentation](/docs/extensions#spectacle-cli).
 
 **Note:** If you want to manually create the build infrastructure for MDX support in a Spectacle deck, you can add the [`spectacle-mdx-loader`](https://github.com/FormidableLabs/spectacle-mdx-loader) plugin to your webpack configuration. Straight Markdown just requires the webpack `raw-loader`.
 

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -22,7 +22,7 @@ To see a list of the extensions we've listed here in the past, please check out 
 
 There are a few companion projects that Formidable directly maintains.
 
-## `spectacle-cli`
+## spectacle-cli
 
 [![spectacle-cli npm version](https://badge.fury.io/js/spectacle-cli.svg)](http://badge.fury.io/js/spectacle-cli)
 
@@ -30,7 +30,7 @@ A collection of tools for serving or generating new presentation decks. Includes
 
 For complete documentation of the CLI, please check out [the repo](https://www.github.com/FormidableLabs/spectacle-cli).
 
-## `spectacle-mdx-loader`
+## spectacle-mdx-loader
 
 [![spectacle-mdx-loader npm version](https://badge.fury.io/js/spectacle-mdx-loader.svg)](http://badge.fury.io/js/spectacle-mdx-loader)
 

--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-order: 4
+order: 7
 ---
 
 <a name="third-party"></a>

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -15,7 +15,7 @@ Yes - you can export your slides in PDF format. Appending your presentation URL 
 
 If you want a black & white version of your slides printed to PDF, append your URL with `?export&print` to get a printer-friendly, flattened, black & white print out of your slideshow.
 
-For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts.md/#query-parameters).
+For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts/#query-parameters).
 
 <a main="faq-2"></a>
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -21,4 +21,4 @@ For more info about the query parameters Spectacle supports, please check out ou
 
 ## Can I write my presentation in TypeScript?
 
-Yes - Spectacle types are shipped with the package, so you can safely use Spectacle in any `.ts` or `.js` presentation without a separate type definition import. Check out [the exported types](../../index.d.ts) for a complete list.
+Yes - Spectacle types are shipped with the package, so you can safely use Spectacle in any `.ts` or `.js` presentation without a separate type definition import. Check out [the exported types](https://github.com/FormidableLabs/spectacle/blob/master/index.d.ts) for a complete list.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -15,7 +15,7 @@ Yes - you can export your slides in PDF format. Appending your presentation URL 
 
 If you want a black & white version of your slides printed to PDF, append your URL with `?export&print` to get a printer-friendly, flattened, black & white print out of your slideshow.
 
-For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts#query-parameters).
+For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](/docs/advanced-concepts#query-parameters).
 
 <a main="faq-2"></a>
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-order: 5
+order: 8
 ---
 
 <a main="frequently-asked-questions"></a>

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -11,22 +11,14 @@ order: 5
 
 ## Can I export my slides for use elsewhere?
 
-Yes! Appending your presentation URL with `?export` will allow you to export your presentation by flattening out your presentation so that you can Print to PDF directly from your browser. 🎉
+Yes - you can export your slides in PDF format. Appending your presentation URL with `?export` will allow you to export your presentation by flattening out your presentation so that you can Print to PDF directly from your browser. 🎉
 
 If you want a black & white version of your slides printed to PDF, append your URL with `?export&print` to get a printer-friendly, flattened, black & white print out of your slideshow.
 
-For more info about the query parameters Spectacle supports, please check out our section about it in the [Advanced Concepts doc](./advanced-concepts.md/#query-parameters).
+For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts.md/#query-parameters).
 
 <a main="faq-2"></a>
 
-## What is the preferred way to deploy a Spectacle presentation?
-
-There are a variety of approaches to deploying your Spectacle presentation for viewership beyond your localhost, but the _preferred_ way is [TODO]().
-
-To deploy your slideshow to TODO,
-
-<a main="faq-3"></a>
-
 ## Can I write my presentation in TypeScript?
 
-The short answer is: yes!
+Yes - Spectacle types are shipped with the package, so you can safely use Spectacle in any `.ts` or `.js` presentation without a separate type definition import. Check out [the exported types](../../index.d.ts) for a complete list.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -15,7 +15,7 @@ Yes - you can export your slides in PDF format. Appending your presentation URL 
 
 If you want a black & white version of your slides printed to PDF, append your URL with `?export&print` to get a printer-friendly, flattened, black & white print out of your slideshow.
 
-For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts/#query-parameters).
+For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts#query-parameters).
 
 <a main="faq-2"></a>
 

--- a/docs/content/themes.md
+++ b/docs/content/themes.md
@@ -1,6 +1,6 @@
 ---
-title: Theme System
-order: 6
+title: Themes
+order: 4
 ---
 
 <a name="theme-system"></a>
@@ -9,9 +9,11 @@ order: 6
 
 Spectacle has a robust theme system that is built upon [styled system](https://styled-system.com/theme-specification).
 
-A theme is a 2-level deep object of theme keys with label and CSS property object values.
+A theme is a 2-level deep object of labeled theme keys and CSS property object values, which is passed directly to the `Deck` component.
 
-### Simple Theme Object Example
+## Theme Object
+
+The following is an example of a simple custom theme object:
 
 ```js
 const theme = {
@@ -26,58 +28,21 @@ const theme = {
 };
 ```
 
-### Usage Example
+## Usage
 
-Components in Spectacle can accept either a value label such as `primary` or a raw CSS value like `#f00`. The label `primary` returns `#f00` since the `backgroundColor` prop belongs in the `color` theme key.
+Components in Spectacle can accept either a value label such as `primary` or a raw CSS value like `#f00`.
+The label `primary` returns `#f00` since the `backgroundColor` prop (CSS property `background-color`) is mapped to the `colors` theme key.
 
 ```jsx
 <Box backgroundColor="primary" />
 <Box backgroundColor="#f00" />
 ```
 
-<a name="space-scales"></a>
-
-### Space Scales
-
-The `space` key is used as a scale for margins, paddings, and gaps for grids. It is an array of integer values. This allows for a more consistent scale of sizes throughout your presentation. The default theme uses three values on the scale, `16`, `24`, and `32`.
-
-#### Theme Object
-
-```jsx
-let theme = {
-  space: [16, 24, 32]
-};
-```
-
-#### Example Usage
-
-To use a scale value pass the index of the value as a numeric prop to any space theme property such as `padding` or `margin`.
-
-```jsx
-<Text padding={2}>Hello World</Text>
-```
-
-#### Default Margin Assignments
-
-Spectacle components use different values on the space scale as defaults for margins. The values can be overridden in your theme by providing alternative values as part of a space array that is at least 3 values deep. If no value is provided Spectacle will default to `0`. Individual margin values can be also provided as `margin` props to the component.
-
-| Component       | Default Space Index | Default Theme Value |
-| --------------- | ------------------- | ------------------- |
-| `Slide`         | `2`                 | `32px`              |
-| `Heading`       | `1`                 | `24px`              |
-| `Text`          | `0`                 | `16px`              |
-| `OrderedList`   | `0`                 | `16px`              |
-| `UnorderedList` | `0`                 | `16px`              |
-| `ListItem`      | `0`                 | `16px`              |
-| `Link`          | `0`                 | `16px`              |
-| `Quote`         | `0`                 | `16px`              |
-| `CodeSpan`      | `0`                 | `16px`              |
-
 <a name="theme-keys-css-props"></a>
 
-## Theme Keys and CSS Properties
+## Theme Keys
 
-The following CSS properties are divided into the below theme keys:
+Common CSS properties are divided into theme keys, which you can override in your custom theme object:
 
 | Theme Key        | CSS Properties                                                          |
 | ---------------- | ----------------------------------------------------------------------- |
@@ -94,4 +59,40 @@ The following CSS properties are divided into the below theme keys:
 | `lineHeights`    | `line-height`                                                           |
 | `letterSpacings` | `letter-spacing`                                                        |
 | `shadows`        | `box-shadow`, `text-shadow`                                             |
-| `zIndices`       | `z-index`                                                               |
+| `zIndices`       | `z-index`   
+
+<a name="scaled-spacing"></a>
+
+## Scaled Spacing
+
+The `space` key is used as a scale for margins, paddings, and gaps for grids. It is an array of integer values. This allows for a more consistent scale of sizes throughout your presentation. The default theme uses three values on the scale, `16`, `24`, and `32`.
+
+Given the following theme:
+
+```jsx
+let theme = {
+  space: [16, 24, 32]
+};
+```
+
+One can use a scale value by passing the index of the value as a numeric prop to any space theme property (such as `padding` or `margin`), like so:
+
+```jsx
+<Text padding={2}>Hello World</Text>
+```
+
+### Default Margin Assignments
+
+Spectacle components use different values on the space scale as defaults for margins. The values can be overridden in your theme by providing alternative values as part of a space array that is at least 3 values deep. If no value is provided, Spectacle will default to `0`. Individual margin values can be also provided as `margin` props to the component.
+
+| Component       | Default Space Index | Default Theme Value |
+| --------------- | ------------------- | ------------------- |
+| `Slide`         | `2`                 | `32px`              |
+| `Heading`       | `1`                 | `24px`              |
+| `Text`          | `0`                 | `16px`              |
+| `OrderedList`   | `0`                 | `16px`              |
+| `UnorderedList` | `0`                 | `16px`              |
+| `ListItem`      | `0`                 | `16px`              |
+| `Link`          | `0`                 | `16px`              |
+| `Quote`         | `0`                 | `16px`              |
+| `CodeSpan`      | `0`                 | `16px`              |

--- a/docs/content/themes.md
+++ b/docs/content/themes.md
@@ -59,7 +59,7 @@ Common CSS properties are divided into theme keys, which you can override in you
 | `lineHeights`    | `line-height`                                                           |
 | `letterSpacings` | `letter-spacing`                                                        |
 | `shadows`        | `box-shadow`, `text-shadow`                                             |
-| `zIndices`       | `z-index`   
+| `zIndices`       | `z-index`                                                               |
 
 <a name="scaled-spacing"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -1,0 +1,62 @@
+---
+title: Getting Started - A Tutorial
+order: 7
+---
+
+<a name="tutorial"></a>
+
+In this guide, we'll show you how to get started with Spectacle, and walk you through the creation and customization of a presentation deck.
+
+<a name="step-one"></a>
+
+## 1. Set up a basic React project
+
+(Probably easiest achieved using [create-react-app]())
+
+<a name="step-two"></a>
+
+## 2. Add Spectacle
+
+<a name="step-three"></a>
+
+## 3. Add some slide content
+
+<a name="step-four"></a>
+
+## 4. Add images
+
+<a name="step-five"></a>
+
+## 5. Add charts
+
+<!-- TODO - Victory impl? -->
+
+<a name="step-six"></a>
+
+## 6. Style your slides
+
+<a name="step-seven"></a>
+
+## 7. Create a theme
+
+<a name="step-eight"></a>
+
+## 8. Add animations
+
+<a name="step-nine"></a>
+
+## 9. Add code samples
+
+<a name="next-steps"></a>
+
+## Next Steps
+
+<a name="documentation-contributing-and-source"></a>
+
+## Documentation, Contributing, and Source
+
+For more information about Spectacle and its components, check out [the docs](https://formidable.com/open-source/spectacle).
+
+Interested in helping out or seeing what's happening under the hood? Spectacle is maintained [on Github](https://github.com/FormidableLabs/spectacle) and you can [start contributing here](https://github.com/FormidableLabs/spectacle/blob/master/docs/CONTRIBUTING.md).
+
+For any questions, feel free to [open a new question on Github](https://github.com/FormidableLabs/spectacle/issues/new?template=question.md).

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started - A Tutorial
-order: 7
+order: 6
 ---
 
 <a name="tutorial"></a>
@@ -15,7 +15,7 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 1. Spin up a new React project using [`create-react-app`](https://github.com/facebook/create-react-app):
 
-    ```sh
+    ```bash
     npx create-react-app spectacle-tutorial
     ```
 
@@ -69,7 +69,7 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 2. To view your slides, supply your markdown to the Spectacle CLI to start a local web server.
 
-    ```sh
+    ```bash
     $ npm install --global spectacle-cli
     $ spectacle -s my-slides.mdx
     ```
@@ -92,7 +92,7 @@ As a self-contained entity, it already has references to the dependencies you ne
 
 ### Styling your Spectacle Deck
 
-The easiest way to apply consistent styles to your Spectacle deck is using [themes](./advanced-concepts#themes).
+The easiest way to apply consistent styles to your Spectacle deck is using [themes](./themes).
 
 1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`). 
 
@@ -120,7 +120,7 @@ The easiest way to apply consistent styles to your Spectacle deck is using [them
 
     b. To use a custom theme with the Markdown CLI (Option Two), supply the file using the `-t` argument.
 
-      ```sh
+      ```bash
       $ npm install --global spectacle-cli
       $ spectacle -s my-slides.mdx -t custom-theme.js
       ```

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -11,19 +11,174 @@ In this guide, we'll show you how to get started with Spectacle, and walk you th
 
 ## 1. Set up a basic React project
 
-(Probably easiest achieved using [create-react-app]())
+Stand up a new React application (_probably easiest achieved using [create-react-app](https://github.com/facebook/create-react-app)_). We will be adding content to an index.js, which should be treated as the main entry point in your application.
 
 <a name="step-two"></a>
 
 ## 2. Add Spectacle
 
+Run `yarn add spectacle` to bring Spectacle into your React application.
+
+Almost all Spectacle presentations are comprised of a couple basic components: One `Deck` and typically multiple `Slide`s. For now, let's import these two basic components to get our deck started.
+
+The imports at the top of your main presentation file should look like this:
+
+```js
+import React from 'react';
+import { Deck, Slide } from 'spectacle';
+```
+
+To create our deck, we'll wrap some Slide components into a Deck in our Presentation class, like so:
+
+```js
+export default class Presentation extends React.Component {
+  render() {
+    return (
+      <Deck>
+        <Slide>Spectacle Boilerplate</Slide>
+        <Slide>Typography</Slide>
+        <Slide>Standard List</Slide>
+        <Slide>Example Quote</Slide>
+      </Deck>
+    );
+  }
+}
+```
+
 <a name="step-three"></a>
 
 ## 3. Add some slide content
 
+To break up our content, we can use the `Heading` and `Text` tags to display varying sizes of text. Every time we want to use a new component from the Spectacle API, we will have to add it to our imports at the top:
+
+```js
+import React from 'react';
+import { Deck, Heading, Slide, Text } from 'spectacle';
+```
+
+Now we can enhance our slides with these components:
+
+```js
+export default class Presentation extends React.Component {
+  render() {
+    return (
+      <Deck>
+        <Slide>
+          <Heading>Spectacle</Heading>
+          <Text>a React.js-based presentation library</Text>
+        </Slide>
+        <Slide>
+          <Heading>Typography</Heading>
+          <Heading>Heading 1</Heading>
+          <Heading>Heading 2</Heading>
+          <Heading>Heading 3</Heading>
+          <Heading>Heading 4</Heading>
+          <Heading>Heading 5</Heading>
+          <Text>Standard text</Text>
+        </Slide>
+        <Slide>
+          <Heading>Standard List</Heading>
+        </Slide>
+        <Slide>
+          <Heading>Example Quote</Heading>
+        </Slide>
+      </Deck>
+    );
+  }
+}
+```
+
+We can bring in additional core tags like `List` and `ListItem` to display bulleted lists on your slides:
+
+```js
+return (
+  ...
+    <Slide>
+      <List>
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+        <ListItem>Item 4</ListItem>
+      </List>
+    </Slide>
+  ...
+)
+```
+
 <a name="step-four"></a>
 
 ## 4. Add images
+
+Create an `assets` directory in the root of your project and save a few of your own images to it. Then, near the top of your file, import your image(s):
+
+<!-- TODO - revise for optimized img loading? -->
+
+```js
+const images = {
+  formidaLogo: require('../assets/formidable-logo.svg'),
+  goodWork: require('../assets/good-work.gif')
+};
+```
+
+Once you've brought in your images, you can supply them to the `src` prop on the `Image` tag to display within your slides (but don't forget to import the tag!). Now, your presentation file should look like this:
+
+```js
+import React from 'react';
+import {
+  BlockQuote,
+  Cite,
+  Deck,
+  Heading,
+  Image,
+  List,
+  ListItem,
+  Quote,
+  Slide,
+  Text
+} from 'spectacle';
+
+const images = {
+  formidaLogo: require('../assets/formidable-logo.svg'),
+  goodWork: require('../assets/good-work.gif')
+};
+
+export default class Presentation extends React.Component {
+  render() {
+    return (
+      <Deck>
+        <Slide>
+          <Heading>Spectacle</Heading>
+          <Text>a React.js-based presentation library</Text>
+        </Slide>
+        <Slide>
+          <Image src={images.formidaLogo} width={800} />
+        </Slide>
+        <Slide>
+          <Heading>Typography</Heading>
+          <Heading>Heading 1</Heading>
+          <Heading>Heading 2</Heading>
+          <Heading>Heading 3</Heading>
+          <Heading>Heading 4</Heading>
+          <Heading>Heading 5</Heading>
+          <Text>Standard text</Text>
+        </Slide>
+        <Slide>
+          <Heading>Standard List</Heading>
+          <List>
+            <ListItem>Item 1</ListItem>
+            <ListItem>Item 2</ListItem>
+            <ListItem>Item 3</ListItem>
+            <ListItem>Item 4</ListItem>
+          </List>
+        </Slide>
+        <Slide>
+          <Image src={images.goodWork} width={500} />
+        </Slide>
+      </Deck>
+    );
+  }
+}
+```
 
 <a name="step-five"></a>
 
@@ -35,21 +190,134 @@ In this guide, we'll show you how to get started with Spectacle, and walk you th
 
 ## 6. Style your slides
 
+<!-- Because the `Text`, `Image`, and `Heading` accept a number of props (like `bold`, `caps`, `fit`, `lineHeight`, and `size`), we can use these props to minimally style our content: -->
+
+<!-- ```js
+export default class Presentation extends React.Component {
+  render() {
+    return (
+      <Deck>
+        <Slide>
+          <Heading size={1} fit caps lineHeight={1}>
+            Spectacle Boilerplate
+          </Heading>
+          <Text margin="10px 0 0" fit bold>
+            open the presentation/index.js file to get started
+          </Text>
+        </Slide>
+        <Slide>
+          <Image src={images.formidaLogo} width={800} />
+        </Slide>
+        <Slide>
+          <Heading size={6} caps>
+            Typography
+          </Heading>
+          <Heading size={1}>Heading 1</Heading>
+          <Heading size={2}>Heading 2</Heading>
+          <Heading size={3}>Heading 3</Heading>
+          <Heading size={4}>Heading 4</Heading>
+          <Heading size={5}>Heading 5</Heading>
+          <Text size={6}>Standard text</Text>
+        </Slide>
+        <Slide>
+          <Heading size={6} caps>
+            Standard List
+          </Heading>
+          <List>
+            <ListItem>Item 1</ListItem>
+            <ListItem>Item 2</ListItem>
+            <ListItem>Item 3</ListItem>
+            <ListItem>Item 4</ListItem>
+          </List>
+        </Slide>
+        <Slide>
+          <Image src={images.goodWork} width={500} />
+        </Slide>
+      </Deck>
+    );
+  }
+}
+``` -->
+
 <a name="step-seven"></a>
 
 ## 7. Create a theme
+
+To style our slides further, we can create a theme to enforce fonts and colors on all of our slides.
 
 <a name="step-eight"></a>
 
 ## 8. Add animations
 
+Using the core Spectacle API, we can supply transition props <!-- TODO - like so -->.
+
+Additionally, you could bring in other core components like `Appear` to spice up your slides. `Appear` will delay the rendering of your text or image for one click, so you can have more control over the timing over your content. Just wrap any fragment you would like to delay with the tag to apply the animation. For example:
+
+```js
+<Slide>
+  <Heading>Animated List</Heading>
+  <List>
+    <Appear>
+      <ListItem>Item 1</ListItem>
+    </Appear>
+    <Appear>
+      <ListItem>Item 2</ListItem>
+    </Appear>
+    <Appear>
+      <ListItem>Item 3</ListItem>
+    </Appear>
+    <Appear>
+      <ListItem>Item 4</ListItem>
+    </Appear>
+  </List>
+</Slide>
+```
+
 <a name="step-nine"></a>
 
 ## 9. Add code samples
 
+Finally, you have a couple of options for displaying code content.
+
+<!-- TODO - is CodePane the same? -->
+<!-- TODO - is ComponentPlayground the same? -->
+
+<!-- `CodePane` and `ComponentPlayground` both offer ways to display code, but they differ in a fundamental way: `CodePane` is a styled, highlighted code preview, while `ComponentPlayground` is a two-paned view with source on the right and a preview pane on the left for showing off custom components. -->
+
+When displaying code using either component, the process is similar to displaying an image. You'll want to start by importing your code examples as assets, like so:
+
+```js
+const code = {
+  deckSample: require('../assets/code/deck.example');
+}
+```
+
+<!-- To then display this code content in a `CodePane` component, you'll provide it as a `source`:
+
+```js
+<Slide>
+  <CodePane
+    lang="jsx"
+    source={code.deckSample}
+    margin="20px auto"
+    overflow="overflow"
+  />
+</Slide>
+``` -->
+
+<!-- To display the same code sample in a `ComponentPlayground`, you'll want to provide the code sample to the component in a similar way, as the `code`:
+
+```js
+<Slide>
+  <ComponentPlayground code={code.deckSample} theme={dark} />
+</Slide>
+``` -->
+
 <a name="next-steps"></a>
 
 ## Next Steps
+
+For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the docs](https://formidable.com/open-source/spectacle).
 
 <a name="documentation-contributing-and-source"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -129,7 +129,7 @@ The easiest way to apply consistent styles to your Spectacle deck is using [them
 
 ### Sharing your Spectacle Deck
 
-For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](https://formidable.com/open-source/spectacle/docs/advanced-concepts/).
+For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](../advanced-concepts/).
 
 <a name="documentation-contributing-and-source"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -5,319 +5,125 @@ order: 7
 
 <a name="tutorial"></a>
 
-In this guide, we'll show you how to get started with Spectacle, and walk you through the creation and customization of a presentation deck.
+# Getting Started with Spectacle: A Tutorial
 
-<a name="step-one"></a>
+In this guide, we'll show you a couple of different ways to get started with Spectacle and walk you through the creation and customization of a presentation deck.
 
-## 1. Set up a basic React project
+<a name="option-one"></a>
 
-Stand up a new React application (_probably easiest achieved using [create-react-app](https://github.com/facebook/create-react-app)_). We will be adding content to an index.js, which should be treated as the main entry point in your application.
+## Option One: Using a standard React-based web app
 
-<a name="step-two"></a>
+1. Spin up a new React project using [`create-react-app`](https://github.com/facebook/create-react-app):
 
-## 2. Add Spectacle
+    ```sh
+    npx create-react-app spectacle-tutorial
+    ```
 
-Run `yarn add spectacle` to bring Spectacle into your React application.
+2. Install Spectacle by running `yarn add spectacle` or `npm i spectacle`.
 
-Almost all Spectacle presentations are comprised of a couple basic components: One `Deck` and typically multiple `Slide`s. For now, let's import these two basic components to get our deck started.
+3. In `App.js`, replace the boilerplate content with this Spectacle starter:
 
-The imports at the top of your main presentation file should look like this:
+    ```jsx
+    import React from 'react';
+    import { Deck, Slide, Heading } from 'spectacle';
 
-```js
-import React from 'react';
-import { Deck, Slide } from 'spectacle';
-```
+    function App() {
+      return (
+        <Deck>
+          <Slide>
+            <Heading>Welcome to Spectacle</Heading>
+          </Slide>
+        </Deck>
+      );
+    }
 
-To create our deck, we'll wrap some Slide components into a Deck in our Presentation class, like so:
+    export default App;
+    ```
 
-```js
-export default class Presentation extends React.Component {
-  render() {
-    return (
-      <Deck>
-        <Slide>Spectacle Boilerplate</Slide>
-        <Slide>Typography</Slide>
-        <Slide>Standard List</Slide>
-        <Slide>Example Quote</Slide>
-      </Deck>
-    );
-  }
-}
-```
+4. And you're good to go! Using `create-react-app`'s built-in `start` script, you can start a hot-reloading server to begin building your Spectacle presentation by running `yarn run start` or `npm run start`.
 
-<a name="step-three"></a>
+<a name="option-two"></a>
 
-## 3. Add some slide content
+## Option Two: Using Markdown and the Spectacle CLI
 
-To break up our content, we can use the `Heading` and `Text` tags to display varying sizes of text. Every time we want to use a new component from the Spectacle API, we will have to add it to our imports at the top:
+1. Create a new markdown file. You can use `.md` or `.mdx` (_MDX lets you mix JSX components inside markdown).
 
-```js
-import React from 'react';
-import { Deck, Heading, Slide, Text } from 'spectacle';
-```
+    You can use this as a starter:
 
-Now we can enhance our slides with these components:
+      ```md
+      # Welcome to Spectacle
 
-```js
-export default class Presentation extends React.Component {
-  render() {
-    return (
-      <Deck>
-        <Slide>
-          <Heading>Spectacle</Heading>
-          <Text>a React.js-based presentation library</Text>
-        </Slide>
-        <Slide>
-          <Heading>Typography</Heading>
-          <Heading>Heading 1</Heading>
-          <Heading>Heading 2</Heading>
-          <Heading>Heading 3</Heading>
-          <Heading>Heading 4</Heading>
-          <Heading>Heading 5</Heading>
-          <Text>Standard text</Text>
-        </Slide>
-        <Slide>
-          <Heading>Standard List</Heading>
-        </Slide>
-        <Slide>
-          <Heading>Example Quote</Heading>
-        </Slide>
-      </Deck>
-    );
-  }
-}
-```
+      - This is a list item
+      - This is another list item
 
-We can bring in additional core tags like `List` and `ListItem` to display bulleted lists on your slides:
+      ---
 
-```js
-return (
-  ...
-    <Slide>
-      <List>
-        <ListItem>Item 1</ListItem>
-        <ListItem>Item 2</ListItem>
-        <ListItem>Item 3</ListItem>
-        <ListItem>Item 4</ListItem>
-      </List>
-    </Slide>
-  ...
-)
-```
+      # Second Slide
 
-<a name="step-four"></a>
+      Text can be **bold** or _italic_!
 
-## 4. Add images
+      Notes: These are presenter notes, only visible in presenter mode to the speaker.
+      ```
 
-Create an `assets` directory in the root of your project and save a few of your own images to it. Then, near the top of your file, import your image(s):
+    **Note:** The triple dash (`---`) is used as a slide delimiter. The `Notes:` keyword is used to embed presenter notes only visible to the speaker in presenter mode.
 
-<!-- TODO - revise for optimized img loading? -->
+2. To view your slides, supply your markdown to the Spectacle CLI to start a local web server.
 
-```js
-const images = {
-  formidaLogo: require('../assets/formidable-logo.svg'),
-  goodWork: require('../assets/good-work.gif')
-};
-```
+    `npx spectacle -s my-slides.mdx`
 
-Once you've brought in your images, you can supply them to the `src` prop on the `Image` tag to display within your slides (but don't forget to import the tag!). Now, your presentation file should look like this:
+3. And you're good to go! The web server you started supports live refreshing and will update your deck as you make changes to the markdown file.
 
-```js
-import React from 'react';
-import {
-  BlockQuote,
-  Cite,
-  Deck,
-  Heading,
-  Image,
-  List,
-  ListItem,
-  Quote,
-  Slide,
-  Text
-} from 'spectacle';
+<a name="option-three"></a>
 
-const images = {
-  formidaLogo: require('../assets/formidable-logo.svg'),
-  goodWork: require('../assets/good-work.gif')
-};
+## Option Three: Using One Page
 
-export default class Presentation extends React.Component {
-  render() {
-    return (
-      <Deck>
-        <Slide>
-          <Heading>Spectacle</Heading>
-          <Text>a React.js-based presentation library</Text>
-        </Slide>
-        <Slide>
-          <Image src={images.formidaLogo} width={800} />
-        </Slide>
-        <Slide>
-          <Heading>Typography</Heading>
-          <Heading>Heading 1</Heading>
-          <Heading>Heading 2</Heading>
-          <Heading>Heading 3</Heading>
-          <Heading>Heading 4</Heading>
-          <Heading>Heading 5</Heading>
-          <Text>Standard text</Text>
-        </Slide>
-        <Slide>
-          <Heading>Standard List</Heading>
-          <List>
-            <ListItem>Item 1</ListItem>
-            <ListItem>Item 2</ListItem>
-            <ListItem>Item 3</ListItem>
-            <ListItem>Item 4</ListItem>
-          </List>
-        </Slide>
-        <Slide>
-          <Image src={images.goodWork} width={500} />
-        </Slide>
-      </Deck>
-    );
-  }
-}
-```
+One Page is a single self-contained `HTML` file that lets you build a deck using no build steps, using [htm](https://github.com/developit/htm) over JSX to reduce the dependencies and load time.
 
-<a name="step-five"></a>
-
-## 5. Add charts
-
-<!-- TODO - Victory impl? -->
-
-<a name="step-six"></a>
-
-## 6. Style your slides
-
-<!-- Because the `Text`, `Image`, and `Heading` accept a number of props (like `bold`, `caps`, `fit`, `lineHeight`, and `size`), we can use these props to minimally style our content: -->
-
-<!-- ```js
-export default class Presentation extends React.Component {
-  render() {
-    return (
-      <Deck>
-        <Slide>
-          <Heading size={1} fit caps lineHeight={1}>
-            Spectacle Boilerplate
-          </Heading>
-          <Text margin="10px 0 0" fit bold>
-            open the presentation/index.js file to get started
-          </Text>
-        </Slide>
-        <Slide>
-          <Image src={images.formidaLogo} width={800} />
-        </Slide>
-        <Slide>
-          <Heading size={6} caps>
-            Typography
-          </Heading>
-          <Heading size={1}>Heading 1</Heading>
-          <Heading size={2}>Heading 2</Heading>
-          <Heading size={3}>Heading 3</Heading>
-          <Heading size={4}>Heading 4</Heading>
-          <Heading size={5}>Heading 5</Heading>
-          <Text size={6}>Standard text</Text>
-        </Slide>
-        <Slide>
-          <Heading size={6} caps>
-            Standard List
-          </Heading>
-          <List>
-            <ListItem>Item 1</ListItem>
-            <ListItem>Item 2</ListItem>
-            <ListItem>Item 3</ListItem>
-            <ListItem>Item 4</ListItem>
-          </List>
-        </Slide>
-        <Slide>
-          <Image src={images.goodWork} width={500} />
-        </Slide>
-      </Deck>
-    );
-  }
-}
-``` -->
-
-<a name="step-seven"></a>
-
-## 7. Create a theme
-
-To style our slides further, we can create a theme to enforce fonts and colors on all of our slides.
-
-<a name="step-eight"></a>
-
-## 8. Add animations
-
-Using the core Spectacle API, we can supply transition props <!-- TODO - like so -->.
-
-Additionally, you could bring in other core components like `Appear` to spice up your slides. `Appear` will delay the rendering of your text or image for one click, so you can have more control over the timing over your content. Just wrap any fragment you would like to delay with the tag to apply the animation. For example:
-
-```js
-<Slide>
-  <Heading>Animated List</Heading>
-  <List>
-    <Appear>
-      <ListItem>Item 1</ListItem>
-    </Appear>
-    <Appear>
-      <ListItem>Item 2</ListItem>
-    </Appear>
-    <Appear>
-      <ListItem>Item 3</ListItem>
-    </Appear>
-    <Appear>
-      <ListItem>Item 4</ListItem>
-    </Appear>
-  </List>
-</Slide>
-```
-
-<a name="step-nine"></a>
-
-## 9. Add code samples
-
-Finally, you have a couple of options for displaying code content.
-
-<!-- TODO - is CodePane the same? -->
-<!-- TODO - is ComponentPlayground the same? -->
-
-<!-- `CodePane` and `ComponentPlayground` both offer ways to display code, but they differ in a fundamental way: `CodePane` is a styled, highlighted code preview, while `ComponentPlayground` is a two-paned view with source on the right and a preview pane on the left for showing off custom components. -->
-
-When displaying code using either component, the process is similar to displaying an image. You'll want to start by importing your code examples as assets, like so:
-
-```js
-const code = {
-  deckSample: require('../assets/code/deck.example');
-}
-```
-
-<!-- To then display this code content in a `CodePane` component, you'll provide it as a `source`:
-
-```js
-<Slide>
-  <CodePane
-    lang="jsx"
-    source={code.deckSample}
-    margin="20px auto"
-    overflow="overflow"
-  />
-</Slide>
-``` -->
-
-<!-- To display the same code sample in a `ComponentPlayground`, you'll want to provide the code sample to the component in a similar way, as the `code`:
-
-```js
-<Slide>
-  <ComponentPlayground code={code.deckSample} theme={dark} />
-</Slide>
-``` -->
+As a self-contained entity, it already has references to the dependencies you need to author and launch a deck in a web browser. Since there is no tooling required, One Page is also optimal on tablets. The One Page `HTML` file can be downloaded from the `examples` directory [in this repository](../../examples/one-page.html).
 
 <a name="next-steps"></a>
 
 ## Next Steps
 
-For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the docs](https://formidable.com/open-source/spectacle).
+<a name="styling"></a>
+
+### Styling your Spectacle Deck
+
+The easiest way to apply consistent styles to your Spectacle deck is using [themes](./advanced-concepts#themes).
+
+1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`). 
+
+    Here's a sample object:
+
+    ```js
+    export default {
+      colors: {
+        primary: 'red',
+        secondary: 'green'
+      },
+      fonts: {
+        header: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+      },
+      fontSizes: {
+        h1: '72px',
+        h2: '64px'
+      }
+    };
+    ```
+
+2. Consume the theme using the approach of your choice:
+
+    a. To use a custom theme with a JSX (Option One) or HTM-deck (Option Three), supply the object to the `theme` prop in the `Deck` tag. `<Deck theme={customTheme}>`.
+
+    b. To use a custom theme with the Markdown CLI (Option Two), supply the file using the `-t` argument.
+
+        npx spectacle -s my-slides.mdx -t custom-theme.js
+
+<a name="sharing"></a>
+
+### Sharing your Spectacle Deck
+
+For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](https://formidable.com/open-source/spectacle/docs/advanced-concepts/).
 
 <a name="documentation-contributing-and-source"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -15,30 +15,30 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 1. Spin up a new React project using [`create-react-app`](https://github.com/facebook/create-react-app):
 
-    ```bash
-    npx create-react-app spectacle-tutorial
-    ```
+   ```bash
+   npx create-react-app spectacle-tutorial
+   ```
 
 2. Install Spectacle by running `yarn add spectacle` or `npm i spectacle`.
 
 3. In `App.js`, replace the boilerplate content with this Spectacle starter:
 
-    ```jsx
-    import React from 'react';
-    import { Deck, Slide, Heading } from 'spectacle';
+   ```jsx
+   import React from 'react';
+   import { Deck, Slide, Heading } from 'spectacle';
 
-    function App() {
-      return (
-        <Deck>
-          <Slide>
-            <Heading>Welcome to Spectacle</Heading>
-          </Slide>
-        </Deck>
-      );
-    }
+   function App() {
+     return (
+       <Deck>
+         <Slide>
+           <Heading>Welcome to Spectacle</Heading>
+         </Slide>
+       </Deck>
+     );
+   }
 
-    export default App;
-    ```
+   export default App;
+   ```
 
 4. And you're good to go! Using `create-react-app`'s built-in `start` script, you can start a hot-reloading server to begin building your Spectacle presentation by running `yarn run start` or `npm run start`.
 
@@ -46,33 +46,33 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 ## Option Two: Using Markdown and the Spectacle CLI
 
-1. Create a new markdown file. You can use `.md` or `.mdx` (_MDX lets you mix JSX components inside markdown).
+1. Create a new markdown file. You can use `.md` or `.mdx` (\_MDX lets you mix JSX components inside markdown).
 
-    You can use this as a starter:
+   You can use this as a starter:
 
-      ```md
-      # Welcome to Spectacle
+   ```md
+   # Welcome to Spectacle
 
-      - This is a list item
-      - This is another list item
+   - This is a list item
+   - This is another list item
 
-      ---
+   ---
 
-      # Second Slide
+   # Second Slide
 
-      Text can be **bold** or _italic_!
+   Text can be **bold** or _italic_!
 
-      Notes: These are presenter notes, only visible in presenter mode to the speaker.
-      ```
+   Notes: These are presenter notes, only visible in presenter mode to the speaker.
+   ```
 
-    **Note:** The triple dash (`---`) is used as a slide delimiter. The `Notes:` keyword is used to embed presenter notes only visible to the speaker in presenter mode.
+   **Note:** The triple dash (`---`) is used as a slide delimiter. The `Notes:` keyword is used to embed presenter notes only visible to the speaker in presenter mode.
 
 2. To view your slides, supply your markdown to the Spectacle CLI to start a local web server.
 
-    ```bash
-    $ npm install --global spectacle-cli
-    $ spectacle -s my-slides.mdx
-    ```
+   ```bash
+   $ npm install --global spectacle-cli
+   $ spectacle -s my-slides.mdx
+   ```
 
 3. And you're good to go! The web server you started supports live refreshing and will update your deck as you make changes to the markdown file.
 
@@ -94,36 +94,36 @@ As a self-contained entity, it already has references to the dependencies you ne
 
 The easiest way to apply consistent styles to your Spectacle deck is using [themes](./themes).
 
-1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`). 
+1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`).
 
-    Here's a sample object:
+   Here's a sample object:
 
-    ```js
-    export default {
-      colors: {
-        primary: 'red',
-        secondary: 'green'
-      },
-      fonts: {
-        header: '"Helvetica Neue", Helvetica, Arial, sans-serif'
-      },
-      fontSizes: {
-        h1: '72px',
-        h2: '64px'
-      }
-    };
-    ```
+   ```js
+   export default {
+     colors: {
+       primary: 'red',
+       secondary: 'green'
+     },
+     fonts: {
+       header: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+     },
+     fontSizes: {
+       h1: '72px',
+       h2: '64px'
+     }
+   };
+   ```
 
 2. Consume the theme using the approach of your choice:
 
-    a. To use a custom theme with a JSX (Option One) or HTM-deck (Option Three), supply the object to the `theme` prop in the `Deck` tag. `<Deck theme={customTheme}>`.
+   a. To use a custom theme with a JSX (Option One) or HTM-deck (Option Three), supply the object to the `theme` prop in the `Deck` tag. `<Deck theme={customTheme}>`.
 
-    b. To use a custom theme with the Markdown CLI (Option Two), supply the file using the `-t` argument.
+   b. To use a custom theme with the Markdown CLI (Option Two), supply the file using the `-t` argument.
 
-      ```bash
-      $ npm install --global spectacle-cli
-      $ spectacle -s my-slides.mdx -t custom-theme.js
-      ```
+   ```bash
+   $ npm install --global spectacle-cli
+   $ spectacle -s my-slides.mdx -t custom-theme.js
+   ```
 
 <a name="sharing"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -69,7 +69,10 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 2. To view your slides, supply your markdown to the Spectacle CLI to start a local web server.
 
-    `npx spectacle -s my-slides.mdx`
+    ```sh
+    $ npm install --global spectacle-cli
+    $ spectacle -s my-slides.mdx
+    ```
 
 3. And you're good to go! The web server you started supports live refreshing and will update your deck as you make changes to the markdown file.
 
@@ -79,7 +82,7 @@ In this guide, we'll show you a couple of different ways to get started with Spe
 
 One Page is a single self-contained `HTML` file that lets you build a deck using no build steps, using [htm](https://github.com/developit/htm) over JSX to reduce the dependencies and load time.
 
-As a self-contained entity, it already has references to the dependencies you need to author and launch a deck in a web browser. Since there is no tooling required, One Page is also optimal on tablets. The One Page `HTML` file can be downloaded from the `examples` directory [in this repository](../../examples/one-page.html).
+As a self-contained entity, it already has references to the dependencies you need to author and launch a deck in a web browser. Since there is no tooling required, One Page is also optimal on tablets. The One Page `HTML` file can be downloaded from the `examples` directory [in this repository](https://unpkg.com/browse/spectacle@latest/examples/one-page.html).
 
 <a name="next-steps"></a>
 
@@ -117,7 +120,10 @@ The easiest way to apply consistent styles to your Spectacle deck is using [them
 
     b. To use a custom theme with the Markdown CLI (Option Two), supply the file using the `-t` argument.
 
-        npx spectacle -s my-slides.mdx -t custom-theme.js
+      ```sh
+      $ npm install --global spectacle-cli
+      $ spectacle -s my-slides.mdx -t custom-theme.js
+      ```
 
 <a name="sharing"></a>
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -92,7 +92,7 @@ As a self-contained entity, it already has references to the dependencies you ne
 
 ### Styling your Spectacle Deck
 
-The easiest way to apply consistent styles to your Spectacle deck is using [themes](./themes).
+The easiest way to apply consistent styles to your Spectacle deck is using [themes](/docs/themes).
 
 1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`).
 
@@ -129,7 +129,7 @@ The easiest way to apply consistent styles to your Spectacle deck is using [them
 
 ### Sharing your Spectacle Deck
 
-For more information on [presenting](./basic-concepts#presenting), [exporting](./advanced-concepts#exporting), [building](./advanced-concepts#build--deployment), or [deploying](./advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](../advanced-concepts/).
+For more information on [presenting](/docs/basic-concepts#presenting), [exporting](/docs/advanced-concepts#exporting), [building](/docs/advanced-concepts#build--deployment), or [deploying](/docs/advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](/docs/advanced-concepts).
 
 <a name="documentation-contributing-and-source"></a>
 

--- a/docs/src/screens/docs/sidebar.js
+++ b/docs/src/screens/docs/sidebar.js
@@ -80,8 +80,7 @@ class Sidebar extends React.Component {
           <SubContentWrapper>
             {subContent.map(sh => {
               const slug = `#${sh.content
-                .replace('&', '')
-                .replace('.', '')
+                .replace(/[&,:]+/gm, '')
                 .split(' ')
                 .join('-')
                 .toLowerCase()}`;

--- a/examples/md/slides.md
+++ b/examples/md/slides.md
@@ -43,7 +43,7 @@ Standard Text
 
 ---
 
-```javascript
+```js
 class SuperCoolComponent extends React.Component {
   render() {
     return <p>code slide works in markdown too whaaaaat</p>;


### PR DESCRIPTION
This PR consolidates efforts to introduce a tutorial (thanks for your work on [`task/tutorial`](https://github.com/FormidableLabs/spectacle/blob/de3b6f62cd4f80103acfb307a29de3cb635e7929/docs/tutorial.md), @carlos-kelly) and guts more TODOs preparing for release.

Remaining tasks:

- [x] Add keyboard control documentation
- [x] Add a preferred deployment option (or maybe a script?)
- [x] Fix _all_ broken links

**Upcoming PR:**

```md
- [ ] Add export documentation (this feature needs to be fixed first)
- [ ] Add images and gifs (2 of the 3 remaining text TODOs)
- [ ] Change all `task/rewrite` strings in links in docs (currently 3) to `master`
```

#### Type of Change

- [X] This change ~requires~ is a documentation update