### PR TITLE
fix sidebar naming

### DIFF
--- a/docs/src/screens/docs/sidebar.js
+++ b/docs/src/screens/docs/sidebar.js
@@ -80,6 +80,7 @@ class Sidebar extends React.Component {
           <SubContentWrapper>
             {subContent.map(sh => {
               const slug = `#${sh.content
+                .replace('&', '')
                 .replace('.', '')
                 .split(' ')
                 .join('-')
@@ -122,7 +123,7 @@ class Sidebar extends React.Component {
             <SidebarNavItem to={`/#`} key={'home'}>
               Home
             </SidebarNavItem>
-            <SidebarNavItem to={`/docs/getting-started`} key={'documentation'}>
+            <SidebarNavItem to={`/docs`} key={'documentation'}>
               Documentation
             </SidebarNavItem>
             {sidebarHeaders &&


### PR DESCRIPTION
@carlos-kelly @kale-stew 

This PR replaces the link to `docs/getting-started` (which doesn't exist as a route in this app) with a link to `/docs`. This PR also removes ampersands from sidebar links so that they match the anchor ids generated when we parse the markdown. Prior to this change, clicking on `build & deployment` in the sidebar would not correctly scroll the page.