### PR TITLE
utils/controller - hash history is always loaded even if a custom history object provided

### DIFF
--- a/src/utils/controller.js
+++ b/src/utils/controller.js
@@ -7,8 +7,6 @@ import { countSlides } from './slides';
 import theme from '../themes/default';
 import Context from './context';
 
-const history = createHashHistory();
-
 export default class Controller extends Component {
   static propTypes = {
     children: PropTypes.node,
@@ -21,7 +19,7 @@ export default class Controller extends Component {
   constructor(props) {
     super(...arguments);
 
-    this.history = props.history || history;
+    this.history = props.history || createHashHistory();
   }
 
   state = {


### PR DESCRIPTION
Hash history is always loaded even if a custom history object is provided to
<Deck history={history} />

If using a custom history object that does not use createHashHistory then there is no need to
use createHashHistory. Moved createHashHistory directly into the Controller to resolve this where it is only created if no custom history object has been provided.



#### Type of Change
- [*] Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
Tests have been run with yarn test and loaded up in Firefox as well. Custom history object
provided to \<Deck \/\> from react routers withRouter HOC to confirm createHashHistory has not been loaded unnecessarily. 
