### PR TITLE
Point docs to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ sudo: false
 branches:
   only:
     - master
-    # TODO(REWRITE): Remove after we release the rewrite.
-    - task/rewrite
 
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ $ yarn
 Our examples are spread out across multiple projects depending on where the core technology lies. We publish most of these to `npm` for use in `spectacle-cli` project to either use with the CLI (`spectacle`) or generate a fresh project boilerplate (`spectacle-boilerplate`).
 
 - `spectacle`
-  - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/task/rewrite/examples/js)
-  - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/task/rewrite/examples/md)
-  - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/task/rewrite/examples/one-page.html)
+  - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/master/examples/js)
+  - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/master/examples/md)
+  - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/master/examples/one-page.html)
 - `spectacle-mdx-loader`
   - [`examples/mdx`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx)
 - `spectacle-cli`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </a>
 </p>
 
-Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck [here](https://raw.githack.com/FormidableLabs/spectacle/task/rewrite/examples/one-page.html/).
+Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck [here](https://raw.githack.com/FormidableLabs/spectacle/master/examples/one-page.html/).
 
 Have a question about Spectacle? Submit an issue in this repository using the "Question" template.
 

--- a/docs/content/basic-concepts.md
+++ b/docs/content/basic-concepts.md
@@ -74,7 +74,7 @@ $ spectacle-boilerplate -m md
 
 To see a more complete examples of a presentation generated with MDX or Markdown, please check out our three samples available for use with the CLI as well as manual builds:
 
-- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/task/rewrite/examples/md) (`spectacle`)
+- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/master/examples/md) (`spectacle`)
 - [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
 - [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
 
@@ -90,7 +90,7 @@ This approach is where you use the library's tags to compose your presentation. 
 
 The bare minimum you'll want to use to build your presentation are the `Deck` element and a `Slide` element. Each `Slide` represents a slide within your presentation `Deck` (the entire slideshow).
 
-To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/task/rewrite/examples/js/index.js).
+To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/js/index.js).
 
 You can also bootstrap a fresh JSX project with `spectacle-boilerplate`:
 
@@ -144,7 +144,7 @@ To create a Spectacle presentation that lives in a single HTML page, you will on
 </script>
 ```
 
-To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/task/rewrite/examples/one-page.html).
+To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/one-page.html).
 
 <a name="presenting"></a>
 


### PR DESCRIPTION
### Description

Points all links from `task/rewrite` to `master` where applicable. This _should_ be the final PR to our rewrite branch before it's released.

Closes #777 