### PR TITLE
Remove lineHeight unit from notes text

### DIFF
--- a/src/components/deck/presenter-deck.js
+++ b/src/components/deck/presenter-deck.js
@@ -164,7 +164,7 @@ const PresenterDeck = props => {
           <Timer />
         </Box>
         <NotesContainer>
-          <Text fontFamily={SYSTEM_FONT} lineHeight="180%" fontSize="1.5vw">
+          <Text fontFamily={SYSTEM_FONT} lineHeight="1.2" fontSize="1.5vw">
             {currentNotes}
           </Text>
         </NotesContainer>


### PR DESCRIPTION
### Description

Fixes an issue with notes overlapping in presenter view. (See image below for bug)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

![image](https://user-images.githubusercontent.com/10567194/75498156-3bf54280-597b-11ea-9c84-27e1792e2554.png)
