### PR TITLE
fix broken link in extensions.md documentation

### DIFF
--- a/docs/content/extensions.md
+++ b/docs/content/extensions.md
@@ -9,7 +9,7 @@ order: 7
 
 In the past, developers across the open-source-iverse have created extensions for use within your Spectacle presentation.
 
-Since the [release of v6](https://github.com/FormidableLabs/spectacle/releases/tag/v6), the previously developed extensions are no longer compatible with the latest and greatest in Spectacle. We hope that changes soon, and we are happy to support you...
+Since the [release of v6](https://github.com/FormidableLabs/spectacle/releases/tag/v6.0.0), the previously developed extensions are no longer compatible with the latest and greatest in Spectacle. We hope that changes soon, and we are happy to support you...
 
 - ... in updating your project if you're one of the folks with a now-deprecated tool.
 - ... with PR review and feedback if you're interested in writing a new tool and don't know where to start.


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

I fixed a broken link found here:
https://github.com/FormidableLabs/spectacle/blob/master/docs/content/extensions.md

From: https://github.com/FormidableLabs/spectacle/releases/tag/v6
To: https://github.com/FormidableLabs/spectacle/releases/tag/v6.0.0

#### Type of Change

- Small typo fix

### How Has This Been Tested?

I ran the docs locally and ensured the link resolved to the correct destination.
