### PR TITLE
Add custom style prop 'textDecoration' to Link

### DIFF
--- a/src/components/typography.js
+++ b/src/components/typography.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
-import { color, typography, space, compose } from 'styled-system';
+import { color, typography, space, compose, system } from 'styled-system';
+
+const decoration = system({ textDecoration: true })
 
 const Text = styled('div')(compose(color, typography, space));
 Text.defaultProps = {
@@ -17,7 +19,7 @@ CodeSpan.defaultProps = {
   fontSize: 'text'
 };
 
-const Link = styled('a')(compose(color, typography, space));
+const Link = styled('a')(compose(color, typography, space, decoration));
 Link.defaultProps = {
   ...Text.defaultProps,
   textDecoration: 'underline',


### PR DESCRIPTION
### Description

Style System's library doesn't include the key 'textDecoration'. It has to be added manually so it can be changed through the theme. This is useful to remove the underline of links. I followed the instructions here: https://styled-system.com/custom-props

#### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I created a presentation and include a slide with a Link, trying to remove the underline from it:

`<Link textDecoration='none'>Testing</Link>`