### PR TITLE
Allow for dynamically updated fontSizes in CodePane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow for `props.fontSize` to override the theme's monospace font size in `CodePane`. [#875](https://github.com/FormidableLabs/spectacle/pull/875)
 - Surface `textDecoration` prop from styled-system for `Link`s. [#869](https://github.com/FormidableLabs/spectacle/pull/869)
 
 ## 6.0.1

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -39,6 +39,10 @@ export default function CodePane(props) {
   }, [themeContext]);
 
   const fontSize = React.useMemo(() => {
+    if (props && props.fontSize) {
+      return props.fontSize;
+    }
+
     if (
       themeContext &&
       themeContext.fontSizes &&
@@ -46,7 +50,9 @@ export default function CodePane(props) {
     ) {
       return themeContext.fontSizes.monospace;
     }
-    return props.fontSize;
+
+    // Default to 15px
+    return 15;
   }, [themeContext, props.fontSize]);
 
   const preStyles = React.useMemo(
@@ -159,7 +165,6 @@ CodePane.propTypes = {
 CodePane.defaultProps = {
   language: 'javascript',
   theme: theme,
-  fontSize: 15,
   highlightStart: -Infinity,
   highlightEnd: Infinity
 };


### PR DESCRIPTION
### Description

Fixes #874 -- now, users can provide a `fontSize` prop to CodePane to dynamically change the font. It will look for props first, then for a monospace theme, and finally fall back to the default size of `15px`.

#### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)