### PR TITLE
Added touch controls to navigate presentations

### DIFF
--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -19,6 +19,7 @@ import usePresentation, {
   MSG_SLIDE_STATE_CHANGE
 } from '../../hooks/use-presentation';
 import useKeyboardControls from '../../hooks/use-keyboard-controls';
+import useTouchControls from '../../hooks/use-touch-controls';
 import {
   DEFAULT_SLIDE_ELEMENT_INDEX,
   DEFAULT_SLIDE_INDEX
@@ -206,6 +207,11 @@ const Deck = props => {
     navigateToNext,
     navigateToPrevious,
     toggleMode
+  });
+
+  useTouchControls({
+    navigateToNext,
+    navigateToPrevious
   });
 
   const { runTransition } = React.useContext(TransitionPipeContext);

--- a/src/hooks/use-touch-controls.js
+++ b/src/hooks/use-touch-controls.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * Hook that navigates to next or previous slide when the user swipes
+ * left or right in a touch device, where there is no keyboard.
+ */
+const useTouchControls = ({ navigateToNext, navigateToPrevious }) => {
+  const touchId = React.useRef(null); // To keep track of which touch started the swipe.
+  const startTouchX = React.useRef(0); // Where the swipe started.
+
+  const threshold = 100; // Pixels the user must drag to trigger a slide swipe.
+
+  React.useEffect(() => {
+    /**
+     * Keep track of which touch even we're following.
+     */
+    function handleTouchStart(e) {
+      if (touchId.current === null) {
+        const touch = e.changedTouches[0];
+        touchId.current = touch.identifier;
+        startTouchX.current = touch.clientX;
+      }
+    }
+
+    /**
+     * Only care about the touch we're tracking.
+     * See how much the user swiped, if it's more than
+     * the threshold, navigate to the previous or next slide.
+     */
+    function handleTouchEnd(e) {
+      const touchList = e.changedTouches;
+      for (let i = 0; i < touchList.length; i++) {
+        const touch = touchList[i];
+        if (touch.identifier === touchId.current) {
+          touchId.current = null;
+          const distance = touch.clientX - startTouchX.current;
+          if (distance > threshold) {
+            navigateToPrevious();
+          } else if (distance < -threshold) {
+            navigateToNext();
+          }
+          break;
+        }
+      }
+    }
+
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [navigateToNext, navigateToPrevious]);
+};
+
+export default useTouchControls;


### PR DESCRIPTION
### Description

On mobile devices, without keyboard, it was impossible to move through the presentations. Users would expect being able to swipe left or right to advance and go back.

I copied the way `use-keyboard-controls.js` handled it, replacing the keyboard with touch events.

On browsers without touch capabilities, the events never fire, so having the hooks should not change anything.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I ran the development server and tested on both my desktop and mobile devices, using the example presentations.