### PR TITLE
docs: broken internal links

### DIFF
--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -92,7 +92,7 @@ As a self-contained entity, it already has references to the dependencies you ne
 
 ### Styling your Spectacle Deck
 
-The easiest way to apply consistent styles to your Spectacle deck is using [themes](/docs/themes).
+The easiest way to apply consistent styles to your Spectacle deck is using [themes](/docs/content/themes.md).
 
 1. Create a theme JS file containing a single object export. Supplied properties will be merged with the default base theme (found in Spectacle at `src/theme/default-theme.js`).
 
@@ -129,7 +129,7 @@ The easiest way to apply consistent styles to your Spectacle deck is using [them
 
 ### Sharing your Spectacle Deck
 
-For more information on [presenting](/docs/basic-concepts#presenting), [exporting](/docs/advanced-concepts#exporting), [building](/docs/advanced-concepts#build--deployment), or [deploying](/docs/advanced-concepts#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](/docs/advanced-concepts).
+For more information on [presenting](/docs/content/basic-concepts.md#presenting), [exporting](/docs/content/advanced-concepts.md#exporting), [building](/docs/content/advanced-concepts.md#build--deployment), or [deploying](/docs/content/advanced-concepts.md#build--deployment) your Spectacle deck, please check out [the documentation on advanced concepts](/docs/content/advanced-concepts.md).
 
 <a name="documentation-contributing-and-source"></a>
 


### PR DESCRIPTION
### Description

there are some broken internal links (404 page) within this file.
I correctly as many as I could within 5 min. There may be more broken links.

I didn't open an issue for this.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the preview feature in github.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated type definitions in `index.d.ts` for any breaking API changes
- [ ] My code follows the style guidelines of this project (I have run `yarn format`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
