### PR TITLE
Bug/broken links

### DIFF
--- a/docs/src/components/mdx.js
+++ b/docs/src/components/mdx.js
@@ -248,17 +248,25 @@ const MdLink = ({ href, children }) => {
     return null;
   }
 
-  if (!/^\w+:/.test(href) && !href.startsWith('#')) {
-    const hasTrailingSlash = location.pathname.endsWith('/');
-    const from = !hasTrailingSlash ? currentPage.path + '/' : currentPage.path;
-    const to = hasTrailingSlash
-      ? path.join(path.dirname(currentPage.originalPath), href)
-      : path.join(currentPage.path, href);
-    return <Link to={relative(from, to)}>{children}</Link>;
+  if (href.startsWith('#')) {
+    return <Link to={href}>{children}</Link>;
+  }
+
+  if (!/^\w+:/.test(href)) {
+    console.log(href)
+    const basePath = location.pathname.replace(currentPage.originalPath, '');
+    const to = href.includes(basePath) ? href : `${basePath}${href}`;
+    // const hasTrailingSlash = location.pathname.endsWith('/');
+    // const from = !hasTrailingSlash ? currentPage.path + '/' : currentPage.path;
+    // const to = hasTrailingSlash
+    //   ? path.join(path.dirname(currentPage.originalPath), href)
+    //   : path.join(currentPage.path, href);
+    // // return <Link to={relative(from, to)}>{children}</Link>;
+    return <Link to={to}>{children}</Link>;
   }
 
   return (
-    <a rel="external" href={href}>
+    <a rel="noopener noreferrer" target="_blank" href={href}>
       {children}
     </a>
   );

--- a/docs/src/components/mdx.js
+++ b/docs/src/components/mdx.js
@@ -8,7 +8,6 @@ import { useMarkdownPage } from 'react-static-plugin-md-pages';
 import Highlight, { Prism } from 'prism-react-renderer';
 import github from 'prism-react-renderer/themes/github';
 import SvgAnchor from '../assets/anchor';
-import { relative } from './sidebar';
 
 const getLanguage = className => {
   const res = className.match(/language-(\w+)/);
@@ -253,15 +252,10 @@ const MdLink = ({ href, children }) => {
   }
 
   if (!/^\w+:/.test(href)) {
-    console.log(href)
+    const dir = path.dirname(currentPage.originalPath);
     const basePath = location.pathname.replace(currentPage.originalPath, '');
-    const to = href.includes(basePath) ? href : `${basePath}${href}`;
-    // const hasTrailingSlash = location.pathname.endsWith('/');
-    // const from = !hasTrailingSlash ? currentPage.path + '/' : currentPage.path;
-    // const to = hasTrailingSlash
-    //   ? path.join(path.dirname(currentPage.originalPath), href)
-    //   : path.join(currentPage.path, href);
-    // // return <Link to={relative(from, to)}>{children}</Link>;
+    const head = dir === '.' ? basePath : `${basePath}${dir}`;
+    const to = href.includes(head) ? href : path.resolve(`/${head}/${href}`);
     return <Link to={to}>{children}</Link>;
   }
 

--- a/docs/src/components/navigation.js
+++ b/docs/src/components/navigation.js
@@ -101,7 +101,7 @@ export const SidebarNavSubItemWrapper = styled.div`
 
 export const SidebarNavSubItem = styled(NavLink).attrs(() => ({}))`
   display: block;
-  color: ${p => p.theme.colors.passive};
+  color: ${p => p.theme.colors.textLight};
   font-weight: ${p => p.theme.fontWeights.body};
   text-decoration: none;
   margin-top: ${p => p.theme.spacing.xs};

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -122,10 +122,7 @@ const Sidebar = props => {
 
       return (
         <React.Fragment key={page.key}>
-          <SidebarNavItem
-            to={relative(pathname, page.path)}
-            isActive={() => isActive}
-          >
+          <SidebarNavItem to={`/${page.path}`} isActive={() => isActive}>
             {page.frontmatter.title}
             {pageChildren.length ? <ChevronItem /> : null}
           </SidebarNavItem>

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -91,10 +91,6 @@ const Sidebar = props => {
       return null;
     }
 
-    // const pathname = location.pathname.endsWith('/')
-    //   ? currentPage.path + '/'
-    //   : currentPage.path;
-
     let children = tree.children;
     if (tree.frontmatter && tree.originalPath) {
       children = [{ ...tree, children: undefined }, ...children];

--- a/docs/src/components/sidebar.js
+++ b/docs/src/components/sidebar.js
@@ -42,18 +42,6 @@ const HeroBadgeWrapper = styled.div`
   }
 `;
 
-export const relative = (from, to) => {
-  if (!from || !to) return null;
-  let [toPath, hash] = to.split('#');
-  let pathname = path.relative(path.dirname(from), toPath);
-  if (!pathname)
-    pathname = path.join(path.relative(from, toPath), path.basename(toPath));
-  if (from.endsWith('/')) pathname = '../' + pathname + '/';
-  if (!pathname.endsWith('/')) pathname += '/';
-  if (hash) pathname += `#${hash}`;
-  return { pathname };
-};
-
 export const SidebarStyling = ({ children, sidebarOpen, closeSidebar }) => {
   const basepath = useBasepath() || '';
   const homepage = basepath ? `/${basepath}/` : '/';
@@ -98,15 +86,14 @@ const Sidebar = props => {
   const currentPage = useMarkdownPage();
   const location = useLocation();
   const tree = useMarkdownTree();
-
   const sidebarItems = useMemo(() => {
     if (!currentPage || !tree || !tree.children || !location) {
       return null;
     }
 
-    const pathname = location.pathname.endsWith('/')
-      ? currentPage.path + '/'
-      : currentPage.path;
+    // const pathname = location.pathname.endsWith('/')
+    //   ? currentPage.path + '/'
+    //   : currentPage.path;
 
     let children = tree.children;
     if (tree.frontmatter && tree.originalPath) {
@@ -116,13 +103,17 @@ const Sidebar = props => {
     return children.map(page => {
       const pageChildren = page.children || [];
 
+      const to = pageChildren.length
+        ? `/${pageChildren[0].path}`
+        : `/${page.path}`;
+
       const isActive = pageChildren.length
-        ? currentPage.path.startsWith(page.path)
-        : currentPage.path === page.path;
+        ? pageChildren.filter(ch => location.pathname.includes(ch.path)).length
+        : location.pathname.includes(page.path);
 
       return (
         <React.Fragment key={page.key}>
-          <SidebarNavItem to={`/${page.path}`} isActive={() => isActive}>
+          <SidebarNavItem to={to} isActive={() => isActive}>
             {page.frontmatter.title}
             {pageChildren.length ? <ChevronItem /> : null}
           </SidebarNavItem>
@@ -132,7 +123,7 @@ const Sidebar = props => {
               {pageChildren.map(childPage => (
                 <SidebarNavSubItem
                   isActive={() => childPage.path === currentPage.path}
-                  to={relative(pathname, childPage.path)}
+                  to={`/${childPage.path}`}
                   key={childPage.key}
                 >
                   {childPage.frontmatter.title}


### PR DESCRIPTION
@kale-stew @carlos-kelly 

This PR resolves relative links in the sidebar and the mdx renderer. Before this, links looked like `../props#space`, and with this change they look like `docs/props#space`

I've tested this both in dev and when serving a local prod build. We should still test again on staging once this is merged into the rewrite branch.

I wanted to make sure the changes I was making here would work for changing content, so I created a subdirectory within `/content` for testing. The link changes I've made here will support a single level of nested docs content, but not deeply nested content. This seems fine to me since the sidebar is only structured to accomodate a single layer of nesting anyway. 

This PR also changes the color of sidebar sub-pages titles from black to white for consistency. None of these are currently rendered since there isn't subdirectory content.