### PR TITLE
ALT-O Keyboard shortcut fix. Issue: #888

### DIFF
--- a/src/hooks/use-keyboard-controls.js
+++ b/src/hooks/use-keyboard-controls.js
@@ -37,8 +37,9 @@ const useKeyboardControls = ({
             e.preventDefault();
           }
         }
-        if (!!e.altKey && isMacOS()) {
-          switch (e.key) {
+        if (e.altKey && isMacOS()) {
+          const key = e.key.toUpperCase();
+          switch (key) {
             case 'ø':
               toggleMode('overviewMode');
               break;
@@ -51,8 +52,9 @@ const useKeyboardControls = ({
             default:
               null;
           }
-        } else if (!!e.altKey && !!e.shiftKey && isWindows()) {
-          switch (e.key) {
+        } else if (e.altKey && isWindows()) {
+          const key = e.key.toUpperCase();
+          switch (key) {
             case 'O':
               toggleMode('overviewMode');
               break;

--- a/src/hooks/use-keyboard-controls.js
+++ b/src/hooks/use-keyboard-controls.js
@@ -38,7 +38,7 @@ const useKeyboardControls = ({
           }
         }
         if (e.altKey && isMacOS()) {
-          const key = e.key.toUpperCase();
+          const key = e.key.toLowerCase();
           switch (key) {
             case 'ø':
               toggleMode('overviewMode');


### PR DESCRIPTION
### Description

Pull request to address the issue of keyboard shortcuts not working for Mac. I also discovered that the shortcuts weren't working for Windows as well.

Fixes #888 

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

The conditions for keyboard shortcuts for Windows & Mac were always falsy, unless CAPS lock was enabled. Tested locally on Windows, **however please test additionally for Mac machines** before merging.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project (I have run `yarn format`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
