### PR TITLE
Fix docs, replace ?export with ?exporterMode

### DIFF
--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -32,5 +32,5 @@ To combine parameters, use multiple `&` to separate the parameters, e.g.: `&expo
 | Parameter       | Description of Use                                                                                                                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `exportMode`    | For exporting your presentation as a PDF. Add it to your project URL and "Save to PDF" directly from the browser                                               |
-| `printMode`     | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?exportMode` e.g. `?exportMode=true&printMode=true`                |
+| `printMode`     | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?exportMode` e.g. `?exportMode=true&printMode=true`      |
 | `presenterMode` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](./basic-concepts#presenting) in our Basic Concepts doc |

--- a/docs/content/advanced-concepts.md
+++ b/docs/content/advanced-concepts.md
@@ -32,5 +32,5 @@ To combine parameters, use multiple `&` to separate the parameters, e.g.: `&expo
 | Parameter       | Description of Use                                                                                                                                             |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `exportMode`    | For exporting your presentation as a PDF. Add it to your project URL and "Save to PDF" directly from the browser                                               |
-| `printMode`     | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?exportMode` e.g. `?exportMode&printMode`                |
+| `printMode`     | Turns your slideshow into a printer-friendly, black & white version. Meant for use concurrently with `?exportMode` e.g. `?exportMode=true&printMode=true`                |
 | `presenterMode` | Displays a Presenter Mode for ease of presentation. For more info on this mode, please see [Presenting](./basic-concepts#presenting) in our Basic Concepts doc |

--- a/docs/content/basic-concepts.md
+++ b/docs/content/basic-concepts.md
@@ -142,9 +142,9 @@ Spectacle comes with a built-in presenter mode. It shows you a slide lookahead, 
 
 To present:
 
-1. Run `yarn start`, which will open up a presentation at [localhost:3000/#](http://localhost:3000/#) by default.
+1. Run `yarn start`, which will open up a presentation at [localhost:3000/](http://localhost:3000/) by default.
 2. Open a second browser window on a different screen.
-3. Append [`?presenter`](http://localhost:3000/#/0?presenter) or [`?presenter&timer`](http://localhost:3000/#/0?presenter&timer) immediately after the `/#`
+3. Append [`?presenterMode=true`](http://localhost:3000/?presenterMode=true) immediately after the `/`
 4. Give an amazingly in-sync and stylish presentation.
 
 **Note:** Any windows/tabs in the same browser running Spectacle will sync to one another, even if you aren't in presentation mode.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -7,9 +7,9 @@ order: 8
 
 ## Can I export my slides for use elsewhere?
 
-Yes - you can export your slides in PDF format. Appending your presentation URL with `?export` will allow you to export your presentation by flattening out your presentation so that you can Print to PDF directly from your browser. 🎉
+Yes - you can export your slides in PDF format. Appending your presentation URL with `?exportMode=true` will allow you to export your presentation by flattening out your presentation so that you can Print to PDF directly from your browser. 🎉
 
-If you want a black & white version of your slides printed to PDF, append your URL with `?export&print` to get a printer-friendly, flattened, black & white print out of your slideshow.
+If you want a black & white version of your slides printed to PDF, append your URL with `?exportMode=true&printMode=true` to get a printer-friendly, flattened, black & white print out of your slideshow.
 
 For more info about the query parameters Spectacle supports, please check out our section about it in the [advanced concepts documentation](./advanced-concepts#query-parameters).
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -142,9 +142,9 @@ Spectacle comes with a built-in presenter mode. It shows you a slide lookahead, 
 
 To present:
 
-1. Run `yarn start`, which will open up a presentation at [localhost:3000/#](http://localhost:3000/#) by default.
+1. Run `yarn start`, which will open up a presentation at [localhost:3000/](http://localhost:3000/) by default.
 2. Open a second browser window on a different screen.
-3. Append [`?presenter`](http://localhost:3000/#/0?presenter) or [`?presenter&timer`](http://localhost:3000/#/0?presenter&timer) immediately after the `/#`
+3. Append [`?presenterMode=true`](http://localhost:3000/?presenterMode=true) immediately after the `/`
 4. Give an amazingly in-sync and stylish presentation.
 
 **Note:** Any windows/tabs in the same browser running Spectacle will sync to one another, even if you aren't in presentation mode.


### PR DESCRIPTION
### Description

Replace `?export` with new `?exportMode=true` across docs.

#### Type of Change
- [x] This change requires a documentation update

### How Has This Been Tested?

Checked markdown preview in `vscode`.