### PR TITLE
Fix description of renature on docs site.

### DIFF
--- a/docs/src/screens/home/_content.js
+++ b/docs/src/screens/home/_content.js
@@ -37,7 +37,7 @@ const content = {
     {
       title: 'Renature',
       description:
-        'A collection of animations that can be used with many inline style libraries, such as Radium or Aphrodite.',
+        'A physics-based animation library for React inspired by the natural world.',
       link: 'https://formidable.com/open-source/renature'
     },
     {


### PR DESCRIPTION
### Description

This PR just fixes the description of `renature` on the Spectacle docs site 🤗 

#### Type of Change

- [X] Docs Update

### How Has This Been Tested?

I cloned the repo and ran the docs site at `localhost:3000/open-source/spectacle`. The `renature` entry now has the proper description that matches its own docs site:

<img width="1342" alt="Screen Shot 2020-05-17 at 12 37 50 PM" src="https://user-images.githubusercontent.com/19421190/82156892-584aa200-983b-11ea-97a0-7dd85fe7d7a1.png">

### Additional Notes

While I was here I noticed that the badges in the footer don't appear to be of uniform size (see screenshot above) 🤔 Just a call out for an additional update if someone else wants to take this on!