### PR TITLE
Presenter mode should show the next animation rather than the next slide

### DIFF
--- a/src/components/deck/presenter-deck.test.js
+++ b/src/components/deck/presenter-deck.test.js
@@ -25,6 +25,9 @@ const children = [
 describe('PresenterDeck', () => {
   beforeEach(() => {
     mockedUseContext.mockReturnValue({
+      slideElementMap: {
+        0: 0
+      },
       state: {
         currentNotes: '',
         currentSlide: 0,
@@ -61,6 +64,9 @@ describe('PresenterDeck', () => {
       terminateConnection: jest.fn()
     };
     mockedUseContext.mockReturnValue({
+      slideElementMap: {
+        0: 0
+      },
       state: {
         currentNotes: '',
         currentSlide: 2,

--- a/src/components/slide.js
+++ b/src/components/slide.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useSlide, { SlideContext } from '../hooks/use-slide';
+import useSlide, {
+  SlideContext,
+  SlideNextElementContext
+} from '../hooks/use-slide';
 import styled, { ThemeContext, css } from 'styled-components';
 import { background, color, space } from 'styled-system';
 import useAutofillHeight from '../hooks/use-autofill-height';
@@ -89,6 +92,7 @@ const Slide = props => {
   } = props;
   const theme = React.useContext(ThemeContext);
   const { state } = React.useContext(DeckContext);
+  const { showNextElement } = React.useContext(SlideNextElementContext) || {};
   const [ratio, setRatio] = React.useState(scaleRatio || 1);
   const [origin, setOrigin] = React.useState({ x: 0, y: 0 });
   const slideRef = React.useRef(null);
@@ -168,10 +172,21 @@ const Slide = props => {
     [state.exportMode, origin, ratio]
   );
 
-  const value = useSlide(slideNum);
+  let value = useSlide(slideNum);
   const { numberOfSlides } = value.state;
 
   useAutofillHeight({ slideWrapperRef, templateRef, contentRef, slideHeight });
+
+  if (showNextElement) {
+    // Next slide preview in the presenter mode might need to show the next animation
+    value = {
+      ...value,
+      state: {
+        ...value.state,
+        currentSlideElement: value.state.currentSlideElement + 1
+      }
+    };
+  }
 
   return (
     <SlideContainer

--- a/src/hooks/use-slide.js
+++ b/src/hooks/use-slide.js
@@ -15,6 +15,7 @@ import { DEFAULT_SLIDE_ELEMENT_INDEX } from '../utils/constants';
 
 // Initialise SlideContext.
 export const SlideContext = React.createContext();
+export const SlideNextElementContext = React.createContext();
 
 function useSlide(slideNum) {
   // Gets state, dispatch and number of slides off DeckContext.

--- a/src/hooks/use-url-routing.js
+++ b/src/hooks/use-url-routing.js
@@ -151,7 +151,8 @@ export default function useUrlRouting(options) {
       return;
     }
     const reverseDirection =
-      slideNumber < currentSlide || slideElementNumber < currentSlideElement;
+      slideNumber < currentSlide ||
+      (slideNumber == currentSlide && slideElementNumber < currentSlideElement);
     const update = {
       slideNumber,
       slideElementNumber,


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #914

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested with `start:js`, presenter view now properly shows the preview of the next animation.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
