### PR TITLE
Update the default branch's name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ about: Create a report to help us improve
 
 <!--
 
-Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest an idea for this project
 
 <!--
 
-Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -5,7 +5,7 @@ about: Ask a question about using Spectacle.
 
 <!--
 
-Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/master/CONTRIBUTING.md#contributor-covenant-code-of-conduct
+Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct
 
 -->
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: false
 
 branches:
   only:
-    - master
+    - main
 
 env:
   global:
@@ -95,10 +95,10 @@ jobs:
         - yarn run deploy:stage
 
       deploy:
-        # Deploy master to production
+        # Deploy main to production
         - provider: script
           # _Note_: `deploy.script` must be a **single** command string
           script: yarn run deploy:prod
           skip_cleanup: true
           on:
-            branch: master
+            branch: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ Our examples are spread out across multiple projects depending on where the core
   - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/main/examples/md)
   - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/main/examples/one-page.html)
 - `spectacle-mdx-loader`
-  - [`examples/mdx`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx)
+  - [`examples/mdx`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/main/examples/mdx)
 - `spectacle-cli`
-  - [`examples/cli-mdx-babel`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/cli-mdx-babel): _Not published_
+  - [`examples/cli-mdx-babel`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/main/examples/cli-mdx-babel): _Not published_
 
 #### This repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ $ yarn
 Our examples are spread out across multiple projects depending on where the core technology lies. We publish most of these to `npm` for use in `spectacle-cli` project to either use with the CLI (`spectacle`) or generate a fresh project boilerplate (`spectacle-boilerplate`).
 
 - `spectacle`
-  - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/master/examples/js)
-  - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/master/examples/md)
-  - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/master/examples/one-page.html)
+  - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/main/examples/js)
+  - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/main/examples/md)
+  - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/main/examples/one-page.html)
 - `spectacle-mdx-loader`
   - [`examples/mdx`](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx)
 - `spectacle-cli`
@@ -107,13 +107,13 @@ $ yarn link
 # In `spectacle-cli` repo
 $ yarn link spectacle
 
-# Check all MDX, MD examples per https://github.com/FormidableLabs/spectacle-cli/blob/master/CONTRIBUTING.md#examples
+# Check all MDX, MD examples per https://github.com/FormidableLabs/spectacle-cli/blob/main/CONTRIBUTING.md#examples
 $ yarn start:examples
 
 # (In another shell) Check mdx:5000, mdx+babel:5001, md:5100
 $ open http://localhost:5000/ http://localhost:5001/ http://localhost:5100/
 
-# Check all JS, MDX, MD boilerplates per https://github.com/FormidableLabs/spectacle-cli/blob/master/CONTRIBUTING.md#boilerplate
+# Check all JS, MDX, MD boilerplates per https://github.com/FormidableLabs/spectacle-cli/blob/main/CONTRIBUTING.md#boilerplate
 $ yarn clean:boilerplate
 $ yarn boilerplate:generate
 $ yarn boilerplate:install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/master/docs/src/assets/logo_spectacle.png" width=250></p>
+<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/main/docs/src/assets/logo_spectacle.png" width=250></p>
 <h2 align="center">Spectacle</h2>
 <p align="center">
 <strong>✨ A ReactJS based Presentation Library ✨</strong>
@@ -13,7 +13,7 @@
 </p>
 
 Looking for a quick preview of what you can do with Spectacle? Check out our Live Demo deck
-[here](https://raw.githack.com/FormidableLabs/spectacle/master/examples/one-page.html).
+[here](https://raw.githack.com/FormidableLabs/spectacle/main/examples/one-page.html).
 
 Have a question about Spectacle? Submit an issue in this repository using the
 ["Question" template](https://github.com/FormidableLabs/spectacle/issues/new?template=question.md).
@@ -23,4 +23,4 @@ Have a question about Spectacle? Submit an issue in this repository using the
 Spectacle's documentation lives on our [docs site](https://www.formidable.com/open-source/spectacle).
 Notice something inaccurate or confusing? Feel free to [open an issue](https://github.com/FormidableLabs/spectacle/issues)
 or [make a pull request](https://github.com/FormidableLabs/spectacle/pulls) to help improve the documentation for everyone!
-The source for our docs site lives in this repo in the [`docs`](https://github.com/FormidableLabs/spectacle/blob/master/docs/README.md) folder.
+The source for our docs site lives in this repo in the [`docs`](https://github.com/FormidableLabs/spectacle/blob/main/docs/README.md) folder.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,7 @@ $ aws-vault exec fmd-spectacle-ci --no-session -- \
 
 ## Tips for developing
 
-- Almost all of your code will be executed in two contexts: first in node for server-side rendering and static html generation, then client-side as a PWA. In addition to writing [node-safe code](https://github.com/nozzle/react-static/blob/master/docs/concepts.md#writing-universal-node-safe-code), this also means that it's necessary to validate that both contexts are working as expected.
+- Almost all of your code will be executed in two contexts: first in node for server-side rendering and static html generation, then client-side as a PWA. In addition to writing [node-safe code](https://github.com/nozzle/react-static/blob/main/docs/concepts.md#writing-universal-node-safe-code), this also means that it's necessary to validate that both contexts are working as expected.
 
 - In addition to two execution contexts, there are three stages: development, staging, and production. `yarn start` uses a local dev server with live reload that takes about one second to rebuild. This is a good choice for most local development, but it's important to keep in mind that **the development server does not build the static html.** For that, you will want to use `yarn build && yarn serve` used for staging and production deploys.
 

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -90,20 +90,20 @@ Appear is a component that makes a component animate on the slide on key press. 
 
 ## Code Pane
 
-CodePane is a component for showing a syntax-highlighted block of source code. It will scroll for overflow amounts of code. The Code Pane will trim whitespace and normalize indents. It will also wrap long lines of code and preserve the indent. Optionally you can have the Code Pane fill the available empty space on your slide via the `autoFillHeight` prop. Themes are configurable objects and can be imported from the [prism-react-renderer themes](https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes).
+CodePane is a component for showing a syntax-highlighted block of source code. It will scroll for overflow amounts of code. The Code Pane will trim whitespace and normalize indents. It will also wrap long lines of code and preserve the indent. Optionally you can have the Code Pane fill the available empty space on your slide via the `autoFillHeight` prop. Themes are configurable objects and can be imported from the [prism-react-renderer themes](https://github.com/FormidableLabs/prism-react-renderer/tree/main/src/themes).
 
 Additionally, `highlightStart` and `highlightEnd` props can be used to highlight certain ranges of code. Combine this with the [Stepper](#stepper) component to iterate over lines of code as you present.
 
-| Props            | Type                                                                                         | Example               |
-| ---------------- | -------------------------------------------------------------------------------------------- | --------------------- |
-| `autoFillHeight` | PropTypes.boolean                                                                            | `false`               |
-| `children`       | PropTypes.string                                                                             | `let name = "Carlos"` |
-| `fontSize`       | PropTypes.number                                                                             | `16`                  |
-| `highlightEnd`   | PropTypes.number                                                                             | `2`                   |
-| `highlightStart` | PropTypes.number                                                                             | `1`                   |
-| `indentSize`     | PropTypes.number                                                                             | `2`                   |
-| `language`       | PropTypes.string                                                                             | `javascript`          |
-| `theme`          | [Prism Theme](https://github.com/FormidableLabs/prism-react-renderer/tree/master/src/themes) | —                     |
+| Props            | Type                                                                                       | Example               |
+| ---------------- | ------------------------------------------------------------------------------------------ | --------------------- |
+| `autoFillHeight` | PropTypes.boolean                                                                          | `false`               |
+| `children`       | PropTypes.string                                                                           | `let name = "Carlos"` |
+| `fontSize`       | PropTypes.number                                                                           | `16`                  |
+| `highlightEnd`   | PropTypes.number                                                                           | `2`                   |
+| `highlightStart` | PropTypes.number                                                                           | `1`                   |
+| `indentSize`     | PropTypes.number                                                                           | `2`                   |
+| `language`       | PropTypes.string                                                                           | `javascript`          |
+| `theme`          | [Prism Theme](https://github.com/FormidableLabs/prism-react-renderer/tree/main/src/themes) | —                     |
 
 ```jsx
 import lightTheme from 'prism-react-renderer/themes/nightOwlLight';

--- a/docs/content/basic-concepts.md
+++ b/docs/content/basic-concepts.md
@@ -67,8 +67,8 @@ $ spectacle-boilerplate -m md
 To see a more complete examples of a presentation generated with MDX or Markdown, please check out our three samples available for use with the CLI as well as manual builds:
 
 - [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/main/examples/md) (`spectacle`)
-- [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
-- [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
+- [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/main/examples/mdx) (`spectacle-mdx-loader`)
+- [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/main/examples/cli-mdx-babel) (`spectacle-cli`)
 
 For a more thorough understanding of the features and flags provided by the CLI, please see its [complete documentation](./extensions#spectacle-cli).
 

--- a/docs/content/basic-concepts.md
+++ b/docs/content/basic-concepts.md
@@ -66,7 +66,7 @@ $ spectacle-boilerplate -m md
 
 To see a more complete examples of a presentation generated with MDX or Markdown, please check out our three samples available for use with the CLI as well as manual builds:
 
-- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/master/examples/md) (`spectacle`)
+- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/main/examples/md) (`spectacle`)
 - [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
 - [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
 
@@ -80,7 +80,7 @@ This approach is where you use the library's tags to compose your presentation. 
 
 The bare minimum you'll want to use to build your presentation are the `Deck` element and a `Slide` element. Each `Slide` represents a slide within your presentation `Deck` (the entire slideshow).
 
-To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/js/index.js).
+To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/main/examples/js/index.js).
 
 You can also bootstrap a fresh JSX project with `spectacle-boilerplate`:
 
@@ -132,7 +132,7 @@ To create a Spectacle presentation that lives in a single HTML page, you will on
 </script>
 ```
 
-To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/one-page.html).
+To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/main/examples/one-page.html).
 
 ## Presenting
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -15,4 +15,4 @@ For more info about the query parameters Spectacle supports, please check out ou
 
 ## Can I write my presentation in TypeScript?
 
-Yes - Spectacle types are shipped with the package, so you can safely use Spectacle in any `.ts` or `.js` presentation without a separate type definition import. Check out [the exported types](https://github.com/FormidableLabs/spectacle/blob/master/index.d.ts) for a complete list.
+Yes - Spectacle types are shipped with the package, so you can safely use Spectacle in any `.ts` or `.js` presentation without a separate type definition import. Check out [the exported types](https://github.com/FormidableLabs/spectacle/blob/main/index.d.ts) for a complete list.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -67,8 +67,8 @@ $ spectacle-boilerplate -m md
 To see a more complete examples of a presentation generated with MDX or Markdown, please check out our three samples available for use with the CLI as well as manual builds:
 
 - [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/main/examples/md) (`spectacle`)
-- [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
-- [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
+- [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/main/examples/mdx) (`spectacle-mdx-loader`)
+- [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/main/examples/cli-mdx-babel) (`spectacle-cli`)
 
 For a more thorough understanding of the features and flags provided by the CLI, please see its [complete documentation](./extensions#spectacle-cli).
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -66,7 +66,7 @@ $ spectacle-boilerplate -m md
 
 To see a more complete examples of a presentation generated with MDX or Markdown, please check out our three samples available for use with the CLI as well as manual builds:
 
-- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/master/examples/md) (`spectacle`)
+- [`.md` Example](https://github.com/FormidableLabs/spectacle/tree/main/examples/md) (`spectacle`)
 - [`.mdx` Example](https://github.com/FormidableLabs/spectacle-mdx-loader/tree/master/examples/mdx) (`spectacle-mdx-loader`)
 - [`.mdx` + Babel Example](https://github.com/FormidableLabs/spectacle-cli/tree/master/examples/cli-mdx-babel) (`spectacle-cli`)
 
@@ -80,7 +80,7 @@ This approach is where you use the library's tags to compose your presentation. 
 
 The bare minimum you'll want to use to build your presentation are the `Deck` element and a `Slide` element. Each `Slide` represents a slide within your presentation `Deck` (the entire slideshow).
 
-To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/js/index.js).
+To see a complete example of a presentation written in JSX, please check out our [sample JSX presentation](https://github.com/FormidableLabs/spectacle/blob/main/examples/js/index.js).
 
 You can also bootstrap a fresh JSX project with `spectacle-boilerplate`:
 
@@ -132,7 +132,7 @@ To create a Spectacle presentation that lives in a single HTML page, you will on
 </script>
 ```
 
-To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/master/examples/one-page.html).
+To see a complete example of a presentation written as a single HTML page, please check out our [sample one page presentation](https://github.com/FormidableLabs/spectacle/blob/main/examples/one-page.html).
 
 ## Presenting
 

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -121,6 +121,6 @@ For more information on [presenting](./basic-concepts#presenting), [exporting](.
 
 For more information about Spectacle and its components, check out [the docs](https://formidable.com/open-source/spectacle).
 
-Interested in helping out or seeing what's happening under the hood? Spectacle is maintained [on Github](https://github.com/FormidableLabs/spectacle) and you can [start contributing here](https://github.com/FormidableLabs/spectacle/blob/master/docs/CONTRIBUTING.md).
+Interested in helping out or seeing what's happening under the hood? Spectacle is maintained [on Github](https://github.com/FormidableLabs/spectacle) and you can [start contributing here](https://github.com/FormidableLabs/spectacle/blob/main/docs/CONTRIBUTING.md).
 
 For any questions, feel free to [open a new question on Github](https://github.com/FormidableLabs/spectacle/issues/new?template=question.md).

--- a/docs/src/screens/home/_content.js
+++ b/docs/src/screens/home/_content.js
@@ -26,7 +26,7 @@ const content = {
     bgStill: require('../../assets/demo-still.png'),
     bgWebm: require('../../assets/demo-presentation.webm'),
     demoUrl:
-      'https://raw.githack.com/FormidableLabs/spectacle/master/examples/one-page.html'
+      'https://raw.githack.com/FormidableLabs/spectacle/main/examples/one-page.html'
   },
   getStarted: {
     description:

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -131,7 +131,7 @@ const Presentation = () => (
     </Slide>
     <Slide
       backgroundColor="tertiary"
-      backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/master/beau.jpg?raw=true)"
+      backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/beau.jpg?raw=true)"
       backgroundOpacity={0.5}
     >
       <Heading>Custom Backgrounds</Heading>

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -132,7 +132,7 @@
               <p>Notes are shown in presenter mode. Open up localhost:3000/?presenterMode=true to see them.</p>
             </${Notes}>
           </${Slide}>
-          <${Slide} backgroundColor="tertiary" backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/master/beau.jpg?raw=true)" backgroundOpacity=${0.5}>
+          <${Slide} backgroundColor="tertiary" backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/beau.jpg?raw=true)" backgroundOpacity=${0.5}>
             <${Heading}>Custom Backgrounds</${Heading}>
             <${UnorderedList}>
               <${ListItem}>


### PR DESCRIPTION
### Description

This PR updates references to the default branch for a number of Formidable repos, pending a few related merges.

- spectacle
- spectacle-cli － (rel [spectacle-cli#34](https://github.com/FormidableLabs/spectacle-cli/pull/34)) 
- spectacle-mdx-loader － (rel [spectacle-mdx-loader#7](https://github.com/FormidableLabs/spectacle-mdx-loader/pull/7))
- formidadogs － (rel [dogs#16](https://github.com/FormidableLabs/dogs/pull/16))