### PR TITLE
Support presenter and overview mode query params inside the url.

### DIFF
--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -1,5 +1,12 @@
 /* eslint-disable react/prop-types */
-import * as React from 'react';
+import React, {
+  useState,
+  useEffect,
+  forwardRef,
+  useMemo,
+  useCallback,
+  createContext
+} from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import { ulid } from 'ulid';
 import { useCollectSlides } from '../../hooks/use-slides';
@@ -10,7 +17,7 @@ import useLocationSync from '../../hooks/use-location-sync';
 import { mergeTheme } from '../../theme';
 import * as queryStringMapFns from '../../location-map-fns/query-string';
 
-export const DeckContext = React.createContext();
+export const DeckContext = createContext();
 const noop = () => {};
 
 const Portal = styled('div')(({ fitAspectRatioStyle, overviewMode }) => [
@@ -29,7 +36,7 @@ const Portal = styled('div')(({ fitAspectRatioStyle, overviewMode }) => [
   }
 ]);
 
-const Deck = React.forwardRef(
+const Deck = forwardRef(
   (
     {
       id: userProvidedId,
@@ -67,7 +74,7 @@ const Deck = React.forwardRef(
     },
     ref
   ) => {
-    const [deckId] = React.useState(userProvidedId || ulid);
+    const [deckId] = useState(userProvidedId || ulid);
 
     const {
       initialized,
@@ -84,7 +91,7 @@ const Deck = React.forwardRef(
       cancelTransition
     } = useDeckState(initialDeckState);
 
-    React.useEffect(() => {
+    useEffect(() => {
       if (!initialized) return;
       onActiveStateChange(activeView);
       onActiveStateChangeExternal(activeView);
@@ -138,7 +145,7 @@ const Deck = React.forwardRef(
       ...queryStringMapFns
     });
 
-    React.useEffect(() => {
+    useEffect(() => {
       const initialView = syncLocation({
         slideIndex: 0,
         stepIndex: 0
@@ -152,7 +159,7 @@ const Deck = React.forwardRef(
       slideIdsInitialized
     ] = useCollectSlides();
 
-    const handleSlideClick = React.useCallback(
+    const handleSlideClick = useCallback(
       slideId => {
         const slideIndex = slideIds.indexOf(slideId);
         onSlideClick(slideIndex);
@@ -163,7 +170,7 @@ const Deck = React.forwardRef(
     const activeSlideId = slideIds[activeView.slideIndex];
     const pendingSlideId = slideIds[pendingView.slideIndex];
 
-    const [passed, upcoming] = React.useMemo(() => {
+    const [passed, upcoming] = useMemo(() => {
       const p = new Set();
       const u = new Set();
       let foundActive = false;
@@ -212,7 +219,7 @@ const Deck = React.forwardRef(
       targetHeight: nativeSlideHeight
     });
 
-    const overviewFrameStyle = React.useMemo(
+    const overviewFrameStyle = useMemo(
       () => ({
         margin: '1rem',
         width: `${overviewScale * nativeSlideWidth}px`,

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -1,12 +1,27 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { parse as parseQS } from 'query-string';
 import DefaultDeck from './default-deck';
 import PresenterMode from '../presenter-mode';
 import useMousetrap from '../../hooks/use-mousetrap';
 import { KEYBOARD_SHORTCUTS, SPECTACLE_MODES } from '../../utils/constants';
 
 export default function SpectacleDeck(props) {
-  const [mode, setMode] = useState(SPECTACLE_MODES.DEFAULT_MODE);
+  const { search: queryString } = location;
+  const { presenterMode, overviewMode } = parseQS(queryString, {
+    parseBooleans: true
+  });
+
+  const defaultMode = useMemo(() => {
+    if (presenterMode) {
+      return SPECTACLE_MODES.PRESENTER_MODE;
+    } else if (overviewMode) {
+      return SPECTACLE_MODES.OVERVIEW_MODE;
+    }
+    return SPECTACLE_MODES.DEFAULT_MODE;
+  }, [overviewMode, presenterMode]);
+
+  const [mode, setMode] = useState(defaultMode);
 
   const toggleMode = useCallback(
     (e, newMode) => {


### PR DESCRIPTION
- Adds support for `overviewMode=true` or `presenterMode=true` to set the deck style into those modes.
- Supports ignoring the param if the value is `false`.