### PR TITLE
v7: Code Pane | Allow single array range in highlightRanges prop

### DIFF
--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -33,22 +33,15 @@ export const availableCodePaneThemes = [
 ];
 
 const checkIfSingleArrayInHighlightRanges = highlightRanges => {
-  if (highlightRanges.length === 0) {
+  if (highlightRanges.length === 0 || highlightRanges.length > 2) {
     return false;
   }
-
-  const [highlightLineNumber] = highlightRanges;
-  return (
-    highlightRanges.length > 0 &&
-    highlightRanges.length <= 2 &&
-    typeof highlightLineNumber !== 'object' &&
-    typeof highlightLineNumber === 'number' &&
-    highlightRanges.every(range => typeof range === 'number')
-  );
+  // Prevents e.g. [3, [5]] from being considered a single array range
+  return highlightRanges.every(range => typeof range === 'number');
 };
 
 const getRangeFormat = ({ isSingleRangeProvided, highlightRanges, step }) => {
-  // if the value passed to highlightRanges is:
+  // If the value passed to highlightRanges is:
   // a single array containing only two numbers e.g. [3, 5]
   if (isSingleRangeProvided) {
     return highlightRanges;

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -67,8 +67,8 @@ const getRangeFormat = ({ isSingleRangeProvided, highlightRanges, step }) => {
 };
 
 const getStyleForLineNumber = (lineNumber, activeRange) => {
-  const isRangeOneLineNumber = activeRange.length === 1;
-  if (isRangeOneLineNumber) {
+  const isOneLineNumber = activeRange.length === 1;
+  if (isOneLineNumber) {
     const [activeLineNumber] = activeRange;
     if (activeLineNumber === lineNumber) {
       return { opacity: 1 };

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -32,14 +32,6 @@ export const availableCodePaneThemes = [
   'xonokai'
 ];
 
-const checkIfSingleArrayInHighlightRanges = highlightRanges => {
-  if (highlightRanges.length === 0 || highlightRanges.length > 2) {
-    return false;
-  }
-  // Prevents e.g. [3, [5]] from being considered a single array range
-  return highlightRanges.every(range => typeof range === 'number');
-};
-
 const getRangeFormat = ({ isSingleRangeProvided, highlightRanges, step }) => {
   // If the value passed to highlightRanges is:
   // a single array containing only two numbers e.g. [3, 5]
@@ -85,13 +77,23 @@ export default function CodePane({
   stepIndex,
   theme: syntaxTheme
 }) {
-  const isSingleRangeProvided = React.useMemo(() => {
-    return checkIfSingleArrayInHighlightRanges(highlightRanges);
-  }, [highlightRanges]);
-
   const numberOfSteps = React.useMemo(() => {
-    return isSingleRangeProvided ? 1 : highlightRanges.length;
-  }, [isSingleRangeProvided, highlightRanges]);
+    if (highlightRanges.length === 0) {
+      return 0;
+    }
+
+    // Checks if the value passed to highlightRanges is a single array containing only two numbers e.g. [3, 5]
+    const isSingleRange =
+      highlightRanges.length <= 2 &&
+      // Prevents e.g. [3, [5]] from being considered a single array range
+      highlightRanges.every(element => typeof element === 'number');
+
+    if (isSingleRange) {
+      return 1;
+    }
+
+    return highlightRanges.length;
+  }, [highlightRanges]);
 
   const theme = React.useContext(ThemeContext);
   const { stepId, isActive, step, placeholder } = useSteps(numberOfSteps, {
@@ -108,7 +110,7 @@ export default function CodePane({
     lineNumber => {
       if (!isActive) return;
       const range = getRangeFormat({
-        isSingleRangeProvided,
+        isSingleRangeProvided: numberOfSteps === 1,
         highlightRanges,
         step
       });
@@ -116,14 +118,14 @@ export default function CodePane({
         style: getStyleForLineNumber(lineNumber, range)
       };
     },
-    [isActive, highlightRanges, step, isSingleRangeProvided]
+    [isActive, highlightRanges, numberOfSteps, step]
   );
 
   const getLineProps = React.useCallback(
     lineNumber => {
       if (!isActive) return;
       const range = getRangeFormat({
-        isSingleRangeProvided,
+        isSingleRangeProvided: numberOfSteps === 1,
         highlightRanges,
         step
       });
@@ -132,7 +134,7 @@ export default function CodePane({
         style: getStyleForLineNumber(lineNumber, range)
       };
     },
-    [isActive, highlightRanges, step, isSingleRangeProvided]
+    [isActive, highlightRanges, numberOfSteps, step]
   );
 
   React.useEffect(() => {

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -211,7 +211,7 @@ CodePane.propTypes = {
     propTypes.oneOfType([
       propTypes.number.isRequired,
       propTypes.arrayOf(propTypes.number.isRequired)
-    ])
+    ]).isRequired
   ),
   language: propTypes.string.isRequired,
   children: propTypes.string.isRequired,


### PR DESCRIPTION
### Description

After verifying that issue #918 was fixed in `main-7`, it was recommended by @carlos-kelly to also allow the user to pass a single array range `[3, 5]` to the `highlightRange` prop in Code Pane

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

To reproduce, pass the following values to the `highlightRanges` prop:

```js
highlightRanges={[6, 8]}
```
![v7-single-array](https://user-images.githubusercontent.com/16032631/99123135-73148e00-25b4-11eb-9db8-405fe1ace195.gif)

```js
highlightRanges={[
  [1], 
  [3], 
  [6, 8]
]}
```
![v7-2d-array](https://user-images.githubusercontent.com/16032631/99123438-0948b400-25b5-11eb-85a0-74c8dff93570.gif)

```js
highlightRanges={[
  1, 
  3, 
  5, 
  [6, 8]
]}
```
![v7-2d-array-with-numbers](https://user-images.githubusercontent.com/16032631/99124154-7c065f00-25b6-11eb-9205-7b4e9b3faf35.gif)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code follows the style guidelines of this project (I have run `yarn format`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
