### PR TITLE
V7: Overview Mode | Update the slideIndex value in url after a user presses tab to select a slide

### DIFF
--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -16,7 +16,6 @@ import useMousetrap from '../../hooks/use-mousetrap';
 import useLocationSync from '../../hooks/use-location-sync';
 import { mergeTheme } from '../../theme';
 import * as queryStringMapFns from '../../location-map-fns/query-string';
-import { KEYBOARD_SHORTCUTS, SPECTACLE_MODES } from '../../utils/constants';
 
 export const DeckContext = createContext();
 const noop = () => {};
@@ -71,8 +70,7 @@ const Deck = forwardRef(
         slideIndex: 0,
         stepIndex: 0
       },
-      suppressBackdropFallback = false,
-      toggleMode
+      suppressBackdropFallback = false
     },
     ref
   ) => {
@@ -136,17 +134,7 @@ const Deck = forwardRef(
         ? {}
         : {
             left: () => stepBackward(),
-            right: () => stepForward(),
-            ...(overviewMode && {
-              [KEYBOARD_SHORTCUTS.TAB_FORWARD_OVERVIEW_MODE]: () =>
-                advanceSlide(),
-              [KEYBOARD_SHORTCUTS.TAB_BACKWARD_OVERVIEW_MODE]: () =>
-                regressSlide({
-                  stepIndex: 0
-                }),
-              [KEYBOARD_SHORTCUTS.SELECT_SLIDE_OVERVIEW_MODE]: e =>
-                toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE)
-            })
+            right: () => stepForward()
           },
       []
     );
@@ -174,16 +162,9 @@ const Deck = forwardRef(
     const handleSlideClick = useCallback(
       (e, slideId) => {
         const slideIndex = slideIds.indexOf(slideId);
-        if (overviewMode) {
-          skipTo({
-            slideIndex,
-            stepIndex: 0
-          });
-          toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE);
-        }
-        onSlideClick(slideIndex);
+        onSlideClick(e, slideIndex);
       },
-      [onSlideClick, overviewMode, skipTo, slideIds, toggleMode]
+      [onSlideClick, slideIds]
     );
 
     const activeSlideId = slideIds[activeView.slideIndex];

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -134,7 +134,11 @@ const Deck = forwardRef(
         ? {}
         : {
             left: () => stepBackward(),
-            right: () => stepForward()
+            right: () => stepForward(),
+            ...(overviewMode && {
+              tab: () => advanceSlide(),
+              'shift+tab': () => regressSlide()
+            })
           },
       []
     );

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -183,7 +183,7 @@ const Deck = forwardRef(
         }
         onSlideClick(slideIndex);
       },
-      [slideIds, overviewMode, skipTo, toggleMode, onSlideClick]
+      [onSlideClick, overviewMode, skipTo, slideIds, toggleMode]
     );
 
     const activeSlideId = slideIds[activeView.slideIndex];

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -16,6 +16,7 @@ import useMousetrap from '../../hooks/use-mousetrap';
 import useLocationSync from '../../hooks/use-location-sync';
 import { mergeTheme } from '../../theme';
 import * as queryStringMapFns from '../../location-map-fns/query-string';
+import { KEYBOARD_SHORTCUTS, SPECTACLE_MODES } from '../../utils/constants';
 
 export const DeckContext = createContext();
 const noop = () => {};
@@ -70,7 +71,8 @@ const Deck = forwardRef(
         slideIndex: 0,
         stepIndex: 0
       },
-      suppressBackdropFallback = false
+      suppressBackdropFallback = false,
+      toggleMode
     },
     ref
   ) => {
@@ -136,11 +138,14 @@ const Deck = forwardRef(
             left: () => stepBackward(),
             right: () => stepForward(),
             ...(overviewMode && {
-              tab: () => advanceSlide(),
-              'shift+tab': () =>
+              [KEYBOARD_SHORTCUTS.TAB_FORWARD_OVERVIEW_MODE]: () =>
+                advanceSlide(),
+              [KEYBOARD_SHORTCUTS.TAB_BACKWARD_OVERVIEW_MODE]: () =>
                 regressSlide({
                   stepIndex: 0
-                })
+                }),
+              [KEYBOARD_SHORTCUTS.SELECT_SLIDE_OVERVIEW_MODE]: e =>
+                toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE)
             })
           },
       []
@@ -167,11 +172,18 @@ const Deck = forwardRef(
     ] = useCollectSlides();
 
     const handleSlideClick = useCallback(
-      slideId => {
+      (e, slideId) => {
         const slideIndex = slideIds.indexOf(slideId);
+        if (overviewMode) {
+          skipTo({
+            slideIndex,
+            stepIndex: 0
+          });
+          toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE);
+        }
         onSlideClick(slideIndex);
       },
-      [onSlideClick, slideIds]
+      [slideIds, overviewMode, skipTo, toggleMode, onSlideClick]
     );
 
     const activeSlideId = slideIds[activeView.slideIndex];

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -137,7 +137,10 @@ const Deck = forwardRef(
             right: () => stepForward(),
             ...(overviewMode && {
               tab: () => advanceSlide(),
-              'shift+tab': () => regressSlide()
+              'shift+tab': () =>
+                regressSlide({
+                  stepIndex: 0
+                })
             })
           },
       []

--- a/src/components/deck/default-deck.js
+++ b/src/components/deck/default-deck.js
@@ -1,10 +1,45 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useCallback, useEffect } from 'react';
 import propTypes from 'prop-types';
 import Deck from './deck';
 import useBroadcastChannel from '../../hooks/use-broadcast-channel';
+import useMousetrap from '../../hooks/use-mousetrap';
+import { KEYBOARD_SHORTCUTS, SPECTACLE_MODES } from '../../utils/constants';
 
-export default function DefaultDeck({ overviewMode = false, ...props }) {
+export default function DefaultDeck({
+  overviewMode = false,
+  toggleMode,
+  ...props
+}) {
   const deck = React.useRef();
+
+  useMousetrap(
+    overviewMode
+      ? {
+          [KEYBOARD_SHORTCUTS.TAB_FORWARD_OVERVIEW_MODE]: () =>
+            deck.current.advanceSlide(),
+          [KEYBOARD_SHORTCUTS.TAB_BACKWARD_OVERVIEW_MODE]: () =>
+            deck.current.regressSlide({
+              stepIndex: 0
+            }),
+          [KEYBOARD_SHORTCUTS.SELECT_SLIDE_OVERVIEW_MODE]: e =>
+            toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE)
+        }
+      : {},
+    []
+  );
+
+  const onSlideClick = useCallback(
+    (e, slideIndex) => {
+      if (overviewMode) {
+        deck.current.skipTo({
+          slideIndex,
+          stepIndex: 0
+        });
+        toggleMode(e, SPECTACLE_MODES.DEFAULT_MODE);
+      }
+    },
+    [overviewMode, toggleMode]
+  );
 
   const [postMessage] = useBroadcastChannel(
     'spectacle_presenter_bus',
@@ -23,7 +58,14 @@ export default function DefaultDeck({ overviewMode = false, ...props }) {
     postMessage('SYNC_REQUEST');
   }, [postMessage]);
 
-  return <Deck overviewMode={overviewMode} ref={deck} {...props} />;
+  return (
+    <Deck
+      overviewMode={overviewMode}
+      onSlideClick={onSlideClick}
+      ref={deck}
+      {...props}
+    />
+  );
 }
 
 DefaultDeck.propTypes = { ...Deck.propTypes, overviewMode: propTypes.bool };

--- a/src/components/deck/default-deck.js
+++ b/src/components/deck/default-deck.js
@@ -12,6 +12,23 @@ export default function DefaultDeck({
 }) {
   const deck = React.useRef();
 
+  const [postMessage] = useBroadcastChannel(
+    'spectacle_presenter_bus',
+    message => {
+      if (message.type !== 'SYNC') return;
+      const nextView = message.payload;
+      if (deck.current.initialized) {
+        deck.current.skipTo(nextView);
+      } else {
+        deck.current.initializeTo(nextView);
+      }
+    }
+  );
+
+  useEffect(() => {
+    postMessage('SYNC_REQUEST');
+  }, [postMessage]);
+
   useMousetrap(
     overviewMode
       ? {
@@ -41,23 +58,6 @@ export default function DefaultDeck({
     [overviewMode, toggleMode]
   );
 
-  const [postMessage] = useBroadcastChannel(
-    'spectacle_presenter_bus',
-    message => {
-      if (message.type !== 'SYNC') return;
-      const nextView = message.payload;
-      if (deck.current.initialized) {
-        deck.current.skipTo(nextView);
-      } else {
-        deck.current.initializeTo(nextView);
-      }
-    }
-  );
-
-  useEffect(() => {
-    postMessage('SYNC_REQUEST');
-  }, [postMessage]);
-
   return (
     <Deck
       overviewMode={overviewMode}
@@ -68,4 +68,8 @@ export default function DefaultDeck({
   );
 }
 
-DefaultDeck.propTypes = { ...Deck.propTypes, overviewMode: propTypes.bool };
+DefaultDeck.propTypes = {
+  ...Deck.propTypes,
+  overviewMode: propTypes.bool,
+  toggleMode: propTypes.func
+};

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -53,7 +53,7 @@ export default function SpectacleDeck(props) {
       return <PresenterMode {...props} />;
 
     case SPECTACLE_MODES.OVERVIEW_MODE:
-      return <DefaultDeck overviewMode {...props} />;
+      return <DefaultDeck overviewMode toggleMode={toggleMode} {...props} />;
 
     default:
       return null;

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -76,6 +76,12 @@ const AnimatedDiv = styled(animated.div)`
   height: 100%;
   position: absolute;
   background: transparent;
+  &:hover {
+    outline: 2px solid white;
+  }
+  &:active {
+    outline: 1px solid white;
+  }
   ${({ tabIndex }) =>
     tabIndex === 0 &&
     css`
@@ -126,9 +132,12 @@ export default function Slide({
     cancelTransition,
     template: deckTemplate
   } = useContext(DeckContext);
-  const handleClick = useCallback(() => {
-    onSlideClick(slideId);
-  }, [onSlideClick, slideId]);
+  const handleClick = useCallback(
+    e => {
+      onSlideClick(e, slideId);
+    },
+    [onSlideClick, slideId]
+  );
 
   const isActive = activeView.slideId === slideId;
   const isPending = pendingView.slideId === slideId;

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -84,7 +84,7 @@ const AnimatedDiv = styled(animated.div)`
     css`
       outline: 2px solid white;
     `}
-  ${({ inOverviewMode }) =>
+  ${({ 'data-in-overview-mode': inOverviewMode }) =>
     inOverviewMode &&
     css`
       &:hover {
@@ -305,7 +305,7 @@ export default function Slide({
             <AnimatedDiv
               ref={setStepContainer}
               onClick={handleClick}
-              inOverviewMode={inOverviewMode}
+              data-in-overview-mode={inOverviewMode}
               tabIndex={inOverviewMode && isActive ? 0 : undefined}
               style={{ ...springFrameStyle, ...frameOverrideStyle }}
             >

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -76,9 +76,6 @@ const AnimatedDiv = styled(animated.div)`
   height: 100%;
   position: absolute;
   background: transparent;
-  &:hover {
-    outline: 2px solid white;
-  }
   &:active {
     outline: 1px solid white;
   }
@@ -86,6 +83,13 @@ const AnimatedDiv = styled(animated.div)`
     tabIndex === 0 &&
     css`
       outline: 2px solid white;
+    `}
+  ${({ isOverviewMode }) =>
+    isOverviewMode &&
+    css`
+      &:hover {
+        outline: 2px solid white;
+      }
     `}
 `;
 
@@ -139,6 +143,7 @@ export default function Slide({
     [onSlideClick, slideId]
   );
 
+  const isOverviewMode = Object.entries(frameOverrideStyle).length > 0;
   const isActive = activeView.slideId === slideId;
   const isPending = pendingView.slideId === slideId;
   const isPassed = passedSlideIds.has(slideId);
@@ -300,11 +305,8 @@ export default function Slide({
             <AnimatedDiv
               ref={setStepContainer}
               onClick={handleClick}
-              tabIndex={
-                Object.entries(frameOverrideStyle).length > 0 && isActive
-                  ? 0
-                  : undefined
-              }
+              isOverviewMode={isOverviewMode}
+              tabIndex={isOverviewMode && isActive ? 0 : undefined}
               style={{ ...springFrameStyle, ...frameOverrideStyle }}
             >
               <SlideContainer

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -79,9 +79,7 @@ const AnimatedDiv = styled(animated.div)`
   ${({ tabIndex }) =>
     tabIndex === 0 &&
     css`
-      &:focus {
-        outline: 2px solid white;
-      }
+      outline: 2px solid white;
     `}
 `;
 
@@ -294,7 +292,9 @@ export default function Slide({
               ref={setStepContainer}
               onClick={handleClick}
               tabIndex={
-                Object.entries(frameOverrideStyle).length > 0 ? 0 : undefined
+                Object.entries(frameOverrideStyle).length > 0 && isActive
+                  ? 0
+                  : undefined
               }
               style={{ ...springFrameStyle, ...frameOverrideStyle }}
             >

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -84,7 +84,7 @@ const AnimatedDiv = styled(animated.div)`
     css`
       outline: 2px solid white;
     `}
-  ${({ 'data-in-overview-mode': inOverviewMode }) =>
+  ${({ 'data-overview-mode': inOverviewMode }) =>
     inOverviewMode &&
     css`
       &:hover {
@@ -305,7 +305,7 @@ export default function Slide({
             <AnimatedDiv
               ref={setStepContainer}
               onClick={handleClick}
-              data-in-overview-mode={inOverviewMode}
+              data-overview-mode={inOverviewMode}
               tabIndex={inOverviewMode && isActive ? 0 : undefined}
               style={{ ...springFrameStyle, ...frameOverrideStyle }}
             >

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -84,8 +84,8 @@ const AnimatedDiv = styled(animated.div)`
     css`
       outline: 2px solid white;
     `}
-  ${({ isOverviewMode }) =>
-    isOverviewMode &&
+  ${({ inOverviewMode }) =>
+    inOverviewMode &&
     css`
       &:hover {
         outline: 2px solid white;
@@ -143,7 +143,7 @@ export default function Slide({
     [onSlideClick, slideId]
   );
 
-  const isOverviewMode = Object.entries(frameOverrideStyle).length > 0;
+  const inOverviewMode = Object.entries(frameOverrideStyle).length > 0;
   const isActive = activeView.slideId === slideId;
   const isPending = pendingView.slideId === slideId;
   const isPassed = passedSlideIds.has(slideId);
@@ -305,8 +305,8 @@ export default function Slide({
             <AnimatedDiv
               ref={setStepContainer}
               onClick={handleClick}
-              isOverviewMode={isOverviewMode}
-              tabIndex={isOverviewMode && isActive ? 0 : undefined}
+              inOverviewMode={inOverviewMode}
+              tabIndex={inOverviewMode && isActive ? 0 : undefined}
               style={{ ...springFrameStyle, ...frameOverrideStyle }}
             >
               <SlideContainer

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -76,21 +76,14 @@ const AnimatedDiv = styled(animated.div)`
   height: 100%;
   position: absolute;
   background: transparent;
-  &:active {
-    outline: 1px solid white;
-  }
   ${({ tabIndex }) =>
     tabIndex === 0 &&
     css`
       outline: 2px solid white;
     `}
-  ${({ 'data-overview-mode': inOverviewMode }) =>
-    inOverviewMode &&
-    css`
-      &:hover {
-        outline: 2px solid white;
-      }
-    `}
+  &:active {
+    outline: 1px solid white;
+  }
 `;
 
 export default function Slide({
@@ -163,6 +156,11 @@ export default function Slide({
   // animated.)
   const infinityDirection = isPassed ? Infinity : -Infinity;
   const internalStepIndex = isActive ? activeView.stepIndex : infinityDirection;
+
+  const [hover, setHover] = useState(false);
+  const onHoverChange = useCallback(() => {
+    setHover(!hover);
+  }, [hover]);
 
   React.useEffect(() => {
     if (!isActive) return;
@@ -305,9 +303,17 @@ export default function Slide({
             <AnimatedDiv
               ref={setStepContainer}
               onClick={handleClick}
-              data-overview-mode={inOverviewMode}
               tabIndex={inOverviewMode && isActive ? 0 : undefined}
-              style={{ ...springFrameStyle, ...frameOverrideStyle }}
+              style={{
+                ...springFrameStyle,
+                ...frameOverrideStyle,
+                ...(inOverviewMode &&
+                  hover && {
+                    outline: '2px solid white'
+                  })
+              }}
+              onMouseEnter={onHoverChange}
+              onMouseLeave={onHoverChange}
             >
               <SlideContainer
                 className={className}

--- a/src/hooks/use-deck-state.js
+++ b/src/hooks/use-deck-state.js
@@ -55,7 +55,7 @@ function deckReducer(state, { type, payload = {} }) {
       return {
         ...state,
         pendingView: merge(state.pendingView, {
-          stepIndex: GOTO_FINAL_STEP,
+          stepIndex: payload?.stepIndex ?? GOTO_FINAL_STEP,
           slideIndex: state.pendingView.slideIndex - 1
         })
       };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,7 +5,10 @@ export const SYSTEM_FONT =
 
 export const KEYBOARD_SHORTCUTS = {
   PRESENTER_MODE: 'mod+p',
-  OVERVIEW_MODE: 'mod+o'
+  OVERVIEW_MODE: 'mod+o',
+  TAB_FORWARD_OVERVIEW_MODE: 'tab',
+  TAB_BACKWARD_OVERVIEW_MODE: 'shift+tab',
+  SELECT_SLIDE_OVERVIEW_MODE: 'enter'
 };
 
 export const SPECTACLE_MODES = {


### PR DESCRIPTION
### Description
1. Update the `slideIndex` value in the url `?slideIndex=2&stepIndex=0` in overview mode after a user presses the **tab** key to select a certain slide or  **shift+tab** to select a previous slide

2. When user switches to overview mode, the current slide will have a outline white border applied to its div

3. Added outline style on hovering a slide in overview mode

4. Pressing enter or clicking on a slide in overview mode, will update the url to contain that slideIndex and exit overview mode

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
• To test PR, visit `http://localhost:3000/?slideIndex=3&stepIndex=0` with a `slideIndex` value of any slide, then press `ctrl/cmd + o` to switch over to overview mode

![spectacle-tab-overview-mode](https://user-images.githubusercontent.com/16032631/99453056-41176a80-28d9-11eb-943e-7e735d98fae9.gif)

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project (I have run `yarn format`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
