### PR TITLE
v7: Bump version number for Babel to build on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "react-dom": "^16.9.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.5",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
-    "@babel/preset-env": "^7.4.5",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/cli": "^7.12.8",
+    "@babel/core": "^7.12.8",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+    "@babel/preset-env": "^7.12.7",
+    "@babel/preset-react": "^7.12.7",
     "@types/react": "^16.9.19",
     "@types/styled-system": "^5.1.4",
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
Bumps Babel version numbers which allows for functional building on Windows CMD/PowerShell