### PR TITLE
v7: Update usePresentation hook tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
+    "@testing-library/react-hooks": "^3.7.0",
     "@types/react": "^16.9.19",
     "@types/styled-system": "^5.1.4",
     "babel-eslint": "^10.0.2",

--- a/src/hooks/use-presentation.js
+++ b/src/hooks/use-presentation.js
@@ -95,6 +95,7 @@ function usePresentation() {
     sendMessage,
     errors,
     addMessageHandler,
+    connection,
     isReceiver: Boolean(getReceiver()),
     isController: Boolean(connection)
   };

--- a/src/hooks/use-presentation.test.js
+++ b/src/hooks/use-presentation.test.js
@@ -1,61 +1,101 @@
-import React from 'react';
-import Enzyme, { mount } from 'enzyme';
+import 'regenerator-runtime/runtime';
+import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-
+import { renderHook, act } from '@testing-library/react-hooks';
 import usePresentation from './use-presentation';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('usePresentation', () => {
-  it('when starting connection it calls start method on PresentationRequest and connection is set to true', () => {
-    const startMock = jest.fn().mockResolvedValue({});
-    class PresentationRequest {
-      constructor() {}
-      start = startMock;
-    }
-    global.PresentationRequest = PresentationRequest;
-    const TestComponent = () => {
-      const { startConnection } = usePresentation();
-      return (
-        <button
-          data-testid="startConnection"
-          onClick={() => startConnection()}
-        ></button>
-      );
-    };
-    const component = mount(<TestComponent />);
-    component.find('[data-testid="startConnection"]').simulate('click');
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  it('when starting connection it calls start method on PresentationRequest.', async () => {
+    const startMock = jest.fn().mockResolvedValue({ terminate: () => {} });
+    global.PresentationRequest = jest
+      .fn()
+      .mockImplementationOnce(() => ({ start: startMock }));
+    const {
+      result: { current },
+      waitForNextUpdate
+    } = renderHook(() => usePresentation(), {});
+    await act(async () => {
+      current.startConnection();
+      await waitForNextUpdate();
+    });
     expect(startMock).toBeCalled();
   });
-  it('when calling terminate connection it calls startConnection', () => {
-    const terminateCallback = jest.fn();
+
+  it('assigns the connection object on start.', async () => {
+    const startMock = jest.fn().mockResolvedValue({ terminate: () => {} });
+    global.PresentationRequest = jest
+      .fn()
+      .mockImplementationOnce(() => ({ start: startMock }));
+    const { result, waitForValueToChange } = renderHook(
+      () => usePresentation(),
+      {}
+    );
+    await act(async () => {
+      result.current.startConnection();
+      await waitForValueToChange(() => {
+        jest.runAllTimers();
+        return result.current.connection;
+      });
+    });
+    expect(result.current.connection).not.toBeNull();
+  });
+
+  it('should send a stringified message to connection send handler.', async () => {
+    const sendMessageFn = jest.fn();
     const startMock = jest
       .fn()
-      .mockResolvedValue({ terminate: () => terminateCallback() });
-    class PresentationRequest {
-      constructor() {}
-      start = startMock;
-    }
-    global.PresentationRequest = PresentationRequest;
-    const TestComponent = () => {
-      const { terminateConnection, startConnection } = usePresentation();
-      return (
-        <>
-          <button
-            data-testid="startConnection"
-            onClick={() => startConnection()}
-          ></button>
-          <button
-            data-testid="terminate connection"
-            onClick={() => terminateConnection()}
-          ></button>
-        </>
-      );
-    };
-    const component = mount(<TestComponent />);
-    component.find('[data-testid="startConnection"]').simulate('click');
-    component.find('[data-testid="terminate connection"]').simulate('click');
-    // Having trouble testing this.
-    // expect(terminateCallback).toBeCalled();
+      .mockResolvedValue({ terminate: () => {}, send: sendMessageFn });
+    global.PresentationRequest = jest
+      .fn()
+      .mockImplementationOnce(() => ({ start: startMock }));
+    const { result, waitForValueToChange } = renderHook(
+      () => usePresentation(),
+      {}
+    );
+    await act(async () => {
+      result.current.startConnection();
+      await waitForValueToChange(() => {
+        jest.runAllTimers();
+        return result.current.connection;
+      });
+      result.current.sendMessage('Spectacle Message :)');
+    });
+    expect(sendMessageFn).toBeCalledWith(
+      JSON.stringify('Spectacle Message :)')
+    );
+  });
+
+  it('should close the connection on terminate.', async () => {
+    const terminateFn = jest.fn();
+    const startMock = jest
+      .fn()
+      .mockResolvedValue({ terminate: terminateFn, send: () => {} });
+    global.PresentationRequest = jest
+      .fn()
+      .mockImplementationOnce(() => ({ start: startMock }));
+    const { result, waitForValueToChange } = renderHook(
+      () => usePresentation(),
+      {}
+    );
+    await act(async () => {
+      result.current.startConnection();
+      await waitForValueToChange(() => {
+        jest.runAllTimers();
+        return result.current.connection;
+      });
+      result.current.terminateConnection();
+    });
+    expect(terminateFn).toBeCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,17 +994,17 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.8.4":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1382,6 +1382,14 @@
     "@styled-system/core" "^5.1.2"
     "@styled-system/css" "^5.1.4"
 
+"@testing-library/react-hooks@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.7.0.tgz#6d75c5255ef49bce39b6465bf6b49e2dac84919e"
+  integrity sha512-TwfbY6BWtWIHitjT05sbllyLIProcysC0dF0q1bbDa7OHLC6A6rJOYJwZ13hzfz3O4RtOuInmprBozJRyyo7/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1476,6 +1484,21 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-test-renderer@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/react@^16.9.19":
   version "16.9.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
@@ -1495,6 +1518,13 @@
   integrity sha512-npB/Fdqc1TH6UwyB9CtsTXkg3zb8jg/WG4LUEQ85cY6oSRgRbytxfsgbgdG+YWQFtbznp3J/4BAdkPB+WsHheA==
   dependencies:
     csstype "^2.6.4"
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
@@ -2992,6 +3022,11 @@ csstype@^2.2.0, csstype@^2.6.4:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
+
+csstype@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
+  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
 cyclist@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Use `react-testing-library/hooks` to test the `usePresentation` hook with the connection functions. The key is to ensure the connection object which is assigned in a Promise to a React state exists before calling a function. We do this with `await waitForValueToChange` and providing the correct selector of the connection object.