### PR TITLE
Convert functions to arrow functions for js examples

### DIFF
--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -54,131 +54,128 @@ const template = () => (
 );
 // SPECTACLE_CLI_TEMPLATE_END
 
-function SlideFragments() {
-  return (
-    <>
-      <Slide>
-        <Text>This is a slide fragment.</Text>
-      </Slide>
-      <Slide>
-        <Text>This is also a slide fragment.</Text>
-        <Appear>
-          <Text>This item shows up!</Text>
-        </Appear>
-        <Appear>
-          <Text>This item also shows up!</Text>
-        </Appear>
-      </Slide>
-    </>
-  );
-}
+const SlideFragments = () => (
+  <>
+    <Slide>
+      <Text>This is a slide fragment.</Text>
+    </Slide>
+    <Slide>
+      <Text>This is also a slide fragment.</Text>
+      <Appear>
+        <Text>This item shows up!</Text>
+      </Appear>
+      <Appear>
+        <Text>This item also shows up!</Text>
+      </Appear>
+    </Slide>
+  </>
+);
 
-function Presentation() {
-  return (
-    <Deck theme={theme} template={template}>
-      <Slide>
-        <FlexBox height="100%">
-          <SpectacleLogo size={500} />
-        </FlexBox>
-        <Notes>
-          Spectacle supports notes per slide.
-          <ol>
-            <li>Notes can now be HTML markup!</li>
-            <li>Lists can make it easier to make points.</li>
-          </ol>
-        </Notes>
-      </Slide>
-      <Slide>
-        <FlexBox height="100%" flexDirection="column">
-          <Heading margin="0px" fontSize="150px">
-            ✨<i>Spectacle</i> ✨
-          </Heading>
-          <Heading margin="0px" fontSize="h2">
-            A ReactJS Presentation Library
-          </Heading>
-          <Heading margin="0px 32px" color="primary" fontSize="h3">
-            Where you can write your decks in JSX, Markdown, or MDX!
-          </Heading>
-        </FlexBox>
-      </Slide>
-      <Slide
-        backgroundColor="tertiary"
-        backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/beau.jpg?raw=true)"
-        backgroundOpacity={0.5}
+const Presentation = () => (
+  <Deck theme={theme} template={template}>
+    <Slide>
+      <FlexBox height="100%">
+        <SpectacleLogo size={500} />
+      </FlexBox>
+      <Notes>
+        Spectacle supports notes per slide.
+        <ol>
+          <li>Notes can now be HTML markup!</li>
+          <li>Lists can make it easier to make points.</li>
+        </ol>
+      </Notes>
+    </Slide>
+    <Slide>
+      <FlexBox height="100%" flexDirection="column">
+        <Heading margin="0px" fontSize="150px">
+          ✨<i>Spectacle</i> ✨
+        </Heading>
+        <Heading margin="0px" fontSize="h2">
+          A ReactJS Presentation Library
+        </Heading>
+        <Heading margin="0px 32px" color="primary" fontSize="h3">
+          Where you can write your decks in JSX, Markdown, or MDX!
+        </Heading>
+      </FlexBox>
+    </Slide>
+    <Slide
+      backgroundColor="tertiary"
+      backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/beau.jpg?raw=true)"
+      backgroundOpacity={0.5}
+    >
+      <Heading>Custom Backgrounds</Heading>
+      <UnorderedList>
+        <ListItem>
+          <CodeSpan>backgroundColor</CodeSpan>
+        </ListItem>
+        <ListItem>
+          <CodeSpan>backgroundImage</CodeSpan>
+        </ListItem>
+        <ListItem>
+          <CodeSpan>backgroundOpacity</CodeSpan>
+        </ListItem>
+        <ListItem>
+          <CodeSpan>backgroundSize</CodeSpan>
+        </ListItem>
+        <ListItem>
+          <CodeSpan>backgroundPosition</CodeSpan>
+        </ListItem>
+        <ListItem>
+          <CodeSpan>backgroundRepeat</CodeSpan>
+        </ListItem>
+      </UnorderedList>
+    </Slide>
+    <Slide>
+      <Heading>Animated Elements</Heading>
+      <OrderedList>
+        <Appear>
+          <ListItem>Elements can animate in!</ListItem>
+        </Appear>
+        <Appear>
+          <ListItem>Out of order</ListItem>
+        </Appear>
+        <Appear>
+          <ListItem>
+            Just identify the order with the prop <CodeSpan>stepIndex</CodeSpan>
+            !
+          </ListItem>
+        </Appear>
+      </OrderedList>
+    </Slide>
+    <Slide>
+      <FlexBox>
+        <Text>These</Text>
+        <Text>Text</Text>
+        <Text color="secondary">Items</Text>
+        <Text fontWeight="bold">Flex</Text>
+      </FlexBox>
+      <Grid gridTemplateColumns="1fr 2fr" gridColumnGap={15}>
+        <Box backgroundColor="primary">
+          <Text color="secondary">Single-size Grid Item</Text>
+        </Box>
+        <Box backgroundColor="secondary">
+          <Text>Double-size Grid Item</Text>
+        </Box>
+      </Grid>
+      <Grid
+        gridTemplateColumns="1fr 1fr 1fr"
+        gridTemplateRows="1fr 1fr 1fr"
+        alignItems="center"
+        justifyContent="center"
+        gridRowGap={1}
       >
-        <Heading>Custom Backgrounds</Heading>
-        <UnorderedList>
-          <ListItem>
-            <CodeSpan>backgroundColor</CodeSpan>
-          </ListItem>
-          <ListItem>
-            <CodeSpan>backgroundImage</CodeSpan>
-          </ListItem>
-          <ListItem>
-            <CodeSpan>backgroundOpacity</CodeSpan>
-          </ListItem>
-          <ListItem>
-            <CodeSpan>backgroundSize</CodeSpan>
-          </ListItem>
-          <ListItem>
-            <CodeSpan>backgroundPosition</CodeSpan>
-          </ListItem>
-          <ListItem>
-            <CodeSpan>backgroundRepeat</CodeSpan>
-          </ListItem>
-        </UnorderedList>
-      </Slide>
-      <Slide>
-        <Heading>Animated Elements</Heading>
-        <OrderedList>
-          <Appear>
-            <ListItem>Elements can animate in!</ListItem>
-          </Appear>
-          <Appear>
-            <ListItem>Out of order</ListItem>
-          </Appear>
-          <Appear>
-            <ListItem>
-              Just identify the order with the prop{' '}
-              <CodeSpan>stepIndex</CodeSpan>!
-            </ListItem>
-          </Appear>
-        </OrderedList>
-      </Slide>
-      <Slide>
-        <FlexBox>
-          <Text>These</Text>
-          <Text>Text</Text>
-          <Text color="secondary">Items</Text>
-          <Text fontWeight="bold">Flex</Text>
-        </FlexBox>
-        <Grid gridTemplateColumns="1fr 2fr" gridColumnGap={15}>
-          <Box backgroundColor="primary">
-            <Text color="secondary">Single-size Grid Item</Text>
-          </Box>
-          <Box backgroundColor="secondary">
-            <Text>Double-size Grid Item</Text>
-          </Box>
-        </Grid>
-        <Grid
-          gridTemplateColumns="1fr 1fr 1fr"
-          gridTemplateRows="1fr 1fr 1fr"
-          alignItems="center"
-          justifyContent="center"
-          gridRowGap={1}
-        >
-          {Array(9)
-            .fill('')
-            .map((_, index) => (
-              <FlexBox paddingTop={0} key={`formidable-logo-${index}`} flex={1}>
-                <Image src={formidableLogo} width={100} />
-              </FlexBox>
-            ))}
-        </Grid>
-      </Slide>
-      <SlideFragments />
-      <Slide>
-        <CodePane language="jsx">{`
+        {Array(9)
+          .fill('')
+          .map((_, index) => (
+            <FlexBox paddingTop={0} key={`formidable-logo-${index}`} flex={1}>
+              <Image src={formidableLogo} width={100} />
+            </FlexBox>
+          ))}
+      </Grid>
+    </Slide>
+    <SlideFragments />
+    <Slide>
+      <CodePane language="jsx">{`
         import { createClient, Provider } from 'urql';
 
         const client = createClient({ url: 'https://0ufyz.sse.codesandbox.io' });
@@ -189,26 +186,25 @@ function Presentation() {
           </Provider>
         );
         `}</CodePane>
+    </Slide>
+    <div>
+      <Slide>
+        <Heading>This is a slide embedded in a div</Heading>
       </Slide>
-      <div>
-        <Slide>
-          <Heading>This is a slide embedded in a div</Heading>
-        </Slide>
-      </div>
-      <MarkdownSlide>
-        {`
+    </div>
+    <MarkdownSlide>
+      {`
         # This is a Markdown Slide
         `}
-      </MarkdownSlide>
-      <MarkdownSlideSet>
-        {`
+    </MarkdownSlide>
+    <MarkdownSlideSet>
+      {`
         # This is the first slide of a Markdown Slide Set
         ---
         # This is the second slide of a Markdown Slide Set
         `}
-      </MarkdownSlideSet>
-    </Deck>
-  );
-}
+    </MarkdownSlideSet>
+  </Deck>
+);
 
 ReactDOM.render(<Presentation />, document.getElementById('root'));


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Converts the `SlideFragments` and `Presentation` from being function declarations to arrow functions in `examples/js/index.js` file. Since they are arrow functions now I also removed the `return` statement

### Checklist: (Feel free to delete this section upon completion)

- [X] I have performed a self-review of my own code
