### PR TITLE
Swap setImmediate with requestAnimationFrame

### DIFF
--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -147,16 +147,13 @@ export default function CodePane({
   );
 
   React.useEffect(() => {
-    const immHandle = setImmediate(() => {
+    window.requestAnimationFrame(() => {
       if (!scrollTarget.current) return;
-      scrollTarget.current.scrollIntoView({
+      scrollTarget.current?.scrollIntoView({
         block: 'center',
         behavior: 'smooth'
       });
     });
-    return () => {
-      clearImmediate(immHandle);
-    };
   }, [isActive, step]);
 
   const customStyle = React.useMemo(() => {


### PR DESCRIPTION
Swaps out `setImmediate` with `requestAnimationFrame`. Verified the scrolling for animation highlight groups still work and it scrolls to the correct spot for long CodePanes.

Addresses #985