### PR TITLE
Fix Link styles to not use Text container styles.

### DIFF
--- a/src/components/__snapshots__/typography.test.js.snap
+++ b/src/components/__snapshots__/typography.test.js.snap
@@ -118,9 +118,6 @@ exports[`<Link /> should render an <a> with text 1`] = `
   color="quaternary"
   fontFamily="text"
   fontSize="text"
-  margin={0}
-  padding={0}
-  textAlign="left"
   textDecoration="underline"
 >
   <StyledComponent
@@ -134,16 +131,13 @@ exports[`<Link /> should render an <a> with text 1`] = `
           "color": "quaternary",
           "fontFamily": "text",
           "fontSize": "text",
-          "margin": 0,
-          "padding": 0,
-          "textAlign": "left",
           "textDecoration": "underline",
         },
         "attrs": Array [],
         "componentStyle": ComponentStyle {
           "componentId": "sc-htpNat",
           "isStatic": false,
-          "lastClassName": "cRHPrL",
+          "lastClassName": "jVigts",
           "rules": Array [
             [Function],
           ],
@@ -159,13 +153,10 @@ exports[`<Link /> should render an <a> with text 1`] = `
       }
     }
     forwardedRef={null}
-    margin={0}
-    padding={0}
-    textAlign="left"
     textDecoration="underline"
   >
     <a
-      className="sc-htpNat cRHPrL"
+      className="sc-htpNat jVigts"
       color="quaternary"
       fontFamily="text"
       fontSize="text"

--- a/src/components/typography.js
+++ b/src/components/typography.js
@@ -21,7 +21,8 @@ CodeSpan.defaultProps = {
 
 const Link = styled('a')(compose(color, typography, space, decoration));
 Link.defaultProps = {
-  ...Text.defaultProps,
+  fontFamily: 'text',
+  fontSize: 'text',
   textDecoration: 'underline',
   color: 'quaternary'
 };


### PR DESCRIPTION
`<Text />` has container styles as it's used typically top-level of a slide like `Heading`. `Link` however is usually inline a `Box` or `List`. This fixes the bug where there are additional margin styles attached to `Link`.