### PR TITLE
fix: Ensure correct page size for export mode is default

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -14,18 +14,18 @@ These are the bare bones of a Spectacle presentation, the two most essential tag
 ### Deck
 
 Wraps the entire presentation and carries most of the overarching slide logic, like `theme` and `template` context.
-A `template` contains Layout tags (referred to as a template render function) and is supplied to the `Deck` component to apply to all subsequent `Slide`s. The last three props are for print and export mode only, they have no effect on the audience or presenter views. The `pageSize` and `pageOrientation` props correspond to the size and orientation values for the [CSS media print size selector](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size). The `printScale` is the ratio for the selected page size, orientation, and slide size. `0.773` is the best ratio for an `A4` page in `landscape` orientation with a default slide size of `1366`-by-`768`.
+A `template` contains Layout tags (referred to as a template render function) and is supplied to the `Deck` component to apply to all subsequent `Slide`s. The last three props are for print and export mode only, they have no effect on the audience or presenter views. The `pageSize` and `pageOrientation` props correspond to the size and orientation values for the [CSS media print size selector](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size). The `pageSize` is automatically set based on the deck theme slide size for a best-fit using export to PDF mode. If you need to print your deck, supply your paper size using the `pageSize` prop. The `printScale` is the ratio for the selected page size, orientation, and slide size. `0.958` is the best ratio for to ensure the PDF export fits the slide theme size. Currently, only Chrome and Chromium-based browsers fully implement the custom page size CSS media print specification. Other browsers such as Firefox and Safari can still export to PDF but the page size will not be a best fit.
 
-| Props              | Type                                     | Default       |
-| ------------------ | ---------------------------------------- | ------------- |
-| `theme`            | [Styled-system theme object](./themes)   |               |
-| `template`         | [Template render function](#layout-tags) |               |
-| `pageSize`         | PropTypes.string                         | `"A4"`        |
-| `pageOrientation`  | `"landscape"` or `"portrait"`            | `"landscape"` |
-| `printScale`       | PropTypes.number                         | `0.773`       |
-| `autoPlay`         | PropTypes.bool                           | `false`       |
-| `autoPlayLoop`     | PropTypes.bool                           | `false`       |
-| `autoPlayInterval` | PropTypes.number (milliseconds)          | `1000`        |
+| Props              | Type                                     | Default            |
+| ------------------ | ---------------------------------------- | ------------------ |
+| `theme`            | [Styled-system theme object](./themes)   |                    |
+| `template`         | [Template render function](#layout-tags) |                    |
+| `pageSize`         | PropTypes.string                         | `"13.66in 7.68in"` |
+| `pageOrientation`  | `"landscape"` or `"portrait"`            | `"landscape"`      |
+| `printScale`       | PropTypes.number                         | `0.959`            |
+| `autoPlay`         | PropTypes.bool                           | `false`            |
+| `autoPlayLoop`     | PropTypes.bool                           | `false`            |
+| `autoPlayInterval` | PropTypes.number (milliseconds)          | `1000`             |
 
 ### Slide
 

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -23,9 +23,15 @@ import {
   printWrapperStyle
 } from './deck-styles';
 import { useAutoPlay } from '../../utils/use-auto-play';
+import defaultTheme from '../../theme/default-theme';
 
 export const DeckContext = createContext();
 const noop = () => {};
+
+/**
+ * The PDF DPI is 96. We want to scale the slide down because it's a 1:1 px to 1/100th of an inch.
+ * However there are some unchangeable margins that make 0.96 too big, so we use 0.959 to prevent overflow.
+ */
 const DEFAULT_PRINT_SCALE = 0.959;
 const DEFAULT_OVERVIEW_SCALE = 0.25;
 
@@ -64,8 +70,8 @@ const Deck = forwardRef(
       template,
       theme: {
         size: { width: nativeSlideWidth, height: nativeSlideHeight } = {
-          width: 1366,
-          height: 768
+          width: defaultTheme.size.width,
+          height: defaultTheme.size.height
         },
         Backdrop: UserProvidedBackdropComponent,
         backdropStyle: themeProvidedBackdropStyle = {

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -26,7 +26,7 @@ import { useAutoPlay } from '../../utils/use-auto-play';
 
 export const DeckContext = createContext();
 const noop = () => {};
-const DEFAULT_PRINT_SCALE = 0.773;
+const DEFAULT_PRINT_SCALE = 0.959;
 const DEFAULT_OVERVIEW_SCALE = 0.25;
 
 const Portal = styled('div')(
@@ -63,7 +63,10 @@ const Deck = forwardRef(
       printScale = DEFAULT_PRINT_SCALE,
       template,
       theme: {
-        slideDimensions: [nativeSlideWidth, nativeSlideHeight] = [1366, 768],
+        size: { width: nativeSlideWidth, height: nativeSlideHeight } = {
+          width: 1366,
+          height: 768
+        },
         Backdrop: UserProvidedBackdropComponent,
         backdropStyle: themeProvidedBackdropStyle = {
           position: 'fixed',

--- a/src/components/deck/index.js
+++ b/src/components/deck/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { parse as parseQS, stringify as stringifyQS } from 'query-string';
 import DefaultDeck from './default-deck';
 import PresenterMode from '../presenter-mode';
-import PrintMode from '../../print-mode';
+import PrintMode from '../print-mode';
 import useMousetrap from '../../hooks/use-mousetrap';
 import { KEYBOARD_SHORTCUTS, SPECTACLE_MODES } from '../../utils/constants';
 import { modeKeyForSearchParam, modeSearchParamForKey } from './modes';

--- a/src/components/print-mode/index.js
+++ b/src/components/print-mode/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import styled, { createGlobalStyle } from 'styled-components';
-import Deck from '../components/deck/deck';
-import { AnimatedDiv } from '../components/slide/slide';
+import Deck from '../deck/deck';
+import { AnimatedDiv } from '../slide/slide';
+import defaultTheme from '../../theme/default-theme';
 
 const Backdrop = styled.div`
   background-color: white;
@@ -27,8 +28,8 @@ const PrintStyle = createGlobalStyle`
 
 export default function PrintMode(props) {
   const { children, theme, exportMode, pageSize, pageOrientation = '' } = props;
-  const width = theme?.size?.width || 1366;
-  const height = theme?.size?.height || 768;
+  const width = theme?.size?.width || defaultTheme.size.width;
+  const height = theme?.size?.height || defaultTheme.size.height;
   const computedPageSize = pageSize || `${width / 100}in ${height / 100}in`;
   return (
     <>

--- a/src/print-mode/index.js
+++ b/src/print-mode/index.js
@@ -13,10 +13,11 @@ const PrintStyle = createGlobalStyle`
     body, html {
       margin: 0;
     }
+    @page {
+      size: ${({ pageSize }) => pageSize};
+    }
     ${AnimatedDiv} {
       @page {
-        size: ${({ pageSize, pageOrientation }) =>
-          `${pageSize} ${pageOrientation}`};
         margin: 0;
       }
     }
@@ -24,16 +25,13 @@ const PrintStyle = createGlobalStyle`
 `;
 
 export default function PrintMode(props) {
-  const {
-    children,
-    theme,
-    exportMode,
-    pageSize = 'letter',
-    pageOrientation = 'landscape'
-  } = props;
+  const { children, theme, exportMode, pageSize } = props;
+  const width = theme?.size?.width || 1366;
+  const height = theme?.size?.height || 768;
+  const computedPageSize = pageSize || `${width / 100}in ${height / 100}in`;
   return (
     <>
-      <PrintStyle pageSize={pageSize} pageOrientation={pageOrientation} />
+      <PrintStyle pageSize={computedPageSize} />
       <Deck
         printMode
         exportMode={exportMode}

--- a/src/print-mode/index.js
+++ b/src/print-mode/index.js
@@ -14,7 +14,8 @@ const PrintStyle = createGlobalStyle`
       margin: 0;
     }
     @page {
-      size: ${({ pageSize }) => pageSize};
+      size: ${({ pageSize, pageOrientation }) =>
+        `${pageSize} ${pageOrientation}`.trim()};
     }
     ${AnimatedDiv} {
       @page {
@@ -25,13 +26,16 @@ const PrintStyle = createGlobalStyle`
 `;
 
 export default function PrintMode(props) {
-  const { children, theme, exportMode, pageSize } = props;
+  const { children, theme, exportMode, pageSize, pageOrientation = '' } = props;
   const width = theme?.size?.width || 1366;
   const height = theme?.size?.height || 768;
   const computedPageSize = pageSize || `${width / 100}in ${height / 100}in`;
   return (
     <>
-      <PrintStyle pageSize={computedPageSize} />
+      <PrintStyle
+        pageSize={computedPageSize}
+        pageOrientation={pageOrientation}
+      />
       <Deck
         printMode
         exportMode={exportMode}


### PR DESCRIPTION
For `exportMode` which is designed for generating a PDF output of the deck, set the page size using CSS print media queries to the correct paper size which maps to the deck theme's slide size.

<img width="1020" alt="Screen Shot 2021-03-10 at 11 55 22 AM" src="https://user-images.githubusercontent.com/1738349/110701494-d5724980-81b6-11eb-983d-726eac3caa4c.png">
