### PR TITLE
Md list appear

### DIFF
--- a/__mocks__/use-resize-observer.js
+++ b/__mocks__/use-resize-observer.js
@@ -1,0 +1,1 @@
+module.exports = () => {};

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -174,9 +174,10 @@ Image is a component to display a picture within a slide. It is analogous to an 
 
 The Markdown components let you include a block of Markdown within a slide using `<Markdown />`, author a complete slide with Markdown using `<MarkdownSlide />`, or author a series of slides with Markdown using `<MarkdownSlides />`. Markdown tags get converted into Spectacle components. The `---` three dash marker when used inside `<MarkdownSlideSet />` is used to divide content into separate slides. Markdown also supports presenter notes using the `Notes:` marker. `<Markdown />` must be a child of `<Slide />` where `<MarkdownSlide />` and `<MarkdownSlideSet />` are children of `<Deck />`.
 
-| Props      | Type             | Example      |
-| ---------- | ---------------- | ------------ |
-| `children` | PropTypes.string | `# Hi there` |
+| Props              | Type              | Example                              |
+| ------------------ | ----------------- | ------------------------------------ |
+| `children`         | PropTypes.string  | `# Hi there`                         |
+| `animateListItems` | PropTypes.boolean | `<MarkdownSlide animateListItems />` |
 
 ```jsx
 <Slide>
@@ -186,10 +187,14 @@ The Markdown components let you include a block of Markdown within a slide using
   </Markdown>
   <Text>Made by Formidable</Text>
 </Slide>
-<MarkdownSlide>
+<MarkdownSlide animateListItems>
   # Use Markdown to write a slide
 
   This is a single slide composed using Markdown.
+  
+  - It uses the `animateListItems` prop so...
+  - it's list items...
+  - will animate in, one at a time.
 </MarkdownSlide>
 <MarkdownSlideSet>
   # Markdown Slide Sets

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -191,7 +191,7 @@ The Markdown components let you include a block of Markdown within a slide using
   # Use Markdown to write a slide
 
   This is a single slide composed using Markdown.
-  
+
   - It uses the `animateListItems` prop so...
   - it's list items...
   - will animate in, one at a time.

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -195,6 +195,9 @@ const Presentation = () => (
     <MarkdownSlide>
       {`
         # This is a Markdown Slide
+        
+        - With some steps.
+        - They'll step in by default.
         `}
     </MarkdownSlide>
     <MarkdownSlideSet>

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -195,10 +195,18 @@ const Presentation = () => (
     <MarkdownSlide>
       {`
         # This is a Markdown Slide
-        
-        - With some steps.
-        - They'll step in by default.
         `}
+    </MarkdownSlide>
+    <MarkdownSlide animateListItems>
+      {`
+       # This is also a Markdown Slide
+       
+       It uses the \`animateListItems\` prop.
+       
+       - Its list items...
+       - they will appear in...
+       - one at a time.
+      `}
     </MarkdownSlide>
     <MarkdownSlideSet>
       {`

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,14 +106,17 @@ declare module 'spectacle' {
   }>;
 
   export const Markdown: React.FC<{
+    animateListItems?: boolean;
     children: React.ReactNode;
   }>;
 
   export const MarkdownSlide: React.FC<{
+    animateListItems?: boolean;
     children: React.ReactNode;
   }>;
 
   export const MarkdownSlideSet: React.FC<{
+    animateListItems?: boolean;
     children: React.ReactNode;
   }>;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -79,7 +79,13 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    // Jest doesn't like the ESM exports from prism.
+    // They aren't needed for current test suite,
+    // so just map to an empty module.
+    'react-syntax-highlighter/dist/esm/styles/prism':
+      '<rootDir>/src/test-utils/empty-module.js'
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
@@ -123,7 +129,7 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['<rootDir>/src/test-utils/test-setup.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -17,6 +17,8 @@ import { root as mdRoot } from 'mdast-builder';
 import mdxComponentMap from '../../utils/mdx-component-mapper';
 import indentNormalizer from '../../utils/indent-normalizer';
 import Notes from '../notes';
+import { ListItem } from '../../index';
+import Appear from '../appear';
 
 export const Markdown = ({
   componentMap: userProvidedComponentMap = mdxComponentMap,
@@ -24,7 +26,8 @@ export const Markdown = ({
     default: 'div',
     getPropsForAST: () => {}
   },
-  children: rawMarkdownText
+  children: rawMarkdownText,
+  animateListItems = false
 }) => {
   const {
     theme: { markdownComponentMap: themeComponentMap = {} } = {}
@@ -64,6 +67,12 @@ export const Markdown = ({
       ...themeComponentMap,
       ...userProvidedComponentMap
     };
+
+    // If user wants to animate list items,
+    // wrap ListItem in Appear
+    if (animateListItems) {
+      componentMap['li'] = AppearingListItem;
+    }
 
     // Create an HOC based on the component map which will specially handle
     // fenced code blocks. (See MarkdownPreHelper for more details.)
@@ -131,18 +140,23 @@ export const Markdown = ({
   );
 };
 
+const AppearingListItem = props => (
+  <Appear>
+    <ListItem {...props} />
+  </Appear>
+);
+
 // TODO: document this thoroughly, it's a public-facing API
 export const MarkdownSlide = ({
-  children: rawMarkdownText,
+  children,
   componentMap,
   template,
+  animateListItems = false,
   ...rest
 }) => {
   return (
     <Slide {...rest}>
-      <Markdown componentMap={componentMap} template={template}>
-        {rawMarkdownText}
-      </Markdown>
+      <Markdown {...{ componentMap, template, animateListItems, children }} />
     </Slide>
   );
 };

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -127,7 +127,8 @@ export const Markdown = ({
     rawMarkdownText,
     getPropsForAST,
     userProvidedComponentMap,
-    themeComponentMap
+    themeComponentMap,
+    animateListItems
   ]);
 
   const { children, ...restProps } = templateProps;

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -6,7 +6,6 @@ import * as React from 'react';
 import Slide from '../slide/slide';
 import { DeckContext } from '../deck/deck';
 import presenterNotesPlugin from '../../utils/remark-rehype-presenter-notes';
-import Appear from '../appear';
 import CodePane from '../code-pane';
 import unified from 'unified';
 import remark from 'remark-parse';
@@ -61,11 +60,6 @@ export const Markdown = ({
     // Construct the component map based on the current theme and any custom
     // mappings provided directly to <Markdown />
     const componentMap = {
-      li: props => (
-        <Appear>
-          <ListItem {...props} />
-        </Appear>
-      ),
       __codeBlock: MarkdownCodePane,
       ...themeComponentMap,
       ...userProvidedComponentMap

--- a/src/components/markdown/markdown.test.js
+++ b/src/components/markdown/markdown.test.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import { MarkdownSlide, MarkdownSlideSet } from './markdown';
+import Adapter from 'enzyme-adapter-react-16';
+import Deck from '../deck/deck';
+import { ListItem } from '../typography';
+import Appear from '../appear';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const mountInsideDeck = tree => {
+  return mount(<Deck>{tree}</Deck>);
+};
+
+describe('<MarkdownSlide />', () => {
+  it('should generate standard unordered lists by default', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide>{`
+        - One
+        - Two
+        - Three
+      `}</MarkdownSlide>
+    );
+
+    expect(wrapper.find('ul')).toHaveLength(1);
+    expect(wrapper.find(ListItem)).toHaveLength(3);
+    expect(wrapper.find(Appear)).toHaveLength(0);
+  });
+
+  it('should generate animated list items with animateListItems', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide animateListItems>{`
+        - One
+        - Two
+        - Three
+      `}</MarkdownSlide>
+    );
+
+    expect(wrapper.find('ul')).toHaveLength(1);
+    expect(wrapper.find(Appear)).toHaveLength(3);
+  });
+});
+
+describe('<MarkdownSlideSet />', () => {
+  it('should generate standard unordered lists by default', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlideSet>{`
+        - One
+        - Two
+        - Three
+        
+        ---
+        
+        - Four
+        - Five
+        - Size
+      `}</MarkdownSlideSet>
+    );
+
+    expect(wrapper.find('ul')).toHaveLength(2);
+    expect(wrapper.find(ListItem)).toHaveLength(6);
+    expect(wrapper.find(Appear)).toHaveLength(0);
+  });
+
+  it('should generate animated list items with animateListItems', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlideSet animateListItems>{`
+        - One
+        - Two
+        - Three
+        
+        ---
+        
+        - Four
+        - Five
+        - Size
+      `}</MarkdownSlideSet>
+    );
+
+    expect(wrapper.find('ul')).toHaveLength(2);
+    expect(wrapper.find(Appear)).toHaveLength(6);
+  });
+});

--- a/src/test-utils/empty-module.js
+++ b/src/test-utils/empty-module.js
@@ -1,0 +1,6 @@
+/**
+ * This file exports an empty object/module.
+ * Jest maps specific ESM modules to this to
+ * effectively ignore them in tests.
+ */
+export default {};

--- a/src/test-utils/test-setup.js
+++ b/src/test-utils/test-setup.js
@@ -1,0 +1,11 @@
+/**
+ * JSDom does not provide this method, but it's needed for various components
+ * to mount appropriately.
+ * Here, we're mocking this method with some static values.
+ */
+window.HTMLElement.prototype.getClientRects = () => [
+  {
+    width: 500,
+    height: 300
+  }
+];

--- a/src/utils/mdx-component-mapper.js
+++ b/src/utils/mdx-component-mapper.js
@@ -1,20 +1,25 @@
 /* eslint-disable react/display-name */
 import * as React from 'react';
 import {
-  CodePane,
+  Appear,
+  Heading,
   Image,
+  Link,
+  ListItem,
   OrderedList,
   Quote,
-  Heading,
-  UnorderedList,
-  Text,
-  ListItem,
-  Link,
-  CodeSpan,
   Table,
+  TableCell,
   TableRow,
-  TableCell
+  Text,
+  UnorderedList
 } from '../';
+
+const AppearingListItem = props => (
+  <Appear>
+    <ListItem {...props} />
+  </Appear>
+);
 
 const mdxComponentMap = {
   p: Text,
@@ -25,7 +30,7 @@ const mdxComponentMap = {
   blockquote: Quote,
   ul: UnorderedList,
   ol: OrderedList,
-  li: ListItem,
+  li: AppearingListItem,
   img: Image,
   a: Link,
   table: Table,

--- a/src/utils/mdx-component-mapper.js
+++ b/src/utils/mdx-component-mapper.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/display-name */
 import * as React from 'react';
 import {
-  Appear,
   Heading,
   Image,
   Link,
@@ -15,12 +14,6 @@ import {
   UnorderedList
 } from '../';
 
-const AppearingListItem = props => (
-  <Appear>
-    <ListItem {...props} />
-  </Appear>
-);
-
 const mdxComponentMap = {
   p: Text,
   h1: props => <Heading {...props} fontSize="h1" />,
@@ -30,7 +23,7 @@ const mdxComponentMap = {
   blockquote: Quote,
   ul: UnorderedList,
   ol: OrderedList,
-  li: AppearingListItem,
+  li: ListItem,
   img: Image,
   a: Link,
   table: Table,


### PR DESCRIPTION
### Description

This PR adds a boolean prop `animateListItems` to the `Markdown` suite of components that automatically transforms MD list items into `Appear > ListItem`. This allows a user to provide MD like:

```jsx
<MarkdownSlide animateListItems>
{`
# Hey world

- One
- Two
- Three
`}
</MarkdownSlide>
```

and have the list items appear in one at a time.

This addresses issue #968.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

I have added some Jest/Enzyme tests to test this new prop. I also added an example to the JS example deck that uses this new prop, which can be used to verify that the list items are animating in accordingly.