### PR TITLE
MD component prop pass-thru

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -175,7 +175,7 @@ Image is a component to display a picture within a slide. It is analogous to an 
 The Markdown components let you include a block of Markdown within a slide using `<Markdown />`, author a complete slide with Markdown using `<MarkdownSlide />`, or author a series of slides with Markdown using `<MarkdownSlides />`. Markdown tags get converted into Spectacle components. The `---` three dash marker when used inside `<MarkdownSlideSet />` is used to divide content into separate slides. Markdown also supports presenter notes using the `Notes:` marker. `<Markdown />` must be a child of `<Slide />` where `<MarkdownSlide />` and `<MarkdownSlideSet />` are children of `<Deck />`.
 
 | Props              | Type              | Example                                                                             |
-| ------------------ | ----------------- | ------------------------------------                                                |
+| ------------------ | ----------------- | ----------------------------------------------------------------------------------- |
 | `children`         | PropTypes.string  | `# Hi there`                                                                        |
 | `componentProps`   | PropTypes.object  | `<MarkdownSlide componentProps={{ color: 'purple' }}># I'm purple!</MarkdownSlide>` |
 | `animateListItems` | PropTypes.boolean | `<MarkdownSlide animateListItems />`                                                |

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -174,10 +174,11 @@ Image is a component to display a picture within a slide. It is analogous to an 
 
 The Markdown components let you include a block of Markdown within a slide using `<Markdown />`, author a complete slide with Markdown using `<MarkdownSlide />`, or author a series of slides with Markdown using `<MarkdownSlides />`. Markdown tags get converted into Spectacle components. The `---` three dash marker when used inside `<MarkdownSlideSet />` is used to divide content into separate slides. Markdown also supports presenter notes using the `Notes:` marker. `<Markdown />` must be a child of `<Slide />` where `<MarkdownSlide />` and `<MarkdownSlideSet />` are children of `<Deck />`.
 
-| Props              | Type              | Example                              |
-| ------------------ | ----------------- | ------------------------------------ |
-| `children`         | PropTypes.string  | `# Hi there`                         |
-| `animateListItems` | PropTypes.boolean | `<MarkdownSlide animateListItems />` |
+| Props              | Type              | Example                                                                             |
+| ------------------ | ----------------- | ------------------------------------                                                |
+| `children`         | PropTypes.string  | `# Hi there`                                                                        |
+| `componentProps`   | PropTypes.object  | `<MarkdownSlide componentProps={{ color: 'purple' }}># I'm purple!</MarkdownSlide>` |
+| `animateListItems` | PropTypes.boolean | `<MarkdownSlide animateListItems />`                                                |
 
 ```jsx
 <Slide>

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -21,8 +21,7 @@ import {
   CodePane,
   MarkdownSlide,
   MarkdownSlideSet,
-  Notes,
-  Markdown
+  Notes
 } from 'spectacle';
 
 const formidableLogo =
@@ -193,16 +192,6 @@ const Presentation = () => (
         <Heading>This is a slide embedded in a div</Heading>
       </Slide>
     </div>
-    <Slide>
-      <Heading>Markdown can be sprinkled into any slide!</Heading>
-      <Markdown componentProps={{ color: 'indigo', backgroundColor: 'pink' }}>{`
-        ## Hey world
-        
-        - One
-        - Two
-        - Three
-      `}</Markdown>
-    </Slide>
     <MarkdownSlide>
       {`
         # This is a Markdown Slide

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -192,9 +192,12 @@ const Presentation = () => (
         <Heading>This is a slide embedded in a div</Heading>
       </Slide>
     </div>
-    <MarkdownSlide>
+    <MarkdownSlide componentProps={{ color: 'yellow' }}>
       {`
         # This is a Markdown Slide
+        
+        - You can pass props down to all elements on the slide.
+        - Just use the \`componentProps\` prop.
         `}
     </MarkdownSlide>
     <MarkdownSlide animateListItems>

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -21,7 +21,8 @@ import {
   CodePane,
   MarkdownSlide,
   MarkdownSlideSet,
-  Notes
+  Notes,
+  Markdown
 } from 'spectacle';
 
 const formidableLogo =
@@ -192,6 +193,16 @@ const Presentation = () => (
         <Heading>This is a slide embedded in a div</Heading>
       </Slide>
     </div>
+    <Slide>
+      <Heading>Markdown can be sprinkled into any slide!</Heading>
+      <Markdown componentProps={{ color: 'indigo', backgroundColor: 'pink' }}>{`
+        ## Hey world
+        
+        - One
+        - Two
+        - Three
+      `}</Markdown>
+    </Slide>
     <MarkdownSlide>
       {`
         # This is a Markdown Slide

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -179,9 +179,25 @@
               <${Heading}>This is a slide embedded in a div</${Heading}>
             </${Slide}>
           </div>
-          <${MarkdownSlide}>
+          <${MarkdownSlide} componentProps=${{
+          color: 'yellow'
+        }}>
             ${`
             # This is a Markdown Slide
+
+            - You can pass props down to all elements on the slide.
+            - Just use the \`componentProps\` prop.
+            `}
+          </${MarkdownSlide}>
+          <${MarkdownSlide} animateListItems>
+            ${`
+            # This is also a Markdown Slide
+
+            It uses the \`animateListItems\` prop.
+
+            - Its list items...
+            - they will appear in...
+            - one at a time.
             `}
           </${MarkdownSlide}>
           <${MarkdownSlideSet}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,19 +105,24 @@ declare module 'spectacle' {
     size: number;
   }>;
 
+  type MdComponentProps = { [key: string]: any };
+
   export const Markdown: React.FC<{
     animateListItems?: boolean;
     children: React.ReactNode;
+    componentProps?: MdComponentProps;
   }>;
 
   export const MarkdownSlide: React.FC<{
     animateListItems?: boolean;
     children: React.ReactNode;
+    componentProps?: MdComponentProps;
   }>;
 
   export const MarkdownSlideSet: React.FC<{
     animateListItems?: boolean;
     children: React.ReactNode;
+    componentProps?: MdComponentProps;
   }>;
 
   export const SpectacleLogo: React.FC<{

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -27,7 +27,8 @@ export const Markdown = ({
     getPropsForAST: () => {}
   },
   children: rawMarkdownText,
-  animateListItems = false
+  animateListItems = false,
+  componentProps = {}
 }) => {
   const {
     theme: { markdownComponentMap: themeComponentMap = {} } = {}
@@ -85,12 +86,19 @@ export const Markdown = ({
       CodeBlockComponent
     );
 
+    const componentMapWithPassedThroughProps = Object.entries(
+      componentMap
+    ).reduce((newMap, [key, Component]) => {
+      newMap[key] = props => <Component {...props} {...componentProps} />;
+      return newMap;
+    }, {});
+
     // Create the compiler for the _user-visible_ markdown (not presenter notes)
     const compiler = unified()
       .use(remark2rehype)
       .use(rehype2react, {
         createElement: React.createElement,
-        components: componentMap
+        components: componentMapWithPassedThroughProps
       });
 
     // Compile each of the values we got back from the template function
@@ -153,11 +161,20 @@ export const MarkdownSlide = ({
   componentMap,
   template,
   animateListItems = false,
+  componentProps = {},
   ...rest
 }) => {
   return (
     <Slide {...rest}>
-      <Markdown {...{ componentMap, template, animateListItems, children }} />
+      <Markdown
+        {...{
+          componentMap,
+          template,
+          animateListItems,
+          componentProps,
+          children
+        }}
+      />
     </Slide>
   );
 };

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -134,9 +134,10 @@ export const Markdown = ({
   }, [
     rawMarkdownText,
     getPropsForAST,
-    userProvidedComponentMap,
     themeComponentMap,
-    animateListItems
+    userProvidedComponentMap,
+    animateListItems,
+    componentProps
   ]);
 
   const { children, ...restProps } = templateProps;

--- a/src/components/markdown/markdown.test.js
+++ b/src/components/markdown/markdown.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
-import { MarkdownSlide, MarkdownSlideSet } from './markdown';
+import { Markdown, MarkdownSlide, MarkdownSlideSet } from './markdown';
 import Adapter from 'enzyme-adapter-react-16';
 import Deck from '../deck/deck';
-import { ListItem } from '../typography';
+import { Heading, ListItem } from '../typography';
 import Appear from '../appear';
+import Slide from '../slide/slide';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -79,5 +80,81 @@ describe('<MarkdownSlideSet />', () => {
 
     expect(wrapper.find('ul')).toHaveLength(2);
     expect(wrapper.find(Appear)).toHaveLength(6);
+  });
+
+  it('Markdown should pass componentProps down to constituent components', () => {
+    const wrapper = mountInsideDeck(
+      <Slide>
+        <Heading>Im not styled...</Heading>
+        <Markdown componentProps={{ color: 'purple' }}>{`
+        # What's up world, I'm styled.
+        
+        - List item
+        - And another one
+      `}</Markdown>
+      </Slide>
+    );
+
+    expect(
+      wrapper
+        .find(Heading)
+        .at(0)
+        .prop('color')
+    ).not.toBe('purple');
+
+    expect(
+      wrapper
+        .find(Heading)
+        .at(1)
+        .prop('color')
+    ).toBe('purple');
+
+    expect(
+      wrapper
+        .find(ListItem)
+        .at(0)
+        .prop('color')
+    ).toBe('purple');
+  });
+
+  it('MarkdownSlide should pass componentProps down to constituent components', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide componentProps={{ color: 'purple' }}>{`
+        # What's up world, I'm styled.
+      `}</MarkdownSlide>
+    );
+
+    expect(
+      wrapper
+        .find(Heading)
+        .at(0)
+        .prop('color')
+    ).toBe('purple');
+  });
+
+  it('MarkdownSlideSet should pass componentProps down to constituent components', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlideSet componentProps={{ color: 'purple' }}>{`
+        # What's up world, I'm styled.
+        
+        ---
+        
+        # Another slide
+      `}</MarkdownSlideSet>
+    );
+
+    expect(
+      wrapper
+        .find(Heading)
+        .at(0)
+        .prop('color')
+    ).toBe('purple');
+
+    expect(
+      wrapper
+        .find(Heading)
+        .at(1)
+        .prop('color')
+    ).toBe('purple');
   });
 });


### PR DESCRIPTION
### Description

This PR allows the user to pass a `componentProps` prop to the `Markdown` suite of components, and these props will be passed down to each individual component generated by the MD conversion process. E.g.,

```jsx
<MarkdownSlide componentProps={{ backgroundColor: 'red', color: 'blue' }}># Ugly header</MarkdownSlide>
```

will style the header with a color of blue, background of red. This gives the user some control over how their markdown components render elements.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Tests added to `markdown.test.js` to test these changes. You can also try the `componentProps` prop out within the JS example slides.
