### PR TITLE
Update Formideploy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react-hooks": "^4.1.2",
     "execa": "^4.0.0",
-    "formideploy": "^0.3.4",
+    "formideploy": "^0.4.0",
     "prettier": "^1.15.1",
     "puppeteer": "^1.13.0",
     "rimraf": "^3.0.0"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4659,10 +4659,10 @@ formidable-oss-badges@^0.3.4:
   resolved "https://registry.yarnpkg.com/formidable-oss-badges/-/formidable-oss-badges-0.3.4.tgz#e79c2e643ad82c41810995fe33a5a44de9e0963e"
   integrity sha512-JUM3JIdjwRvyaaeHk6/oS71AjCEhO/rDV27JsejxdhmxdDL0AOMsGyxxR69StLPEXsXBOKGsf9D9owlI6U4vnw==
 
-formideploy@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/formideploy/-/formideploy-0.3.4.tgz#0d22774ff53b45aebcb7703fea23ac510ca10fbd"
-  integrity sha512-zObCcyB8aQor2F07IiuJYN7GUlwebZsZje6XwOsK6mfv8/Y6HZm88poUcxMrqZgy5DO3funLNnzP1DNgDBc1hg==
+formideploy@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/formideploy/-/formideploy-0.4.0.tgz#47faa93cb9878b1e121f5c7b1aee7e19a58c295e"
+  integrity sha512-ipbm84CU/ax5ssRlXBPZbxP/QSfoFszxW5Ny4mtLiBqSi6WDZE7QPIuNxQgEtN6eeQx+SiGOXSsb1sp6Bw9eQw==
   dependencies:
     "@octokit/rest" "^17.8.0"
     chalk "^4.0.0"


### PR DESCRIPTION
Updates Formideploy from 0.3.4 to 0.4.0 to fix a bug involving mime type when deploying to AWS.