### PR TITLE
Export Contexts, Theme. Update types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,4 +128,56 @@ declare module 'spectacle' {
   export const SpectacleLogo: React.FC<{
     size: number;
   }>;
+
+  export const defaultTheme: {
+    colors: Record<string, string>;
+    size: Record<string, number>;
+    fonts: Record<string, string>;
+    fontSizes: Record<string, string>;
+    space: number[];
+  };
+
+  export const SlideContext: React.Context<{
+    immediate: boolean;
+    slideId: number;
+    isSlideActive: boolean;
+    activationThresholds: number;
+    activeStepIndex: number;
+  }>;
+
+  export const DeckContext: React.Context<{
+    deckId: number;
+    slideCount: number;
+    useAnimations: boolean;
+    slidePortalNode: React.ReactNode;
+    onSlideClick(e: Event, slideId: number): void;
+    theme: Record<string, string | number | number[]>;
+    frameOverrideStyle: Record<string, string | number>;
+    wrapperOverrideStyle: Record<string, string | number>;
+    backdropNode: React.ReactNode;
+    notePortalNode: React.ReactNode;
+    initialized: boolean;
+    passedSlideIds: number[];
+    upcomingSlideIds: number[];
+    activeView: {
+      slideIndex: number;
+      stepIndex: number;
+    };
+    pendingView: {
+      slideIndex: number;
+      stepIndex: number;
+    };
+    skipTo(options: { slideIndex: number; stepIndex: number }): void;
+    stepForward(): void;
+    advanceSlide(): void;
+    regressSlide(): void;
+    commitTransition(): void;
+    cancelTransition(): void;
+    template:
+      | React.ReactNode
+      | ((options: {
+          slideNumber: number;
+          numberOfSlides: number;
+        }) => React.ReactNode);
+  }>;
 }

--- a/src/components/notes.js
+++ b/src/components/notes.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import propTypes from 'prop-types';
-import { DeckContext } from '../components/deck/deck';
-import { SlideContext } from '../components/slide/slide';
+import { DeckContext } from './deck/deck';
+import { SlideContext } from './slide/slide';
 
 export default function Notes({ children }) {
   const { notePortalNode } = React.useContext(DeckContext);
@@ -15,5 +15,5 @@ export default function Notes({ children }) {
 }
 
 Notes.propTypes = {
-  children: propTypes.node.isRequired
+  children: propTypes.node
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Deck from './components/deck';
-import Slide from './components/slide/slide';
+import Slide, { SlideContext } from './components/slide/slide';
 import Appear from './components/appear';
 import CodePane from './components/code-pane';
 import {
@@ -34,6 +34,8 @@ import SpectacleLogo from './components/logo';
 import mdxComponentMap from './utils/mdx-component-mapper';
 import { removeNotes, isolateNotes } from './utils/notes';
 import indentNormalizer from './utils/indent-normalizer';
+import { DeckContext } from './components/deck/deck';
+import defaultTheme from './theme/default-theme';
 
 export {
   Appear,
@@ -67,7 +69,10 @@ export {
   TableHeader,
   TableBody,
   mdxComponentMap,
+  DeckContext,
+  SlideContext,
   removeNotes,
   isolateNotes,
-  indentNormalizer
+  indentNormalizer,
+  defaultTheme
 };


### PR DESCRIPTION
### Description

Projects that consume or sit on top of Spectacle might need access to the Deck and Slide Contexts. Additionally the defaultTheme should have always been exported so users could build upon it. This also fixes a bug where Notes requires children.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested by linking the repo and consuming the types in a sample project.
