### PR TITLE
Don't default values in MD components

### DIFF
--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -23,15 +23,14 @@ import Appear from '../appear';
 export const Markdown = ({
   componentMap: userProvidedComponentMap = mdxComponentMap,
   template: { default: TemplateComponent, getPropsForAST } = {
-    default: 'div',
-    getPropsForAST: () => {}
+    default: 'div'
   },
   children: rawMarkdownText,
   animateListItems = false,
-  componentProps = {}
+  componentProps
 }) => {
   const {
-    theme: { markdownComponentMap: themeComponentMap = {} } = {}
+    theme: { markdownComponentMap: themeComponentMap } = {}
   } = React.useContext(DeckContext);
 
   const [templateProps, noteElements] = React.useMemo(() => {
@@ -65,7 +64,7 @@ export const Markdown = ({
     // mappings provided directly to <Markdown />
     const componentMap = {
       __codeBlock: MarkdownCodePane,
-      ...themeComponentMap,
+      ...(themeComponentMap || {}),
       ...userProvidedComponentMap
     };
 
@@ -89,7 +88,9 @@ export const Markdown = ({
     const componentMapWithPassedThroughProps = Object.entries(
       componentMap
     ).reduce((newMap, [key, Component]) => {
-      newMap[key] = props => <Component {...props} {...componentProps} />;
+      newMap[key] = props => (
+        <Component {...props} {...(componentProps || {})} />
+      );
       return newMap;
     }, {});
 


### PR DESCRIPTION
### Description

This PR removes some default prop values to avoid over re-rendering that was causing issues with animated elements in MD components.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Linting/Jest tests passed, tested using JS example template.