### PR TITLE
Add support for listStyleType in lists

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,13 +53,17 @@ declare module 'spectacle' {
     StyledSystem.TypographyProps &
     StyledSystem.SpaceProps;
 
+  type ListStyleProps = {
+    listStyleType?: CSSStyleRule['style']['listStyleType'];
+  };
+
   export const Text: React.FC<TypographyProps>;
   export const CodeSpan: React.FC<TypographyProps>;
   export const Heading: React.FC<TypographyProps>;
   export const ListItem: React.FC<TypographyProps>;
   export const Quote: React.FC<TypographyProps>;
-  export const OrderedList: React.FC<TypographyProps>;
-  export const UnorderedList: React.FC<TypographyProps>;
+  export const OrderedList: React.FC<TypographyProps & ListStyleProps>;
+  export const UnorderedList: React.FC<TypographyProps & ListStyleProps>;
   export const Link: React.FC<TypographyProps &
     React.AnchorHTMLAttributes<Record<string, unknown>>>;
 

--- a/src/components/typography.js
+++ b/src/components/typography.js
@@ -55,7 +55,11 @@ Quote.defaultProps = {
   margin: 0
 };
 
-const OrderedList = styled('ol')(compose(color, typography, space));
+const listStyle = system({
+  listStyleType: true
+});
+
+const OrderedList = styled('ol')(compose(color, typography, space, listStyle));
 OrderedList.defaultProps = {
   color: 'primary',
   fontFamily: 'text',
@@ -64,7 +68,9 @@ OrderedList.defaultProps = {
   margin: 0
 };
 
-const UnorderedList = styled('ul')(compose(color, typography, space));
+const UnorderedList = styled('ul')(
+  compose(color, typography, space, listStyle)
+);
 UnorderedList.defaultProps = {
   color: 'primary',
   fontFamily: 'text',


### PR DESCRIPTION
### Description

This PR adds support for `list-style-type` in lists, allow the user to specify a `listStyleType` (e.g. `listStyleType="square"`).

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Test suite has been run and passed. Tested manually with the JS slide example.