### PR TITLE
Use StyledSystems FlexboxProps type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare module 'spectacle' {
     StyledSystem.BorderProps;
 
   export const Box: React.FC<BoxProps>;
-  export const FlexBox: React.FC<BoxProps & StyledSystem.FlexProps>;
+  export const FlexBox: React.FC<BoxProps & StyledSystem.FlexboxProps>;
   export const Grid: React.FC<{
     children: React.ReactNode;
   } & StyledSystem.LayoutProps &


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Uses the correct prop definitons for the `Flexbox` component. `StyledSystem.FlexProps` revers to the `flex` CSS property whereas `StyledSystem.FlexboxProps` revers to the whole collection of configurable flexbox CSS properties.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
