### PR TITLE
Add missing type for indentNormalizer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Spectacle 7.0.0
 // Project: Formidable Spectacle
-// Definitions by: Kylie Stewart, Urmit Patel, and Carlos Kelly
+// Definitions by: Kylie Stewart, Urmit Patel, Grant Sander, and Carlos Kelly
 
 declare module 'spectacle' {
   import * as React from 'react';
@@ -184,4 +184,6 @@ declare module 'spectacle' {
           numberOfSlides: number;
         }) => React.ReactNode);
   }>;
+
+  export const indentNormalizer: (input: string) => string;
 }


### PR DESCRIPTION
### Description

We are exporting `indentNormalizer` but do not have it as part of our typedefs. This adds it.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested by linking the project to another repo that uses typescript and ensuring the type is working.

<img width="579" alt="Screen Shot 2021-04-05 at 9 50 17 AM" src="https://user-images.githubusercontent.com/1738349/113587526-86240b00-95f4-11eb-9b8c-eecdb7fd8701.png">

