### PR TITLE
CodePane Syntax Theme Import Fix

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -96,7 +96,7 @@ Appear is a component that makes a component animate on the slide on key press. 
 
 CodePane is a component for showing a syntax-highlighted block of source code. It will scroll for overflow amounts of code, trim whitespace and normalize indents. It will also wrap long lines of code and preserve the indent. CodePane uses the [React Syntax Highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter) Component.
 
-The `theme` prop accepts a configurable object or a string of the available [Prism Themes](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/index.js); `'atomDark'`, `'base16AteliersulphurpoolLight'`, `'cb'`, `'coy'`, `'darcula'`, `'dark'`, `'duotoneDark'`, `'duotoneEarth'`, `'duotoneForest'`, `'duotoneLight'`, `'duotoneSea'`, `'duotoneSpace'`, `'funky'`, `'ghcolors'`, `'hopscotch'`, `'okaidia'`, `'pojoaque'`, `'prism'`, `'solarizedlight'`, `'tomorrow'`, `'twilight'`, `'vs'` and `'xonokai'`.
+The `theme` prop accepts a configurable object or pre-defined theme object from the available [Prism Themes](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/index.js).
 
 Additionally, the `highlightRanges` prop accepts an array that can be used to highlight certain ranges of code:
 
@@ -114,21 +114,19 @@ Array values can even be mixed to include sub-arrays (for multiple lines) and nu
 
 _Note that each range will be considered as a step in your current slide's animation. Each range will be highlighted as you move forward or backwards on each step._
 
-| Props             | Type                                                                                                                                          | Example                          | Default Props |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------- |
-| `children`        | PropTypes.string                                                                                                                              | `let name = "Carlos"`            | -             |
-| `highlightRanges` | PropTypes.arrayOf(PropTypes.number) or PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number))                                                 | `[1, 3]` or `[[6, 8], [10, 15]]` | -             |
-| `language`        | PropTypes.string                                                                                                                              | `javascript`                     | -             |
-| `theme`           | PropTypes.object or [Prism Theme](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/index.js) | `twilight`                       | `atomDark`    |
+| Props             | Type                                                                                          | Example                                                                                                                   | Default Props        |
+| ----------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `children`        | PropTypes.string                                                                              | `let name = "Carlos"`                                                                                                     | -                    |
+| `highlightRanges` | PropTypes.arrayOf(PropTypes.number) or PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)) | `[1, 3]` or `[[6, 8], [10, 15]]`                                                                                          | -                    |
+| `language`        | PropTypes.string                                                                              | `javascript`                                                                                                              | -                    |
+| `theme`           | PropTypes.object or                                                                           | [Prism Theme](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/index.js) | vs-dark Theme Object |
 
 ```jsx
+import tomorrow from 'react-syntax-highlighter/dist/cjs/styles/prism/tomorrow';
+
 () => (
   <Slide>
-    <CodePane
-      language="javascript"
-      theme="solarizedlight"
-      highlightRanges={[1, 3]}
-    >
+    <CodePane language="javascript" theme={tomorrow} highlightRanges={[1, 3]}>
       {`
       const App = () => (
         <Provider value={client}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module 'spectacle' {
   export const CodePane: React.FC<{
     children: React.ReactNode;
     language: string;
-    theme?: Record<string, unknown> | string;
+    theme?: Record<string, unknown>;
     stepIndex?: number;
     highlightRanges: number | number[];
   }>;

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -4,33 +4,8 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { useSteps } from '../hooks/use-steps';
 import indentNormalizer from '../utils/indent-normalizer';
 import { ThemeContext } from 'styled-components';
-import * as styles from 'react-syntax-highlighter/dist/esm/styles/prism';
+import dark from 'react-syntax-highlighter/dist/cjs/styles/prism/vs-dark';
 
-export const availableCodePaneThemes = [
-  'atomDark',
-  'base16AteliersulphurpoolLight',
-  'cb',
-  'coy',
-  'darcula',
-  'dark',
-  'duotoneDark',
-  'duotoneEarth',
-  'duotoneForest',
-  'duotoneLight',
-  'duotoneSea',
-  'duotoneSpace',
-  'funky',
-  'ghcolors',
-  'hopscotch',
-  'okaidia',
-  'pojoaque',
-  'prism',
-  'solarizedlight',
-  'tomorrow',
-  'twilight',
-  'vs',
-  'xonokai'
-];
 const checkForNumberValues = ranges => {
   return ranges.every(element => typeof element === 'number');
 };
@@ -80,7 +55,7 @@ export default function CodePane({
   language,
   children: rawCodeString,
   stepIndex,
-  theme: syntaxTheme
+  theme: syntaxTheme = dark
 }) {
   const numberOfSteps = React.useMemo(() => {
     if (
@@ -175,12 +150,6 @@ export default function CodePane({
     };
   }, [theme]);
 
-  const syntaxStyle = React.useMemo(() => {
-    if (typeof syntaxTheme === 'string') {
-      return styles[syntaxTheme];
-    } else syntaxTheme;
-  }, [syntaxTheme]);
-
   return (
     <>
       {placeholder}
@@ -191,7 +160,7 @@ export default function CodePane({
         showLineNumbers
         lineProps={getLineProps}
         lineNumberProps={getLineNumberProps}
-        style={syntaxStyle}
+        style={syntaxTheme}
       >
         {children}
       </SyntaxHighlighter>
@@ -209,9 +178,5 @@ CodePane.propTypes = {
   language: propTypes.string.isRequired,
   children: propTypes.string.isRequired,
   stepIndex: propTypes.number,
-  theme: propTypes.oneOf([propTypes.object, ...availableCodePaneThemes])
-};
-
-CodePane.defaultProps = {
-  theme: 'atomDark'
+  theme: propTypes.object
 };


### PR DESCRIPTION
### Description

This simplifies our theme imports to a single default dark theme and requires the user to import any custom themes in their own deck. This reduces the overall bundle size, but could potentially result in any usages of a string-based Prism theme `CodePane` to stop rendering.

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

To ensure the import doesn't break consumers that don't transform node modules, this was linked to a project to verify the cjs usage did not throw an `export` keyword error.