### PR TITLE
Allow mobile device users to advance + regress slides with touch controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-fast-compare": "^3.2.0",
     "react-is": "^16.13.1",
     "react-spring": "^8.0.25",
+    "react-swipeable": "^6.1.0",
     "react-syntax-highlighter": "^12.2.1",
     "rehype-react": "^6.0.0",
     "remark-parse": "^8.0.3",

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -86,6 +86,7 @@ const Deck = forwardRef(
       } = {},
 
       onSlideClick = noop,
+      onMobileSlide = noop,
 
       disableInteractivity = false,
       notePortalNode,
@@ -350,6 +351,7 @@ const Deck = forwardRef(
               useAnimations,
               slidePortalNode,
               onSlideClick: handleSlideClick,
+              onMobileSlide: onMobileSlide,
               theme: restTheme,
 
               frameOverrideStyle: frameStyle,
@@ -401,6 +403,7 @@ Deck.propTypes = {
   template: propTypes.oneOfType([propTypes.node, propTypes.func]),
   theme: propTypes.object,
   onSlideClick: propTypes.func,
+  onMobileSlide: propTypes.func,
   disableInteractivity: propTypes.bool,
   notePortalNode: propTypes.node,
   useAnimations: propTypes.bool,

--- a/src/components/deck/default-deck.js
+++ b/src/components/deck/default-deck.js
@@ -62,10 +62,23 @@ export default function DefaultDeck({
     [overviewMode, toggleMode]
   );
 
+  const onMobileSlide = e => {
+    if (navigator.maxTouchPoints < 1) return;
+    switch (e.dir) {
+      case 'Left':
+        deck.current.advanceSlide();
+        break;
+      case 'Right':
+        deck.current.regressSlide();
+        break;
+    }
+  };
+
   return (
     <Deck
       overviewMode={overviewMode}
       onSlideClick={onSlideClick}
+      onMobileSlide={onMobileSlide}
       printMode={printMode}
       exportMode={exportMode}
       ref={deck}

--- a/src/components/deck/default-deck.js
+++ b/src/components/deck/default-deck.js
@@ -66,7 +66,7 @@ export default function DefaultDeck({
     if (navigator.maxTouchPoints < 1) return;
     switch (e.dir) {
       case 'Left':
-        deck.current.advanceSlide();
+        deck.current.stepForward();
         break;
       case 'Right':
         deck.current.regressSlide();

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -15,6 +15,7 @@ import { useSpring, animated } from 'react-spring';
 import { useSlide } from '../../hooks/use-slides';
 import { useCollectSteps } from '../../hooks/use-steps';
 import { GOTO_FINAL_STEP } from '../../hooks/use-deck-state';
+import { useSwipeable } from 'react-swipeable';
 
 const noop = () => {};
 
@@ -107,6 +108,7 @@ export default function Slide({
 
   const {
     onSlideClick = noop,
+    onMobileSlide,
     useAnimations,
     slidePortalNode,
     frameOverrideStyle = {},
@@ -280,6 +282,9 @@ export default function Slide({
     };
   }, [wrapperOverrideStyle, theme, padding]);
 
+  const swipeHandler = useSwipeable({
+    onSwiped: eventData => onMobileSlide(eventData)
+  });
   return (
     <>
       {placeholder}
@@ -318,6 +323,7 @@ export default function Slide({
                 backgroundRepeat={backgroundRepeat}
                 backgroundSize={backgroundSize}
                 color={textColor}
+                {...swipeHandler}
               >
                 <TemplateWrapper style={wrapperOverrideStyle}>
                   {(typeof template === 'function' ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -7139,6 +7139,11 @@ react-spring@^8.0.25:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
 
+react-swipeable@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-6.1.0.tgz#558b08a797a749a33e98492af84f2ca84a23d146"
+  integrity sha512-vB6+bv1I5L9nfuM7quu41o/kK1f3a7cTQ3NHNWkOltg5uhBpnH6xvkQJeoPfKQ6K4pnifELXY65wzWwWBa+zGg==
+
 react-syntax-highlighter@^12.2.1:
   version "12.2.1"
   resolved "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz"


### PR DESCRIPTION
### Description

On mobile devices users can swipe left to advance slide and right to regress slide.

Fixes #984 

#### Type of Change

Feature to address [Issue#984](https://github.com/FormidableLabs/spectacle/issues/984)

