### PR TITLE
remove useAnimatedSteps from use-hooks.js

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -86,12 +86,12 @@ These tags are for adding tables with content to your slides.
 
 Appear is a component that makes a component animate on the slide on key press. The default animation is opacity. It is currently required to specify the order of elements to be animated starting with `1`. Sequential `<Appear />` tags do not have to be in order.
 
-| Props              | Type                                                        | Example                                        |
-| ------------------ | ----------------------------------------------------------- | ---------------------------------------------- |
-| `children`         | PropTypes.string                                            | `<Text>Hi</Text>`                              |
-| `stepIndex`        | PropTypes.number                                            | `1`                                            |
-| `activeStyle`      | PropTypes.object                                            | `{ opacity: '1' }`                             |
-| `inactiveStyle`    | PropTypes.object                                            | `{ opacity: '0' }`                             |
+| Props           | Type             | Example            |
+| --------------- | ---------------- | ------------------ |
+| `children`      | PropTypes.string | `<Text>Hi</Text>`  |
+| `stepIndex`     | PropTypes.number | `1`                |
+| `activeStyle`   | PropTypes.object | `{ opacity: '1' }` |
+| `inactiveStyle` | PropTypes.object | `{ opacity: '0' }` |
 
 ## Code Pane
 

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -89,8 +89,9 @@ Appear is a component that makes a component animate on the slide on key press. 
 | Props              | Type                                                        | Example                                        |
 | ------------------ | ----------------------------------------------------------- | ---------------------------------------------- |
 | `children`         | PropTypes.string                                            | `<Text>Hi</Text>`                              |
-| `elementNum`       | PropTypes.number                                            | `1`                                            |
-| `transitionEffect` | PropTypes.shape({<br/>to: object;<br />from: object;<br/>}) | `{ to: { opacity: 1 }, from: { opacity: 0 } }` |
+| `stepIndex`        | PropTypes.number                                            | `1`                                            |
+| `activeStyle`      | PropTypes.object                                            | `{ opacity: '1' }`                             |
+| `inactiveStyle`    | PropTypes.object                                            | `{ opacity: '0' }`                             |
 
 ## Code Pane
 

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { animated } from 'react-spring';
-import { useAnimatedSteps } from '../hooks/use-steps';
+import { animated, useSpring } from 'react-spring';
+import { useSteps } from '../hooks/use-steps';
+import { SlideContext } from './slide/slide';
 
 export default function Appear({
   id,
@@ -10,21 +11,12 @@ export default function Appear({
   children: childrenOrRenderFunction,
   tagName = 'div',
   stepIndex,
-  numSteps = 1
+  visibleStyle = { opacity: '1' },
+  invisibleStyle = { opacity: '0' }
 }) {
-  if (numSteps !== 1 && typeof childrenOrRenderFunction !== 'function') {
-    console.warn(
-      'TransitionElement seems to have multiple steps for no reason?'
-    );
-  }
+  const { immediate } = React.useContext(SlideContext);
 
-  const { transitions, isActive, step, placeholder } = useAnimatedSteps(
-    numSteps,
-    {
-      id,
-      stepIndex
-    }
-  );
+  const { isActive, placeholder } = useSteps(1, { id, stepIndex });
 
   const AnimatedEl = animated[tagName];
 
@@ -35,17 +27,17 @@ export default function Appear({
     children = childrenOrRenderFunction;
   }
 
+  const springStyle = useSpring({
+    to: isActive ? visibleStyle : invisibleStyle,
+    immediate
+  });
+
   return (
     <>
       {placeholder}
-      {transitions.map(
-        ({ item, props, key }) =>
-          item && (
-            <AnimatedEl key={key} style={props} className={className}>
-              {children}
-            </AnimatedEl>
-          )
-      )}
+      <AnimatedEl style={springStyle} className={className}>
+        {children}
+      </AnimatedEl>
     </>
   );
 }
@@ -56,5 +48,7 @@ Appear.propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   tagName: PropTypes.string,
   stepIndex: PropTypes.number,
-  numSteps: PropTypes.number
+  numSteps: PropTypes.number,
+  visibleStyle: PropTypes.object,
+  invisibleStyle: PropTypes.object
 };

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -11,8 +11,8 @@ export default function Appear({
   children: childrenOrRenderFunction,
   tagName = 'div',
   stepIndex,
-  visibleStyle = { opacity: '1' },
-  invisibleStyle = { opacity: '0' }
+  activeStyle = { opacity: '1' },
+  inactiveStyle = { opacity: '0' }
 }) {
   const { immediate } = React.useContext(SlideContext);
 
@@ -28,7 +28,7 @@ export default function Appear({
   }
 
   const springStyle = useSpring({
-    to: isActive ? visibleStyle : invisibleStyle,
+    to: isActive ? activeStyle : inactiveStyle,
     immediate
   });
 
@@ -49,6 +49,6 @@ Appear.propTypes = {
   tagName: PropTypes.string,
   stepIndex: PropTypes.number,
   numSteps: PropTypes.number,
-  visibleStyle: PropTypes.object,
-  invisibleStyle: PropTypes.object
+  activeStyle: PropTypes.object,
+  inactiveStyle: PropTypes.object
 };

--- a/src/hooks/use-steps.js
+++ b/src/hooks/use-steps.js
@@ -68,43 +68,6 @@ export function useSteps(numSteps = 1, { id: userProvidedId, stepIndex } = {}) {
   };
 }
 
-// TODO: same as above. this is a public-facing API, document it!
-export function useAnimatedSteps(
-  numSteps = 1,
-  {
-    namedTransition,
-    transition: userProvidedTransition = {},
-    ...useStepsOpts
-  } = {}
-) {
-  const { immediate } = React.useContext(SlideContext);
-
-  const { stepId, isActive, step, placeholder } = useSteps(
-    numSteps,
-    useStepsOpts
-  );
-
-  const transitions = useTransition(isActive, null, {
-    immediate,
-    from: {
-      opacity: 0
-    },
-    enter: {
-      opacity: 1
-    },
-    leave: {
-      opacity: 0
-    }
-  });
-
-  return {
-    transitions,
-    isActive,
-    step,
-    placeholder
-  };
-}
-
 // Similar to <Deck>, this is where we go looking for "step placeholder"
 // elements. The main difference here is that slide placeholders are 1:1 with
 // slides, whereas step placeholders may represent multiple steps. So, the


### PR DESCRIPTION
### Description

Simplify `Appear` elements by removing useAnimatedSteps. `Appear` elements can now be nested within each other.

Fixes # (issue)

#### Type of Change

- [X] Refactor