### PR TITLE
Demo Update: Add 2x2 Grid example to JS demo

### DIFF
--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -195,7 +195,7 @@ const Presentation = () => (
     <MarkdownSlide componentProps={{ color: 'yellow' }}>
       {`
         # This is a Markdown Slide
-        
+
         - You can pass props down to all elements on the slide.
         - Just use the \`componentProps\` prop.
         `}
@@ -203,14 +203,40 @@ const Presentation = () => (
     <MarkdownSlide animateListItems>
       {`
        # This is also a Markdown Slide
-       
+
        It uses the \`animateListItems\` prop.
-       
+
        - Its list items...
        - they will appear in...
        - one at a time.
       `}
     </MarkdownSlide>
+    <Slide>
+      <Grid
+        flex={1}
+        gridTemplateColumns="50% 50%"
+        gridTemplateRows="50% 50%"
+        height="100%"
+      >
+        <FlexBox alignItems="center" justifyContent="center">
+          <Heading>This is a 4x4 Grid</Heading>
+        </FlexBox>
+        <FlexBox alignItems="center" justifyContent="center">
+          <Text textAlign="center">
+            With all the content aligned and justified center.
+          </Text>
+        </FlexBox>
+        <FlexBox alignItems="center" justifyContent="center">
+          <Text textAlign="center">
+            It uses Spectacle <CodeSpan>{'<Grid />'}</CodeSpan> and{' '}
+            <CodeSpan>{'<FlexBox />'}</CodeSpan> components.
+          </Text>
+        </FlexBox>
+        <FlexBox alignItems="center" justifyContent="center">
+          <Box width={200} height={200} backgroundColor="secondary" />
+        </FlexBox>
+      </Grid>
+    </Slide>
     <MarkdownSlideSet>
       {`
         # This is the first slide of a Markdown Slide Set

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -13,7 +13,7 @@
     <script src="https://unpkg.com/react-dom@16.13.1/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/react-is@16.13.1/umd/react-is.production.min.js"></script>
     <script src="https://unpkg.com/prop-types@15.7.2/prop-types.min.js"></script>
-    <script src="https://unpkg.com/spectacle@^7.1.0/dist/spectacle.min.js"></script>
+    <script src="https://unpkg.com/spectacle@^8/dist/spectacle.min.js"></script>
     <!-- <script src="../dist/spectacle.js"></script> -->
 
     <script type="module">
@@ -200,6 +200,26 @@
             - one at a time.
             `}
           </${MarkdownSlide}>
+          <${Slide}>
+            <${Grid} flex=${1} gridTemplateColumns="50% 50%" gridTemplateRows="50% 50%" height="100%">
+              <${FlexBox} alignItems="center" justifyContent="center">
+                <${Heading}>This is a 4x4 Grid</${Heading}>
+              </${FlexBox}>
+              <${FlexBox} alignItems="center" justifyContent="center">
+                <${Text} textAlign="center">With all the content aligned and justified center.</${Text}>
+              </${FlexBox}>
+              <${FlexBox} alignItems="center" justifyContent="center">
+                <${Text} textAlign="center">It uses Spectacle <${CodeSpan}>
+                    ${"<Grid />"}
+                  </${CodeSpan}> and <${CodeSpan}>
+                    ${"<FlexBox />"}
+                  </${CodeSpan}> components.</${Text}>
+              </${FlexBox}>
+              <${FlexBox} alignItems="center" justifyContent="center">
+                <${Box} width=${200} height=${200} backgroundColor="secondary" />
+              </${FlexBox}>
+            </${Grid}>
+          </${Slide}>
           <${MarkdownSlideSet}>
             ${`
             # This is the first slide of a Markdown Slide Set

--- a/scripts/one-page.js
+++ b/scripts/one-page.js
@@ -59,6 +59,8 @@ const getSrcContent = async src => {
         // Indent
         .split('\n')
         .join('\n  ')
+        // Handle pretty() erroneous newline after string literal
+        .replace(/\${\"\n[ ]*/gm, '${"')
         // Final newline
         .replace('}>`;', '}>\n`;');
 


### PR DESCRIPTION
### Description

Adds a 2x2 center-content grid layout using built-in Spectacle Grid and FlexBox components to the JS example 

#### Type of Change

Adds a demonstration of how to use a 2x2 center-content grid using JSX

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<img width="1241" alt="Screen Shot 2021-04-26 at 4 23 50 PM" src="https://user-images.githubusercontent.com/1738349/116153566-24176c80-a6ad-11eb-84b7-fd29ccafa78a.png">
