### PR TITLE
Feature: Add raw HTML support to markdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+- Allow raw HTML in Markdown content.
+
 ## 8.0.1
 
-- Fixed nagivation by swiping on touch-devices
+- Fixed navigation by swiping on touch-devices
 
 ## 8.0.0
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-spring": "^8.0.25",
     "react-swipeable": "^6.1.0",
     "react-syntax-highlighter": "^12.2.1",
+    "rehype-raw": "^5.1.0",
     "rehype-react": "^6.0.0",
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -11,6 +11,7 @@ import unified from 'unified';
 import remark from 'remark-parse';
 import mdastAssert from 'mdast-util-assert';
 import remark2rehype from 'remark-rehype';
+import remarkRaw from 'rehype-raw';
 import rehype2react from 'rehype-react';
 import { isValidElementType } from 'react-is';
 import { root as mdRoot } from 'mdast-builder';
@@ -96,7 +97,8 @@ export const Markdown = ({
 
     // Create the compiler for the _user-visible_ markdown (not presenter notes)
     const compiler = unified()
-      .use(remark2rehype)
+      .use(remark2rehype, { allowDangerousHtml: true })
+      .use(remarkRaw)
       .use(rehype2react, {
         createElement: React.createElement,
         components: componentMapWithPassedThroughProps
@@ -121,7 +123,8 @@ export const Markdown = ({
     // chunk in a <Note> component. (Rather than React.Fragment, which is the
     // default behavior.)
     const notesCompiler = unified()
-      .use(remark2rehype)
+      .use(remark2rehype, { allowDangerousHtml: true })
+      .use(remarkRaw)
       .use(rehype2react, {
         createElement: React.createElement,
         Fragment: Notes

--- a/src/components/markdown/markdown.test.js
+++ b/src/components/markdown/markdown.test.js
@@ -40,6 +40,38 @@ describe('<MarkdownSlide />', () => {
     expect(wrapper.find('ul')).toHaveLength(1);
     expect(wrapper.find(Appear)).toHaveLength(3);
   });
+
+  it('should work with raw HTML', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide>{`
+        - One <div>one-div</div>
+        - Two <i>two-i-1</i><i>two-i-2</i>
+        - Three
+      `}</MarkdownSlide>
+    );
+
+    // Assert raw HTML elements are actually present.
+    expect(
+      wrapper
+        .find('li')
+        .at(0)
+        .children()
+        .find('div')
+    ).toHaveLength(1);
+    expect(
+      wrapper
+        .find('li')
+        .at(1)
+        .children()
+        .find('i')
+    ).toHaveLength(2);
+    expect(
+      wrapper
+        .find('li')
+        .at(2)
+        .children()
+    ).toHaveLength(1);
+  });
 });
 
 describe('<MarkdownSlideSet />', () => {
@@ -49,9 +81,9 @@ describe('<MarkdownSlideSet />', () => {
         - One
         - Two
         - Three
-        
+
         ---
-        
+
         - Four
         - Five
         - Size
@@ -69,9 +101,9 @@ describe('<MarkdownSlideSet />', () => {
         - One
         - Two
         - Three
-        
+
         ---
-        
+
         - Four
         - Five
         - Size
@@ -88,7 +120,7 @@ describe('<MarkdownSlideSet />', () => {
         <Heading>Im not styled...</Heading>
         <Markdown componentProps={{ color: 'purple' }}>{`
         # What's up world, I'm styled.
-        
+
         - List item
         - And another one
       `}</Markdown>
@@ -136,9 +168,9 @@ describe('<MarkdownSlideSet />', () => {
     const wrapper = mountInsideDeck(
       <MarkdownSlideSet componentProps={{ color: 'purple' }}>{`
         # What's up world, I'm styled.
-        
+
         ---
-        
+
         # Another slide
       `}</MarkdownSlideSet>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hast@^2.0.0":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"
+  integrity sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz"
@@ -1307,6 +1314,11 @@
   version "13.7.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz"
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
+
+"@types/parse5@^5.0.0":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
+  integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -4371,16 +4383,67 @@ hast-to-hyperscript@^9.0.0:
     unist-util-is "^4.0.0"
     web-namespaces "^1.0.0"
 
+hast-util-from-parse5@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz#554e34abdeea25ac76f5bd950a1f0180e0b3bc2a"
+  integrity sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==
+  dependencies:
+    "@types/parse5" "^5.0.0"
+    hastscript "^6.0.0"
+    property-information "^5.0.0"
+    vfile "^4.0.0"
+    vfile-location "^3.2.0"
+    web-namespaces "^1.0.0"
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz"
   integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hast-util-raw@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-6.1.0.tgz#e16a3c2642f65cc7c480c165400a40d604ab75d0"
+  integrity sha512-5FoZLDHBpka20OlZZ4I/+RBw5piVQ8iI1doEvffQhx5CbCyTtP8UCq8Tw6NmTAMtXgsQxmhW7Ly8OdFre5/YMQ==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    hast-util-from-parse5 "^6.0.0"
+    hast-util-to-parse5 "^6.0.0"
+    html-void-elements "^1.0.0"
+    parse5 "^6.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
+    vfile "^4.0.0"
+    web-namespaces "^1.0.0"
+    xtend "^4.0.0"
+    zwitch "^1.0.0"
+
+hast-util-to-parse5@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz#1ec44650b631d72952066cea9b1445df699f8479"
+  integrity sha512-Lu5m6Lgm/fWuz8eWnrKezHtVY83JeRGaNQ2kn9aJgqaxvVkFCZQBEhgodZUDUvoodgyROHDb3r5IxAEdl6suJQ==
+  dependencies:
+    hast-to-hyperscript "^9.0.0"
+    property-information "^5.0.0"
+    web-namespaces "^1.0.0"
+    xtend "^4.0.0"
+    zwitch "^1.0.0"
 
 hastscript@^5.0.0:
   version "5.1.2"
   resolved "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz"
   integrity sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==
   dependencies:
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
     comma-separated-tokens "^1.0.0"
     hast-util-parse-selector "^2.0.0"
     property-information "^5.0.0"
@@ -4480,6 +4543,11 @@ html-minifier@^3.2.3:
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.4.x"
+
+html-void-elements@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
+  integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
 html-webpack-plugin@^3.2.0:
   version "3.2.0"
@@ -6665,6 +6733,11 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
+parse5@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
@@ -7318,6 +7391,13 @@ regjsparser@^0.6.4:
   integrity sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==
   dependencies:
     jsesc "~0.5.0"
+
+rehype-raw@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-5.1.0.tgz#66d5e8d7188ada2d31bc137bc19a1000cf2c6b7e"
+  integrity sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==
+  dependencies:
+    hast-util-raw "^6.1.0"
 
 rehype-react@^6.0.0:
   version "6.2.0"
@@ -8898,7 +8978,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vfile-location@^3.0.0:
+vfile-location@^3.0.0, vfile-location@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz"
   integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==


### PR DESCRIPTION
### Description

This PR adds raw HTML support like normal Markdown. Our present scheme strips out all tags leaving only text.

My use case is wanting things like font-awesome icon additions which have no clear path of introduction other than HTML and other than that I'd rather be in markdown 😉 

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added a unit test and tested in the deck I'm working on that I'd want this support on.

### Other notes

This PR does add dangerous HTML, which is seems only risky if your deck uses outside input. I didn't see anywhere in the docs that we note previous behavior stripped HTML tags in MD, but maybe we might want to:

1. Evaluate risks of this new behavior? If risky, put behind an option instead?
2. Update the docs somewhere?