### PR TITLE
Add support for custom transitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ test/screenshots
 \.hg
 .idea
 .vscode
+.nova
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+- Added support for custom slide and deck transitions
+- Added Fade and Slide transition objects as built-in transitions
+- Updated JS example with spinning custom slide transition
+
 ## 8.1.0
 
 - Allow raw HTML in Markdown content.

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -16,33 +16,35 @@ These are the bare bones of a Spectacle presentation, the two most essential tag
 Wraps the entire presentation and carries most of the overarching slide logic, like `theme` and `template` context.
 A `template` contains Layout tags (referred to as a template render function) and is supplied to the `Deck` component to apply to all subsequent `Slide`s. The last three props are for print and export mode only, they have no effect on the audience or presenter views. The `pageSize` and `pageOrientation` props correspond to the size and orientation values for the [CSS media print size selector](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/size). The `pageSize` is automatically set based on the deck theme slide size for a best-fit using export to PDF mode. If you need to print your deck, supply your paper size using the `pageSize` prop. The `printScale` is the ratio for the selected page size, orientation, and slide size. `0.958` is the best ratio for to ensure the PDF export fits the slide theme size. Currently, only Chrome and Chromium-based browsers fully implement the custom page size CSS media print specification. Other browsers such as Firefox and Safari can still export to PDF but the page size will not be a best fit.
 
-| Props              | Type                                     | Default            |
-| ------------------ | ---------------------------------------- | ------------------ |
-| `theme`            | [Styled-system theme object](./themes)   |                    |
-| `template`         | [Template render function](#layout-tags) |                    |
-| `pageSize`         | PropTypes.string                         | `"13.66in 7.68in"` |
-| `pageOrientation`  | `"landscape"` or `"portrait"`            | `"landscape"`      |
-| `printScale`       | PropTypes.number                         | `0.959`            |
-| `autoPlay`         | PropTypes.bool                           | `false`            |
-| `autoPlayLoop`     | PropTypes.bool                           | `false`            |
-| `autoPlayInterval` | PropTypes.number (milliseconds)          | `1000`             |
+| Props              | Type                                        | Default            |
+| ------------------ | ------------------------------------------- | ------------------ |
+| `theme`            | [Styled-system theme object](./themes)      |                    |
+| `template`         | [Template render function](#layout-tags)    |                    |
+| `pageSize`         | PropTypes.string                            | `"13.66in 7.68in"` |
+| `pageOrientation`  | `"landscape"` or `"portrait"`               | `"landscape"`      |
+| `printScale`       | PropTypes.number                            | `0.959`            |
+| `autoPlay`         | PropTypes.bool                              | `false`            |
+| `autoPlayLoop`     | PropTypes.bool                              | `false`            |
+| `autoPlayInterval` | PropTypes.number (milliseconds)             | `1000`             |
+| `transition`       | [**Transition**](./props#transition-object) | `slideTransition`  |
 
 ### Slide
 
 Wraps a single slide within your presentation; identifies what is contained to a single view. If a transition effect is applied to this slide, it will override the Deck-specified transition.
 
-| Props                | Type             |
-| -------------------- | ---------------- |
-| `backgroundColor`    | PropTypes.string |
-| `backgroundImage`    | PropTypes.string |
-| `backgroundOpacity`  | PropTypes.number |
-| `backgroundPosition` | PropTypes.string |
-| `backgroundRepeat`   | PropTypes.string |
-| `backgroundSize`     | PropTypes.string |
-| `scaleRatio`         | PropTypes.number |
-| `slideNum`           | PropTypes.number |
-| `template`           | PropTypes.func   |
-| `textColor`          | PropTypes.string |
+| Props                | Type                                        |
+| -------------------- | ------------------------------------------- |
+| `backgroundColor`    | PropTypes.string                            |
+| `backgroundImage`    | PropTypes.string                            |
+| `backgroundOpacity`  | PropTypes.number                            |
+| `backgroundPosition` | PropTypes.string                            |
+| `backgroundRepeat`   | PropTypes.string                            |
+| `backgroundSize`     | PropTypes.string                            |
+| `scaleRatio`         | PropTypes.number                            |
+| `slideNum`           | PropTypes.number                            |
+| `template`           | PropTypes.func                              |
+| `textColor`          | PropTypes.string                            |
+| `transition`         | [**Transition**](./props#transition-object) |
 
 ## Typography Tags
 

--- a/docs/content/props.md
+++ b/docs/content/props.md
@@ -16,16 +16,16 @@ An example transition object looks like:
 ```javascript
 const transition = {
   from: {
-    position: 'fixed',
-    transform: 'translate(100%, 0%)'
+    opacity: 0,
+    transform: 'rotate(45deg)'
   },
   enter: {
-    position: 'fixed',
-    transform: 'translate(0, 0%)'
+    opacity: 1,
+    transform: 'rotate(0)'
   },
   leave: {
-    position: 'fixed',
-    transform: 'translate(-100%, 0%)'
+    opacity: 0,
+    transform: 'rotate(315deg)'
   }
 };
 ```

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -99,6 +99,20 @@ const Presentation = () => (
       </FlexBox>
     </Slide>
     <Slide
+      transition={{
+        from: {
+          transform: 'scale(0.5) rotate(45deg)',
+          opacity: 0
+        },
+        enter: {
+          transform: 'scale(1) rotate(0)',
+          opacity: 1
+        },
+        leave: {
+          transform: 'scale(0.2) rotate(315deg)',
+          opacity: 0
+        }
+      }}
       backgroundColor="tertiary"
       backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/src/beau.jpg?raw=true)"
       backgroundOpacity={0.5}

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -100,7 +100,20 @@
               <${Heading} margin="0px 32px" color="primary" fontSize="h3">Where you can write your decks in JSX, Markdown, or MDX!</${Heading}>
             </${FlexBox}>
           </${Slide}>
-          <${Slide} backgroundColor="tertiary" backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/src/beau.jpg?raw=true)" backgroundOpacity=${0.5}>
+          <${Slide} transition=${{
+          from: {
+            transform: 'scale(0.5) rotate(45deg)',
+            opacity: 0
+          },
+          enter: {
+            transform: 'scale(1) rotate(0)',
+            opacity: 1
+          },
+          leave: {
+            transform: 'scale(0.2) rotate(315deg)',
+            opacity: 0
+          }
+        }} backgroundColor="tertiary" backgroundImage="url(https://github.com/FormidableLabs/dogs/blob/main/src/beau.jpg?raw=true)" backgroundOpacity=${0.5}>
             <${Heading}>Custom Backgrounds</${Heading}>
             <${UnorderedList}>
               <${ListItem}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,12 @@ declare module 'spectacle' {
   import * as StyledSystem from 'styled-system';
   import { ExtendedKeyboardEvent } from 'mousetrap';
 
+  export type SlideTransition = {
+    from: Record<string, string | number>;
+    leave: Record<string, string | number>;
+    enter: Record<string, string | number>;
+  };
+
   export type TemplateFn = (options: {
     numberOfSlides: number;
     currentSlide: number;
@@ -25,6 +31,7 @@ declare module 'spectacle' {
     theme?: Record<string, any>;
     template?: TemplateFn | React.ReactNode;
     printScale?: number;
+    transition?: SlideTransition;
   }>;
 
   export const Slide: React.FC<{
@@ -38,6 +45,7 @@ declare module 'spectacle' {
     padding?: string | number;
     textColor?: string;
     template?: TemplateFn | React.ReactNode;
+    transition?: SlideTransition;
   }>;
 
   export const Appear: React.FC<{
@@ -189,7 +197,10 @@ declare module 'spectacle' {
           slideNumber: number;
           numberOfSlides: number;
         }) => React.ReactNode);
+    transition: SlideTransition;
   }>;
 
   export const indentNormalizer: (input: string) => string;
+  export const fadeTransition: SlideTransition;
+  export const slideTransition: SlideTransition;
 }

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -24,6 +24,8 @@ import {
 } from './deck-styles';
 import { useAutoPlay } from '../../utils/use-auto-play';
 import defaultTheme from '../../theme/default-theme';
+import { defaultTransition } from '../transitions';
+import PropTypes from 'prop-types';
 
 export const DeckContext = createContext();
 const noop = () => {};
@@ -100,7 +102,8 @@ const Deck = forwardRef(
       suppressBackdropFallback = false,
       autoPlay = false,
       autoPlayLoop = false,
-      autoPlayInterval = 1000
+      autoPlayInterval = 1000,
+      transition = defaultTransition
     },
     ref
   ) => {
@@ -376,6 +379,7 @@ const Deck = forwardRef(
               regressSlide,
               commitTransition,
               cancelTransition,
+              transition,
               template
             }}
           >
@@ -416,7 +420,12 @@ Deck.propTypes = {
   suppressBackdropFallback: propTypes.bool,
   autoPlay: propTypes.bool,
   autoPlayLoop: propTypes.bool,
-  autoPlayInterval: propTypes.number
+  autoPlayInterval: propTypes.number,
+  transition: PropTypes.shape({
+    from: PropTypes.object,
+    enter: PropTypes.object,
+    leave: PropTypes.object
+  })
 };
 
 export default Deck;

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -25,7 +25,6 @@ import {
 import { useAutoPlay } from '../../utils/use-auto-play';
 import defaultTheme from '../../theme/default-theme';
 import { defaultTransition } from '../transitions';
-import PropTypes from 'prop-types';
 
 export const DeckContext = createContext();
 const noop = () => {};
@@ -421,10 +420,10 @@ Deck.propTypes = {
   autoPlay: propTypes.bool,
   autoPlayLoop: propTypes.bool,
   autoPlayInterval: propTypes.number,
-  transition: PropTypes.shape({
-    from: PropTypes.object,
-    enter: PropTypes.object,
-    leave: PropTypes.object
+  transition: propTypes.shape({
+    from: propTypes.object,
+    enter: propTypes.object,
+    leave: propTypes.object
   })
 };
 

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -16,7 +16,6 @@ import { useSlide } from '../../hooks/use-slides';
 import { useCollectSteps } from '../../hooks/use-steps';
 import { GOTO_FINAL_STEP } from '../../hooks/use-deck-state';
 import { useSwipeable } from 'react-swipeable';
-import { defaultTransition } from '../transitions';
 
 const noop = () => {};
 
@@ -111,7 +110,6 @@ export default function Slide({
     slidePortalNode,
     frameOverrideStyle = {},
     wrapperOverrideStyle = {},
-    initialized: deckInitialized,
     passedSlideIds,
     upcomingSlideIds,
     activeView,

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -16,14 +16,11 @@ import { useSlide } from '../../hooks/use-slides';
 import { useCollectSteps } from '../../hooks/use-steps';
 import { GOTO_FINAL_STEP } from '../../hooks/use-deck-state';
 import { useSwipeable } from 'react-swipeable';
+import { defaultTransition } from '../transitions';
 
 const noop = () => {};
 
 export const SlideContext = createContext(null);
-
-const STAGE_RIGHT = 'translateX(-100%)';
-const CENTER_STAGE = 'translateX(0%)';
-const STAGE_LEFT = 'translateX(100%)';
 
 const SlideContainer = styled('div')`
   ${color};
@@ -92,6 +89,7 @@ export default function Slide({
   padding,
   textColor,
   template,
+  transition: slideTransition = {},
   className = ''
 }) {
   if (useContext(SlideContext)) {
@@ -122,6 +120,7 @@ export default function Slide({
     regressSlide,
     commitTransition,
     cancelTransition,
+    transition,
     template: deckTemplate,
     slideCount
   } = useContext(DeckContext);
@@ -131,6 +130,14 @@ export default function Slide({
     },
     [onSlideClick, slideId]
   );
+
+  const mergedTransition = useMemo(() => {
+    const result = { ...transition };
+    'from' in slideTransition && (result.from = slideTransition.from);
+    'enter' in slideTransition && (result.enter = slideTransition.enter);
+    'leave' in slideTransition && (result.leave = slideTransition.leave);
+    return result;
+  }, [slideTransition, transition]);
 
   const inOverviewMode = Object.entries(frameOverrideStyle).length > 0;
   const isActive = activeView.slideId === slideId;
@@ -239,24 +246,31 @@ export default function Slide({
 
   const target = useMemo(() => {
     if (isPassed) {
-      return [{ transform: STAGE_RIGHT }, { display: 'none' }];
+      return [mergedTransition.leave, { display: 'none' }];
     }
     if (isActive) {
       return {
-        transform: CENTER_STAGE,
+        ...mergedTransition.enter,
         display: 'unset'
       };
     }
     if (isUpcoming) {
       return {
-        transform: STAGE_LEFT,
+        ...mergedTransition.from,
         display: 'none'
       };
     }
     return {
       display: 'none'
     };
-  }, [isPassed, isActive, isUpcoming]);
+  }, [
+    isPassed,
+    isActive,
+    isUpcoming,
+    mergedTransition.leave,
+    mergedTransition.enter,
+    mergedTransition.from
+  ]);
 
   const immediate = !animate || !useAnimations;
 
@@ -360,7 +374,12 @@ Slide.propTypes = {
   children: PropTypes.node.isRequired,
   padding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   textColor: PropTypes.string,
-  template: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+  template: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  transition: PropTypes.shape({
+    from: PropTypes.object,
+    enter: PropTypes.object,
+    leave: PropTypes.object
+  })
 };
 
 Slide.defaultProps = {

--- a/src/components/transitions/index.js
+++ b/src/components/transitions/index.js
@@ -1,4 +1,8 @@
-export const opacity = {
+const STAGE_RIGHT = 'translateX(-100%)';
+const CENTER_STAGE = 'translateX(0%)';
+const STAGE_LEFT = 'translateX(100%)';
+
+export const fadeTransition = {
   from: {
     opacity: 0
   },
@@ -10,14 +14,16 @@ export const opacity = {
   }
 };
 
-export const slide = {
+export const slideTransition = {
   from: {
-    transform: 'translate(100%, 0%)'
+    transform: STAGE_LEFT
   },
   enter: {
-    transform: 'translate(0%, 0%)'
+    transform: CENTER_STAGE
   },
   leave: {
-    transform: 'translate(-100%, 0%)'
+    transform: STAGE_RIGHT
   }
 };
+
+export const defaultTransition = slideTransition;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import indentNormalizer from './utils/indent-normalizer';
 import { DeckContext } from './components/deck/deck';
 import useMousetrap from './hooks/use-mousetrap';
 import defaultTheme from './theme/default-theme';
+import { fadeTransition, slideTransition } from './components/transitions';
 
 export {
   Appear,
@@ -76,5 +77,7 @@ export {
   isolateNotes,
   indentNormalizer,
   defaultTheme,
-  useMousetrap
+  useMousetrap,
+  fadeTransition,
+  slideTransition
 };


### PR DESCRIPTION
### Description

Adds support for custom transitions and two built-in transition objects: Fade and Slide. Slide is the default transitions for decks. Slides can have custom transitions that override the default Deck transition style on a per-slide basis.

- Updates one page and JS examples
- Updates documentation 

Fixes # (issue)

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Added examples to both the OnePage and JS Decks.
