### PR TITLE
Fixed showLineNumbers and theme sizing for CodePane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `showLineNumbers` and theme sizing for `<CodePane />`
+
 ## 8.2.0
 
 - Added support for custom slide and deck transitions

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -123,6 +123,7 @@ _Note that each range will be considered as a step in your current slide's anima
 | `highlightRanges` | PropTypes.arrayOf(PropTypes.number) or PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)) | `[1, 3]` or `[[6, 8], [10, 15]]`                                                                                          | -                    |
 | `language`        | PropTypes.string                                                                              | `javascript`                                                                                                              | -                    |
 | `theme`           | PropTypes.object or                                                                           | [Prism Theme](https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/index.js) | vs-dark Theme Object |
+| `showLineNumbers` | PropTypes.bool                                                                                | `true`, `false`                                                                                                           | `true`               |
 
 ```jsx
 import tomorrow from 'react-syntax-highlighter/dist/cjs/styles/prism/tomorrow';

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -200,6 +200,14 @@ const Presentation = () => (
           </Provider>
         );
         `}</CodePane>
+      <Box height={20} />
+      <CodePane language="java" showLineNumbers={false}>{`
+        public class NoLineNumbers {
+          public static void main(String[] args) {
+            System.out.println("Hello");
+          }
+        }
+        `}</CodePane>
     </Slide>
     <div>
       <Slide>

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,8 @@ declare module 'spectacle' {
     language: string;
     theme?: Record<string, unknown>;
     stepIndex?: number;
-    highlightRanges: number | number[];
+    highlightRanges?: number | number[];
+    showLineNumbers?: boolean;
   }>;
 
   type TypographyProps = {
@@ -82,7 +83,7 @@ declare module 'spectacle' {
     React.AnchorHTMLAttributes<Record<string, unknown>>>;
 
   type BoxProps = {
-    children: React.ReactNode;
+    children?: React.ReactNode;
   } & StyledSystem.ColorProps &
     StyledSystem.SpaceProps &
     StyledSystem.LayoutProps &

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -53,6 +53,7 @@ const getStyleForLineNumber = (lineNumber, activeRange) => {
 export default function CodePane({
   highlightRanges = [],
   language,
+  showLineNumbers = true,
   children: rawCodeString,
   stepIndex,
   theme: syntaxTheme = dark
@@ -157,7 +158,7 @@ export default function CodePane({
         customStyle={customStyle}
         language={language}
         wrapLines
-        showLineNumbers
+        showLineNumbers={showLineNumbers}
         lineProps={getLineProps}
         lineNumberProps={getLineNumberProps}
         style={syntaxTheme}
@@ -173,8 +174,9 @@ CodePane.propTypes = {
     propTypes.oneOfType([
       propTypes.number.isRequired,
       propTypes.arrayOf(propTypes.number.isRequired)
-    ]).isRequired
+    ])
   ),
+  showLineNumbers: propTypes.bool,
   language: propTypes.string.isRequired,
   children: propTypes.string.isRequired,
   stepIndex: propTypes.number,

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -70,10 +70,6 @@ const Deck = forwardRef(
       printScale = DEFAULT_PRINT_SCALE,
       template,
       theme: {
-        size: { width: nativeSlideWidth, height: nativeSlideHeight } = {
-          width: defaultTheme.size.width,
-          height: defaultTheme.size.height
-        },
         Backdrop: UserProvidedBackdropComponent,
         backdropStyle: themeProvidedBackdropStyle = {
           position: 'fixed',
@@ -107,6 +103,10 @@ const Deck = forwardRef(
     ref
   ) => {
     const [deckId] = useState(userProvidedId || ulid);
+    const {
+      width: nativeSlideWidth = defaultTheme.size.width,
+      height: nativeSlideHeight = defaultTheme.size.height
+    } = restTheme.size || {};
 
     const {
       initialized,


### PR DESCRIPTION
### Description

Fixes `showLineNumbers` to be a prop and not have `true` as a hard coded value. Also ensures the theme size is correctly passed to the ThemeProvider.

Fixes #1024 

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested via the example deck by providing a custom theme size and a new number-less code pane example.