### PR TITLE
Forward refs on components 

### DIFF
--- a/src/components/fullscreen.js
+++ b/src/components/fullscreen.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useToggleFullScreen } from '../hooks/use-full-screen';
 
-const FullScreen = props => {
+const FullScreen = React.forwardRef((props, ref) => {
   const Container = styled('div')`
     @media print {
       display: none;
@@ -14,6 +14,7 @@ const FullScreen = props => {
   const toggleFullScreen = useToggleFullScreen();
   return (
     <Container
+      ref={ref}
       className="spectacle-fullscreen-button"
       onClick={toggleFullScreen}
       style={{ pointerEvents: 'all' }}
@@ -30,7 +31,9 @@ const FullScreen = props => {
       </svg>
     </Container>
   );
-};
+});
+
+FullScreen.displayName = 'Fullscreen';
 
 FullScreen.propTypes = {
   color: propTypes.string,

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -21,10 +21,10 @@ const Container = styled('div')`
   }
 `;
 
-const Progress = props => {
+const Progress = React.forwardRef((props, ref) => {
   const { slideCount, skipTo, activeView } = React.useContext(DeckContext);
   return (
-    <Container className="spectacle-progress-indicator">
+    <Container ref={ref} className="spectacle-progress-indicator">
       {Array(slideCount)
         .fill(0)
         .map((_, idx) => (
@@ -44,7 +44,9 @@ const Progress = props => {
         ))}
     </Container>
   );
-};
+});
+
+Progress.displayName = 'Progress';
 
 Progress.propTypes = {
   color: propTypes.string,


### PR DESCRIPTION
### Description

Forwards refs to CodePane, FullScreen, Markdown and Progress components so that the internal elements can be referenced externally.

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested by adding a ref to each of the components in question on the example/js project to confirm that they are being forwarded and set correctly:

<img width="625" alt="Screenshot 2021-06-10 at 15 49 26" src="https://user-images.githubusercontent.com/9557798/121548892-4a972a00-ca05-11eb-8f22-a4d5b2142bc7.png">
