### PR TITLE
Avoid unnecessarily mounting the contents of slides that are not visible

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -86,28 +86,28 @@ These tags are for adding tables with content to your slides.
 
 ## useSteps
 
-The `useSteps` hook allows a component to participate in the _slide step sequence_ for a given Slide. 
+The `useSteps` hook allows a component to participate in the _slide step sequence_ for a given Slide.
 
 NOTE: the vast majority of use cases are covered by the `Stepper` and `Appear` components documented below- in fact, they are implemented via this hook. The only case in which you may need to use this hook explicitly is if you need more precise control over a component in your presentation.
 
 ### Arguments and Options
 
 - `numSteps` The first argument to this hook, `numSteps`, indicates how many steps your component will occupy in the slide step sequence. The second argument is an options object which accepts two options: `id` and `stepIndex`.
-- `options.id`: *(For debugging and testing purposes only.)* Allows you to customize the step sequence ID for this component.
+- `options.id`: _(For debugging and testing purposes only.)_ Allows you to customize the step sequence ID for this component.
 - `options.priority`: Allows fine-grained control over the sequencing of multiple step sequence participants in a given Slide. By default, participants will be activated in the order in which they are rendered. However, this option allows you to specify a "priority"- for instance, a participant with `priority: -1` will run before any other participant, _regardless_ of render order.
 
 ### Return Values
 
 This hook returns four values: `stepId`, `isActive`, `step`, and `placeholder`.
 
-- `stepId`: *(For debugging and testing purposes only.)* Either the `id` option passed into the hook, or a randomly-generated ULID.
+- `stepId`: _(For debugging and testing purposes only.)_ Either the `id` option passed into the hook, or a randomly-generated ULID.
 - `step`: the _relative_ step within this participant's step sequence. Before the slide has reached this participant, this value is `-1`. When the slide reaches this stepper, it will increase at each step until it reaches `numSteps - 1`, and will remain there after the slide step has 'passed' it.
 - `isActive`: Boolean value indicating whether the slide step sequence has reached this participant. Equivalent to the expression `step >= 0`.
-- `placeholder`: DOM node which *must* be rendered by the consumer component- this is how a Slide detects step sequence participants.
+- `placeholder`: DOM node which _must_ be rendered by the consumer component- this is how a Slide detects step sequence participants.
 
 ## Stepper
 
-`<Stepper>` is a thin wrapper around `useSteps`. The length of its `values` list indicates the number of steps it occupies in the slide step sequence. Each of these values are passed in turn to the render function you provide.  Additionally, it allows you to specify styles which should be applied before and after it is activated, and uses `react-spring` to interpolate between the 'active style' and the 'inactive style'.
+`<Stepper>` is a thin wrapper around `useSteps`. The length of its `values` list indicates the number of steps it occupies in the slide step sequence. Each of these values are passed in turn to the render function you provide. Additionally, it allows you to specify styles which should be applied before and after it is activated, and uses `react-spring` to interpolate between the 'active style' and the 'inactive style'.
 
 The render function you provide (either via the `render` prop or as a '`children` function') is called with three arguments:
 
@@ -121,16 +121,18 @@ For instance, suppose we render a slide like this:
 <Slide>
   <p>Hello, world!</p>
   <Stepper tagName="p" alwaysVisible values={['foo', 'bar']}>
-    {(value, step, isActive) => (isActive
+    {(value, step, isActive) =>
+      isActive
         ? `The first stepper is not active. Step: ${step} Value: ${value}`
         : `The first stepper is active. Step: ${step} Value: ${value}`
-    )}
+    }
   </Stepper>
   <Stepper tagName="p" alwaysVisible values={['baz', 'quux']}>
-    {(value, step, isActive) => (isActive
+    {(value, step, isActive) =>
+      isActive
         ? `The second stepper is not active. Step: ${step} Value: ${value}`
         : `The second stepper is active. Step: ${step} Value: ${value}`
-    )}
+    }
   </Stepper>
 </Slide>
 ```
@@ -145,7 +147,7 @@ The following output will be rendered as you step through the slide:
 
 <!-- slide step 1 -->
 <p>Hello, world!</p>
-<p>The first stepper is active. Step: 0 Value: foo </p>
+<p>The first stepper is active. Step: 0 Value: foo</p>
 <p>The second stepper is not active. Step: -1 Value: undefined</p>
 
 <!-- slide step 2 -->
@@ -171,7 +173,7 @@ The following output will be rendered as you step through the slide:
 
 ### Props
 
-- `id`: *(For debugging and testing purposes only)* Passed to `useSteps`.
+- `id`: _(For debugging and testing purposes only)_ Passed to `useSteps`.
 - `priority`: Passed to `useSteps`.
 - `render`: Render function (see above.)
 - `children`: Render function (see above.)
@@ -180,20 +182,21 @@ The following output will be rendered as you step through the slide:
 - `values`: Values array (see description above).
 - `alwaysVisible`: Forces this stepper to always have its active style applied.
 - `activeStyle`: Style object applied when this `<Stepper>` is active. Defaults to `{ opacity: 1 }`.
-- `inactiveStyle`: Style object applied when this `<Stepper>` is inactive.  Defaults to `{ opacity: 0 }`.
+- `inactiveStyle`: Style object applied when this `<Stepper>` is inactive. Defaults to `{ opacity: 0 }`.
 
 ## Appear
 
 Appear is a thin wrapper around `useSteps`. It occupies a single step within the slide step sequence. It wraps its child elements in an animated container element, and uses `react-spring` to interpolate between its `activeStyle` and `inactiveStyle`.
 
 ### Props
-- `id`: *(For debugging and testing purposes only)* Passed to `useSteps`.
+
+- `id`: _(For debugging and testing purposes only)_ Passed to `useSteps`.
 - `priority`: Passed to `useSteps`.
 - `children`: Children rendered within this `Appear`.
 - `className`: Class name applied to the animated container element.
 - `tagName`: Tag which will be used as the animated container element. Defaults to `div`.
 - `activeStyle`: Style object applied when this `<Appear>` is active. Defaults to `{ opacity: 1 }`.
-- `inactiveStyle`: Style object applied when this `<Appear>` is inactive.  Defaults to `{ opacity: 0 }`.
+- `inactiveStyle`: Style object applied when this `<Appear>` is inactive. Defaults to `{ opacity: 0 }`.
 
 ## Code Pane
 

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -12,6 +12,7 @@ import {
   FullScreen,
   Progress,
   Appear,
+  Stepper,
   Slide,
   Deck,
   Text,
@@ -64,6 +65,16 @@ const SlideFragments = () => (
       <Appear>
         <Text>This item shows up!</Text>
       </Appear>
+      <Stepper values={['foo', 'bar', 'baz']}>
+        {(value, step) => (
+          <>
+            <Text>This is a stepper with multiple values.</Text>
+            <Text>
+              The value is {value} on step {step}
+            </Text>
+          </>
+        )}
+      </Stepper>
       <Appear>
         <Text>This item also shows up!</Text>
       </Appear>
@@ -148,10 +159,9 @@ const Presentation = () => (
         <Appear>
           <ListItem>Out of order</ListItem>
         </Appear>
-        <Appear>
+        <Appear priority={0}>
           <ListItem>
-            Just identify the order with the prop <CodeSpan>stepIndex</CodeSpan>
-            !
+            Just identify the order with the prop <CodeSpan>priority</CodeSpan>!
           </ListItem>
         </Appear>
       </OrderedList>
@@ -229,8 +239,8 @@ const Presentation = () => (
        It uses the \`animateListItems\` prop.
 
        - Its list items...
-       - they will appear in...
-       - one at a time.
+       - ...will appear...
+       - ...one at a time.
       `}
     </MarkdownSlide>
     <Slide>

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -13,8 +13,8 @@
     <script src="https://unpkg.com/react-dom@16.13.1/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/react-is@16.13.1/umd/react-is.production.min.js"></script>
     <script src="https://unpkg.com/prop-types@15.7.2/prop-types.min.js"></script>
-    <script src="https://unpkg.com/spectacle@^8/dist/spectacle.min.js"></script>
-    <!-- <script src="../dist/spectacle.js"></script> -->
+    <!-- <script src="https://unpkg.com/spectacle@^8/dist/spectacle.min.js"></script> -->
+    <script src="../dist/spectacle.js"></script>
 
     <script type="module">
       const {
@@ -37,7 +37,8 @@
         CodePane,
         MarkdownSlide,
         MarkdownSlideSet,
-        Notes
+        Notes,
+        Stepper
       } = Spectacle;
 
       import htm from 'https://unpkg.com/htm@^3?module';
@@ -75,6 +76,15 @@
           <${Appear}>
             <${Text}>This item shows up!</${Text}>
           </${Appear}>
+          <${Stepper} values=${['foo', 'bar', 'baz']}>
+            ${(value, step) => (
+              html`
+                <${Text}>
+                  This is a stepper with multiple values. The value is ${value} on step ${step}
+                </${Text}>
+              `
+            )}
+          </${Stepper}>
           <${Appear}>
             <${Text}>This item also shows up!</${Text}>
           </${Appear}>
@@ -145,8 +155,8 @@
               <${Appear}>
                 <${ListItem}>Out of order</${ListItem}>
               </${Appear}>
-              <${Appear}>
-                <${ListItem}>Just identify the order with the prop <${CodeSpan}>stepIndex</${CodeSpan}>!</${ListItem}>
+              <${Appear} priority=${0}>
+                <${ListItem}>Just identify the order with the prop <${CodeSpan}>priority</${CodeSpan}>!</${ListItem}>
               </${Appear}>
             </${OrderedList}>
           </${Slide}>
@@ -209,8 +219,8 @@
             It uses the \`animateListItems\` prop.
 
             - Its list items...
-            - they will appear in...
-            - one at a time.
+            - ...will appear...
+            - ...one at a time.
             `}
           </${MarkdownSlide}>
           <${Slide}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,9 +49,41 @@ declare module 'spectacle' {
   }>;
 
   export const Appear: React.FC<{
-    children: React.ReactNode;
+    id?: string | number;
+    priority?: number;
+    /** @deprecated use priority prop instead */
     stepIndex?: number;
+    children: React.ReactNode;
+    className?: string;
+    tagName?: keyof JSX.IntrinsicElements;
+    activeStyle?: unknown;
+    inactiveStyle?: unknown;
   }>;
+
+  type StepperProps<T extends unknown[] = unknown[]> = {
+    id?: string | number;
+    priority?: number;
+    /** @deprecated use priority prop instead */
+    stepIndex?: number;
+    render?: (
+      value: T[number],
+      step: number,
+      isActive: boolean
+    ) => React.ReactNode;
+    children?: (
+      value: T[number],
+      step: number,
+      isActive: boolean
+    ) => React.ReactNode;
+    className?: string;
+    tagName?: keyof JSX.IntrinsicElements;
+    values: T;
+    alwaysVisible?: boolean;
+    activeStyle?: unknown;
+    inactiveStyle?: unknown;
+  };
+
+  export const Stepper: React.FC<StepperProps>;
 
   export const CodePane: React.FC<{
     children: React.ReactNode;

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -11,6 +11,7 @@ function SteppedComponent({
   children: childrenOrRenderFunction,
   tagName = 'div',
   priority,
+  stepIndex,
   numSteps = 1,
   alwaysAppearActive = false,
   activeStyle = { opacity: '1' },
@@ -18,7 +19,11 @@ function SteppedComponent({
 }) {
   const { immediate } = React.useContext(SlideContext);
 
-  const { isActive, step, placeholder } = useSteps(numSteps, { id, priority });
+  const { isActive, step, placeholder } = useSteps(numSteps, {
+    id,
+    priority,
+    stepIndex
+  });
 
   const AnimatedEl = animated[tagName];
 
@@ -53,6 +58,7 @@ SteppedComponent.propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   tagName: PropTypes.string,
   priority: PropTypes.number,
+  stepIndex: PropTypes.number,
   numSteps: PropTypes.number,
   alwaysAppearActive: PropTypes.bool,
   activeStyle: PropTypes.object,
@@ -70,6 +76,7 @@ export function Appear({ children, ...restProps }) {
 Appear.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   priority: PropTypes.number,
+  stepIndex: PropTypes.number,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   className: PropTypes.string,
   tagName: PropTypes.string,
@@ -86,9 +93,6 @@ export function Stepper({
   inactiveStyle,
   ...restProps
 }) {
-  console.log(renderFn);
-  console.log(renderChildrenFn);
-
   if (renderFn !== undefined && renderChildrenFn !== undefined) {
     throw new Error(
       '<Stepper> component specified both `render` prop and a render function as its `children`.'
@@ -112,15 +116,12 @@ export function Stepper({
 Stepper.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   priority: PropTypes.number,
-
+  stepIndex: PropTypes.number,
   render: PropTypes.func,
   children: PropTypes.func,
-
   className: PropTypes.string,
   tagName: PropTypes.string,
-
   values: PropTypes.arrayOf(PropTypes.any).isRequired,
-
   alwaysVisible: PropTypes.bool,
   activeStyle: PropTypes.object,
   inactiveStyle: PropTypes.object

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -99,7 +99,6 @@ export function Stepper({
     );
   }
 
-
   return (
     <SteppedComponent
       {...restProps}

--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -5,18 +5,20 @@ import { animated, useSpring } from 'react-spring';
 import { useSteps } from '../hooks/use-steps';
 import { SlideContext } from './slide/slide';
 
-export default function Appear({
+function SteppedComponent({
   id,
   className,
   children: childrenOrRenderFunction,
   tagName = 'div',
-  stepIndex,
+  priority,
+  numSteps = 1,
+  alwaysAppearActive = false,
   activeStyle = { opacity: '1' },
   inactiveStyle = { opacity: '0' }
 }) {
   const { immediate } = React.useContext(SlideContext);
 
-  const { isActive, placeholder } = useSteps(1, { id, stepIndex });
+  const { isActive, step, placeholder } = useSteps(numSteps, { id, priority });
 
   const AnimatedEl = animated[tagName];
 
@@ -35,20 +37,91 @@ export default function Appear({
   return (
     <>
       {placeholder}
-      <AnimatedEl style={springStyle} className={className}>
+      <AnimatedEl
+        style={alwaysAppearActive ? activeStyle : springStyle}
+        className={className}
+      >
         {children}
       </AnimatedEl>
     </>
   );
 }
 
-Appear.propTypes = {
+SteppedComponent.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   className: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   tagName: PropTypes.string,
-  stepIndex: PropTypes.number,
+  priority: PropTypes.number,
   numSteps: PropTypes.number,
+  alwaysAppearActive: PropTypes.bool,
+  activeStyle: PropTypes.object,
+  inactiveStyle: PropTypes.object
+};
+
+export function Appear({ children, ...restProps }) {
+  return (
+    <SteppedComponent {...restProps} numSteps={1}>
+      {children}
+    </SteppedComponent>
+  );
+}
+
+Appear.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  priority: PropTypes.number,
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+  className: PropTypes.string,
+  tagName: PropTypes.string,
+  activeStyle: PropTypes.object,
+  inactiveStyle: PropTypes.object
+};
+
+export function Stepper({
+  values,
+  render: renderFn,
+  children: renderChildrenFn,
+  alwaysVisible = false,
+  activeStyle,
+  inactiveStyle,
+  ...restProps
+}) {
+  console.log(renderFn);
+  console.log(renderChildrenFn);
+
+  if (renderFn !== undefined && renderChildrenFn !== undefined) {
+    throw new Error(
+      '<Stepper> component specified both `render` prop and a render function as its `children`.'
+    );
+  }
+
+
+  return (
+    <SteppedComponent
+      {...restProps}
+      numSteps={values.length}
+      alwaysAppearActive={alwaysVisible}
+    >
+      {(step, isActive) =>
+        (renderFn || renderChildrenFn)(values[step], step, isActive)
+      }
+    </SteppedComponent>
+  );
+}
+
+Stepper.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  priority: PropTypes.number,
+
+  render: PropTypes.func,
+  children: PropTypes.func,
+
+  className: PropTypes.string,
+  tagName: PropTypes.string,
+
+  values: PropTypes.arrayOf(PropTypes.any).isRequired,
+
+  alwaysVisible: PropTypes.bool,
   activeStyle: PropTypes.object,
   inactiveStyle: PropTypes.object
 };

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -215,19 +215,15 @@ const Deck = forwardRef(
     const activeSlideId = slideIds[activeView.slideIndex];
     const pendingSlideId = slideIds[pendingView.slideIndex];
 
-    const [passed, upcoming, prevSlideId, nextSlideId] = useMemo(() => {
+    const [passed, upcoming, prevSlideId] = useMemo(() => {
       const p = new Set();
       const u = new Set();
       let prev = null;
-      let next = null;
 
       let foundActive = false;
       for (const slideId of slideIds) {
         if (foundActive) {
           u.add(slideId);
-          if (next === null) {
-            next = slideId;
-          }
         } else if (slideId === activeSlideId) {
           foundActive = true;
         } else {
@@ -235,7 +231,7 @@ const Deck = forwardRef(
           prev = slideId;
         }
       }
-      return [p, u, prev, next];
+      return [p, u, prev];
     }, [slideIds, activeSlideId]);
 
     const fullyInitialized = initialized && slideIdsInitialized;
@@ -372,7 +368,6 @@ const Deck = forwardRef(
               passedSlideIds: passed,
               upcomingSlideIds: upcoming,
               prevSlideId,
-              nextSlideId,
               activeView: {
                 ...activeView,
                 slideId: activeSlideId

--- a/src/components/deck/deck.js
+++ b/src/components/deck/deck.js
@@ -215,20 +215,27 @@ const Deck = forwardRef(
     const activeSlideId = slideIds[activeView.slideIndex];
     const pendingSlideId = slideIds[pendingView.slideIndex];
 
-    const [passed, upcoming] = useMemo(() => {
+    const [passed, upcoming, prevSlideId, nextSlideId] = useMemo(() => {
       const p = new Set();
       const u = new Set();
+      let prev = null;
+      let next = null;
+
       let foundActive = false;
       for (const slideId of slideIds) {
         if (foundActive) {
           u.add(slideId);
+          if (next === null) {
+            next = slideId;
+          }
         } else if (slideId === activeSlideId) {
           foundActive = true;
         } else {
           p.add(slideId);
+          prev = slideId;
         }
       }
-      return [p, u];
+      return [p, u, prev, next];
     }, [slideIds, activeSlideId]);
 
     const fullyInitialized = initialized && slideIdsInitialized;
@@ -364,6 +371,8 @@ const Deck = forwardRef(
               initialized: fullyInitialized,
               passedSlideIds: passed,
               upcomingSlideIds: upcoming,
+              prevSlideId,
+              nextSlideId,
               activeView: {
                 ...activeView,
                 slideId: activeSlideId

--- a/src/components/markdown/markdown.js
+++ b/src/components/markdown/markdown.js
@@ -19,7 +19,7 @@ import mdxComponentMap from '../../utils/mdx-component-mapper';
 import indentNormalizer from '../../utils/indent-normalizer';
 import Notes from '../notes';
 import { ListItem } from '../../index';
-import Appear from '../appear';
+import { Appear } from '../appear';
 
 export const Markdown = React.forwardRef(
   (

--- a/src/components/markdown/markdown.test.js
+++ b/src/components/markdown/markdown.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import { Markdown, MarkdownSlide, MarkdownSlideSet } from './markdown';
 import Adapter from 'enzyme-adapter-react-16';
 import Deck from '../deck/deck';
 import { Heading, ListItem } from '../typography';
 import { Appear } from '../appear';
 import Slide from '../slide/slide';
+import pretty from 'pretty';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -90,8 +92,8 @@ describe('<MarkdownSlideSet />', () => {
       `}</MarkdownSlideSet>
     );
 
-    expect(wrapper.find('ul')).toHaveLength(2);
-    expect(wrapper.find(ListItem)).toHaveLength(6);
+    expect(wrapper.find('ul')).toHaveLength(1);
+    expect(wrapper.find(ListItem)).toHaveLength(3);
     expect(wrapper.find(Appear)).toHaveLength(0);
   });
 
@@ -110,8 +112,8 @@ describe('<MarkdownSlideSet />', () => {
       `}</MarkdownSlideSet>
     );
 
-    expect(wrapper.find('ul')).toHaveLength(2);
-    expect(wrapper.find(Appear)).toHaveLength(6);
+    expect(wrapper.find('ul')).toHaveLength(1);
+    expect(wrapper.find(Appear)).toHaveLength(3);
   });
 
   it('Markdown should pass componentProps down to constituent components', () => {
@@ -136,13 +138,6 @@ describe('<MarkdownSlideSet />', () => {
 
     expect(
       wrapper
-        .find(Heading)
-        .at(1)
-        .prop('color')
-    ).toBe('purple');
-
-    expect(
-      wrapper
         .find(ListItem)
         .at(0)
         .prop('color')
@@ -164,29 +159,35 @@ describe('<MarkdownSlideSet />', () => {
     ).toBe('purple');
   });
 
-  it('MarkdownSlideSet should pass componentProps down to constituent components', () => {
-    const wrapper = mountInsideDeck(
-      <MarkdownSlideSet componentProps={{ color: 'purple' }}>{`
-        # What's up world, I'm styled.
+  it('MarkdownSlideSet should pass componentProps down to constituent components', async () => {
+    let deck;
 
-        ---
+    const wrapper = mount(
+      <Deck
+        ref={r => {
+          deck = r;
+        }}
+      >
+        <MarkdownSlideSet componentProps={{ color: 'purple' }}>{`
+          # Slide one
 
-        # Another slide
-      `}</MarkdownSlideSet>
+          ---
+
+          # Slide two
+        `}</MarkdownSlideSet>
+      </Deck>
     );
 
-    expect(
-      wrapper
-        .find(Heading)
-        .at(0)
-        .prop('color')
-    ).toBe('purple');
+    act(() => {
+      deck.advanceSlide();
+    });
 
-    expect(
-      wrapper
-        .find(Heading)
-        .at(1)
-        .prop('color')
-    ).toBe('purple');
+    wrapper.update();
+
+    const headings = wrapper.find(Heading);
+    expect(headings.at(0).prop('color')).toBe('purple');
+    expect(headings.at(0).text()).toBe('Slide one');
+    expect(headings.at(1).prop('color')).toBe('purple');
+    expect(headings.at(1).text()).toBe('Slide two');
   });
 });

--- a/src/components/markdown/markdown.test.js
+++ b/src/components/markdown/markdown.test.js
@@ -4,7 +4,7 @@ import { Markdown, MarkdownSlide, MarkdownSlideSet } from './markdown';
 import Adapter from 'enzyme-adapter-react-16';
 import Deck from '../deck/deck';
 import { Heading, ListItem } from '../typography';
-import Appear from '../appear';
+import { Appear } from '../appear';
 import Slide from '../slide/slide';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -112,6 +112,8 @@ export default function Slide({
     wrapperOverrideStyle = {},
     passedSlideIds,
     upcomingSlideIds,
+    prevSlideId,
+    nextSlideId,
     activeView,
     pendingView,
     advanceSlide,
@@ -142,6 +144,8 @@ export default function Slide({
   const isPending = pendingView.slideId === slideId;
   const isPassed = passedSlideIds.has(slideId);
   const isUpcoming = upcomingSlideIds.has(slideId);
+  const isNext = nextSlideId === slideId;
+  const isPrev = prevSlideId === slideId;
 
   const willEnter = !isActive && isPending;
   const willExit = isActive && !isPending;
@@ -310,6 +314,7 @@ export default function Slide({
         }}
       >
         {slidePortalNode &&
+          (isPending || isActive || isPrev || isNext) &&
           ReactDOM.createPortal(
             <AnimatedDiv
               ref={setStepContainer}

--- a/src/components/slide/slide.js
+++ b/src/components/slide/slide.js
@@ -113,7 +113,6 @@ export default function Slide({
     passedSlideIds,
     upcomingSlideIds,
     prevSlideId,
-    nextSlideId,
     activeView,
     pendingView,
     advanceSlide,
@@ -144,7 +143,6 @@ export default function Slide({
   const isPending = pendingView.slideId === slideId;
   const isPassed = passedSlideIds.has(slideId);
   const isUpcoming = upcomingSlideIds.has(slideId);
-  const isNext = nextSlideId === slideId;
   const isPrev = prevSlideId === slideId;
 
   const willEnter = !isActive && isPending;
@@ -314,7 +312,7 @@ export default function Slide({
         }}
       >
         {slidePortalNode &&
-          (isPending || isActive || isPrev || isNext) &&
+          (isPending || isActive || isPrev) &&
           ReactDOM.createPortal(
             <AnimatedDiv
               ref={setStepContainer}

--- a/src/hooks/use-steps.js
+++ b/src/hooks/use-steps.js
@@ -13,7 +13,10 @@ const PLACEHOLDER_CLASS_NAME = 'step-placeholder';
  * Returns the stepId, whether or not the step is active, the relative step
  * number and the DOM placeholder.
  */
-export function useSteps(numSteps = 1, { id: userProvidedId, stepIndex } = {}) {
+export function useSteps(
+  numSteps = 1,
+  { id: userProvidedId, priority, stepIndex } = {}
+) {
   const [stepId] = React.useState(userProvidedId || ulid);
 
   const { activeStepIndex, activationThresholds } = React.useContext(
@@ -61,8 +64,13 @@ export function useSteps(numSteps = 1, { id: userProvidedId, stepIndex } = {}) {
     'data-step-count': numSteps
   };
 
-  if (stepIndex !== undefined) {
-    placeholderProps['data-step-index'] = stepIndex;
+  if (priority !== undefined) {
+    placeholderProps['data-priority'] = priority;
+  } else if (stepIndex !== undefined) {
+    console.warn(
+      '`options.stepIndex` option to `useSteps` is deprecated- please use `priority` option instead.'
+    );
+    placeholderProps['data-priority'] = stepIndex;
   }
 
   return {
@@ -91,28 +99,28 @@ export function useCollectSteps() {
 
     const [thresholds, numSteps] = [...placeholderNodes]
       .map((node, index) => {
-        let { stepId, stepCount, stepIndex } = node.dataset;
+        let { stepId, stepCount, priority } = node.dataset;
 
         stepCount = Number(stepCount);
         if (isNaN(stepCount)) {
           stepCount = 1;
         }
-        stepIndex = Number(stepIndex);
-        if (isNaN(stepIndex)) {
-          stepIndex = index;
+        priority = Number(priority);
+        if (isNaN(priority)) {
+          priority = index;
         }
         return {
           id: stepId,
           count: stepCount,
-          index: stepIndex
+          priority
         };
       })
       .concat()
-      .sort(sortByKeyComparator('index'))
+      .sort(sortByKeyComparator('priority'))
       .reduce(
         (memo, el) => {
           const [thresholds, nextThreshold] = memo;
-          const { id, count, index } = el;
+          const { id, count } = el;
           thresholds[id] = nextThreshold;
           return [thresholds, nextThreshold + count];
         },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Deck from './components/deck';
 import Slide, { SlideContext } from './components/slide/slide';
-import Appear from './components/appear';
+import { Appear, Stepper } from './components/appear';
 import CodePane from './components/code-pane';
 import {
   OrderedList,
@@ -65,6 +65,7 @@ export {
   MarkdownSlide,
   MarkdownPreHelper,
   SpectacleLogo,
+  Stepper,
   Table,
   TableCell,
   TableRow,


### PR DESCRIPTION
### Description

This improves performance by reducing the number of components responding to DeckContext updates. This is especially important when using `Progress` components in larger presentations- the current implementation results in rendering O(n^2) little circles (where `n` is the number of slides) despite only O(n) of them being visible.

The solution here is to have `Deck` keep track of the _previous_ and _next_ slide IDs, and pass them down through `DeckContext`. `Slide` reads these values from context and only renders its contents into the `slidePortalNode` if it's the active slide, the pending slide, or the previous slide.

Fixes # 1022

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manual verification that behavior appears correct on example presentations.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated type definitions in `index.d.ts` for any breaking API changes
- [x] My code follows the style guidelines of this project (I have run `yarn format`)
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
