### PR TITLE
Fix Stepper component to apply (in)activeStyle properties properly

### DIFF
--- a/src/components/appear.js
+++ b/src/components/appear.js
@@ -104,6 +104,8 @@ export function Stepper({
       {...restProps}
       numSteps={values.length}
       alwaysAppearActive={alwaysVisible}
+      activeStyle={activeStyle}
+      inactiveStyle={inactiveStyle}
     >
       {(step, isActive) =>
         (renderFn || renderChildrenFn)(values[step], step, isActive)


### PR DESCRIPTION
### Description

Stepper is a wrapper around SteppedComponent but failed to forward these arguments. This was not an issue for the Appear component since that one doesn't explicitly name its properties but just passes all of them to SteppedComponent through `...restProps`.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

While working on a presentation of mine, I noticed the `activeStyle` property does not get taken into account. With this change, it does.
