### PR TITLE
Feature: Copy your code with one-click for live demos.

### DIFF
--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -157,9 +157,9 @@ const CodePane = React.forwardRef(
 
     return (
       <>
+        <CopyButton content={children} />
         {placeholder}
         <div ref={ref}>
-          <CopyButton content={children} />
           <SyntaxHighlighter
             customStyle={customStyle}
             language={language}

--- a/src/components/code-pane.js
+++ b/src/components/code-pane.js
@@ -5,7 +5,7 @@ import { useSteps } from '../hooks/use-steps';
 import indentNormalizer from '../utils/indent-normalizer';
 import { ThemeContext } from 'styled-components';
 import dark from 'react-syntax-highlighter/dist/cjs/styles/prism/vs-dark';
-
+import CopyButton from './copybutton';
 const checkForNumberValues = ranges => {
   return ranges.every(element => typeof element === 'number');
 };
@@ -159,6 +159,7 @@ const CodePane = React.forwardRef(
       <>
         {placeholder}
         <div ref={ref}>
+          <CopyButton content={children} />
           <SyntaxHighlighter
             customStyle={customStyle}
             language={language}

--- a/src/components/copybutton.js
+++ b/src/components/copybutton.js
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Container = styled('div')``;
+
+const ButtonWithStyle = styled('button')`
+  position: absolute;
+  right: 0;
+  transform: translate(-110%, 50%);
+  background: transparent;
+  outline: none;
+  border: none;
+  color: #f5f5f5;
+  cursor: pointer;
+`;
+
+const CopyButton = props => {
+  function copy(content) {
+    const input = document.createElement('textarea');
+    input.innerHTML = content;
+    document.body.appendChild(input);
+    input.select();
+    var result = document.execCommand('copy');
+    document.body.removeChild(input);
+    return result;
+  }
+  return (
+    <Container>
+      <ButtonWithStyle onClick={() => copy(props.content)}>
+        {props.name}
+      </ButtonWithStyle>
+    </Container>
+  );
+};
+
+CopyButton.propTypes = {
+  content: propTypes.any,
+  name: propTypes.string
+};
+
+CopyButton.defaultProps = {
+  content: 'Hi',
+  name: 'COPY'
+};
+
+export default CopyButton;


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

**Copy (Top-right) Code Button with One Simple Click**. (_Can be used with other components as well_)
People sometimes need to copy code when they are giving a live demo as well. 
I needed this...
![image](https://user-images.githubusercontent.com/25868126/133925722-4939bb1d-366f-4a0d-85ad-890c4b45d124.png)

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] I ran the `yarn test` with 100% successful results.

### Checklist: 

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project (I have run `yarn format`)
- [x] My changes generate no new warnings
