### PR TITLE
fix: highlightRanges definition supports [[0,1]] syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,7 @@ declare module 'spectacle' {
     language: string;
     theme?: Record<string, unknown>;
     stepIndex?: number;
-    highlightRanges?: number | number[];
+    highlightRanges?: number | (number | number[])[];
     showLineNumbers?: boolean;
   }>;
 


### PR DESCRIPTION
### Description

This PR fixes an issue with the Typescript definition of `highlightRanges`.

As per [Documentation](https://formidable.com/open-source/spectacle/docs/api-reference/#code-pane):

> Array values can even be mixed to include sub-arrays (for multiple lines) and numbers (for single lines), e.g.,
> `[[1, 3], 5, [6, 8], [10, 15], 20]`.

Using such a syntax with TypeScript, after this fix, is now possible.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Perform the change, see that `tsc` doesn't complain again, done.

Try with the following snippet:
```tsx
<CodePane language="js" highlightRanges={
          [1, [2, 13], [3, 6], [7, 9], [10, 12]]
}>
{`
   let hello = 'world';
`}
</CodePane>
```