### PR TITLE
Bug: Update docs link relativity

### DIFF
--- a/docs/src/screens/home/_content.js
+++ b/docs/src/screens/home/_content.js
@@ -30,7 +30,7 @@ const content = {
   getStarted: {
     description:
       'There are several flexible options for getting started with Spectacle, using either JSX or MDX syntax - dive into the documentation to see all the ways you can get a presentation up and running.',
-    link: '/docs/basic-concepts/'
+    link: 'docs/basic-concepts/'
   },
   oss: [
     {


### PR DESCRIPTION
### Description

Updates "Get Started" documentation link to be relative to page instead of relative to root.

#### Fixes
Current documentation link goes to `https://formidable.com/docs/basic-concepts/` which can fail if don't visit the base page first and even then seems to intermittently fail and show a 404 page. The link as is would also break if a user were to bookmark it. This change updates it to be `https://formidable.com/open-source/spectacle/docs/basic-concepts/`

#### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Locally confirmed link works as expected
