### PR TITLE
fix: ensure background doesn't disappear in export/overview mode with a bk image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed disappearing slides with background images in export and overveiw mode [#1100](https://github.com/FormidableLabs/spectacle/issues/1100)
+- Fixed disappearing slides with background images in export and overview mode [#1100](https://github.com/FormidableLabs/spectacle/issues/1100)
 
 ## 9.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed disappearing slides with background images in export and overveiw mode [#1100](https://github.com/FormidableLabs/spectacle/issues/1100)
+
 ## 9.0.1
 
 - Fix export mode. [#1097](https://github.com/FormidableLabs/spectacle/issues/1097)

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -348,7 +348,7 @@ const Slide = (props: SlideProps): JSX.Element => {
               onClick={handleClick}
               tabIndex={inOverviewMode && isActive ? 0 : undefined}
               style={{
-                ...springFrameStyle,
+                ...(inOverviewMode ? {} : springFrameStyle),
                 ...frameOverrideStyle,
                 ...(inOverviewMode &&
                   hover && {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Ensures slides with background images do not disappear in export and overview modes. The reason it was breaking is any animated or spring styles never get activated in those modes so we need to nullify them.

Fixes #1100 

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<img width="1327" alt="Screen Shot 2022-04-19 at 9 13 51 AM" src="https://user-images.githubusercontent.com/1738349/164035317-c34e04f5-30d5-450e-b5de-3abf208b4b07.png">
<img width="1364" alt="Screen Shot 2022-04-19 at 9 56 58 AM" src="https://user-images.githubusercontent.com/1738349/164035325-d926c4bf-056d-4c8c-9945-8eb31cbfac29.png">

