### PR TITLE
Allow for same background image in all slides #1104

### DIFF
--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -27,6 +27,8 @@ A `template` contains Layout tags (referred to as a template render function) an
 | `autoPlayLoop`     | PropTypes.bool                              | `false`            |
 | `autoPlayInterval` | PropTypes.number (milliseconds)             | `1000`             |
 | `transition`       | [**Transition**](./props#transition-object) | `slideTransition`  |
+| `backgroundImage`  | PropTypes.string                            |                    |
+
 
 ### Slide
 

--- a/src/components/deck/deck.tsx
+++ b/src/components/deck/deck.tsx
@@ -71,6 +71,7 @@ export type DeckContextType = {
   cancelTransition(): void;
   template: TemplateFn | ReactNode;
   transition: SlideTransition;
+  backgroundImage?: string;
 };
 
 export const DeckContext = createContext<DeckContextType>(null as any);
@@ -150,7 +151,8 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
       autoPlay = false,
       autoPlayLoop = false,
       autoPlayInterval = 1000,
-      transition = defaultTransition
+      transition = defaultTransition,
+      backgroundImage
     },
     ref
   ) => {
@@ -429,7 +431,8 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
               commitTransition,
               cancelTransition,
               transition,
-              template
+              template,
+              backgroundImage
             }}
           >
             <div ref={setPlaceholderContainer} style={{ display: 'none' }}>
@@ -479,6 +482,7 @@ export type DeckProps = {
   overviewScale?: number;
   transition?: SlideTransition;
   suppressBackdropFallback?: boolean;
+  backgroundImage?: string;
 };
 /**
  * These types are only used internally,
@@ -496,6 +500,7 @@ export type DeckInternalProps = DeckProps & {
   notePortalNode?: HTMLDivElement | null;
   backdropStyle?: Partial<CSSStyleDeclaration>;
   onActiveStateChange?: (activeView: DeckView) => void;
+  backgroundImage?: string;
 };
 
 export default Deck;

--- a/src/components/presenter-mode/index.tsx
+++ b/src/components/presenter-mode/index.tsx
@@ -30,7 +30,7 @@ const PreviewSlideWrapper = styled.div<{ visible?: boolean }>(
 );
 
 const PresenterMode = (props: PresenterModeProps): JSX.Element => {
-  const { children, theme } = props;
+  const { children, theme, backgroundImage } = props;
   const deck = useRef<DeckRef>(null);
   const previewDeck = useRef<DeckRef>(null);
   const [notePortalNode, setNotePortalNode] = useState<HTMLDivElement | null>();
@@ -112,6 +112,7 @@ const PresenterMode = (props: PresenterModeProps): JSX.Element => {
           onActiveStateChange={onActiveStateChange}
           ref={deck}
           theme={theme}
+          backgroundImage={backgroundImage}
         >
           {children}
         </DeckInternal>
@@ -122,6 +123,7 @@ const PresenterMode = (props: PresenterModeProps): JSX.Element => {
             backdropStyle={deckBackdropStyles.nextSlide}
             ref={previewDeck}
             theme={theme}
+            backgroundImage={backgroundImage}
           >
             {children}
           </DeckInternal>
@@ -136,4 +138,5 @@ export default PresenterMode;
 type PresenterModeProps = {
   theme?: SpectacleThemeOverrides;
   children: ReactNode;
+  backgroundImage?: string;
 };

--- a/src/components/print-mode/index.tsx
+++ b/src/components/print-mode/index.tsx
@@ -33,7 +33,8 @@ export default function PrintMode({
   theme,
   exportMode,
   pageSize,
-  pageOrientation = ''
+  pageOrientation = '',
+  backgroundImage
 }: PrintModeProps) {
   const width = theme?.size?.width || defaultTheme.size.width;
   const height = theme?.size?.height || defaultTheme.size.height;
@@ -49,6 +50,7 @@ export default function PrintMode({
         exportMode={exportMode}
         disableInteractivity
         theme={{ ...theme, Backdrop, backdropStyle: {} }}
+        backgroundImage={backgroundImage}
       >
         {children}
       </DeckInternal>
@@ -62,4 +64,5 @@ type PrintModeProps = {
   exportMode?: boolean;
   pageSize?: string;
   pageOrientation?: '' | 'landscape' | 'portrait';
+  backgroundImage?: string;
 };

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -135,7 +135,8 @@ const Slide = (props: SlideProps): JSX.Element => {
     cancelTransition,
     transition,
     template: deckTemplate,
-    slideCount
+    slideCount,
+    backgroundImage: deckBackgroundImage
   } = useContext(DeckContext);
 
   const handleClick = useCallback(
@@ -361,7 +362,7 @@ const Slide = (props: SlideProps): JSX.Element => {
               <SlideContainer
                 className={className}
                 backgroundColor={backgroundColor}
-                backgroundImage={backgroundImage}
+                backgroundImage={backgroundImage || deckBackgroundImage}
                 backgroundOpacity={backgroundOpacity}
                 backgroundPosition={backgroundPosition}
                 backgroundRepeat={backgroundRepeat}


### PR DESCRIPTION


### Description

Adds a backgroundImage prop to Deck, DeckInternal and DeckContext. In Slide component the backgroundImage from Deck will be used if none is provided.

Fixes #1104 

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested changes locally in the provided example.
