### PR TITLE
Fix: Newlines in markdown slides correctly render line breaks

### DIFF
--- a/src/components/markdown/markdown.test.tsx
+++ b/src/components/markdown/markdown.test.tsx
@@ -68,6 +68,20 @@ describe('<MarkdownSlide />', () => {
     );
     expect(wrapper.find('br')).toHaveLength(4);
   });
+
+  it('should generate line breaks for inline paragraph elements with carriage returns', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide>{`One\r\n**Two**\r\n_Three_\r\n\`Four\`\r\n~~Five~~`}</MarkdownSlide>
+    );
+    expect(wrapper.find('br')).toHaveLength(4);
+  });
+
+  it('should generate line breaks for inline paragraph elements with mixed returns', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide>{`One\n**Two**\r\n_Three_\n\`Four\`\r\n~~Five~~`}</MarkdownSlide>
+    );
+    expect(wrapper.find('br')).toHaveLength(4);
+  });
 });
 
 describe('<MarkdownSlideSet />', () => {

--- a/src/components/markdown/markdown.test.tsx
+++ b/src/components/markdown/markdown.test.tsx
@@ -55,6 +55,19 @@ describe('<MarkdownSlide />', () => {
     expect(wrapper.find('li').at(1).children().find('i')).toHaveLength(2);
     expect(wrapper.find('li').at(2).children()).toHaveLength(1);
   });
+
+  it('should generate line breaks for inline paragraph elements', () => {
+    const wrapper = mountInsideDeck(
+      <MarkdownSlide>{`
+        One
+        **Two**
+        _Three_
+        \`Four\`
+        ~~Five~~
+      `}</MarkdownSlide>
+    );
+    expect(wrapper.find('br')).toHaveLength(4);
+  });
 });
 
 describe('<MarkdownSlideSet />', () => {

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -123,7 +123,7 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
           // Replace \r\n and \n with <br /> for paragraphs
           const children =
             key === 'p'
-              ? props?.children?.map((child: any, i: number) => {
+              ? props.children?.map((child: any, i: number) => {
                   if (typeof child == 'string') {
                     const lines = child.split(/\r\n|\n/g);
                     return lines.map((str, i) => (

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -120,6 +120,7 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
         componentMap
       ).reduce((newMap, [key, Component]) => {
         newMap[key] = (props: any) => {
+          // Replace \n with <br />
           const children = props?.children?.map((child: any) => {
             if (child === '\n') return <br />;
             if (typeof child == 'string') {

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -120,13 +120,12 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
         componentMap
       ).reduce((newMap, [key, Component]) => {
         newMap[key] = (props: any) => {
-          // Replace \n with <br /> for paragraphs
+          // Replace \r\n and \n with <br /> for paragraphs
           const children =
             key === 'p'
               ? props?.children?.map((child: any, i: number) => {
-                  if (child === '\n') return <br key={i} />;
                   if (typeof child == 'string') {
-                    const lines = child.split('\n');
+                    const lines = child.split(/\r\n|\n/g);
                     return lines.map((str, i) => (
                       <React.Fragment key={i}>
                         {str}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -19,7 +19,7 @@ import indentNormalizer from '../../utils/indent-normalizer';
 import Notes from '../notes';
 import { ListItem } from '../../index';
 import { Appear } from '../appear';
-import {
+import React, {
   ElementType,
   FC,
   forwardRef,
@@ -120,17 +120,23 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
         componentMap
       ).reduce((newMap, [key, Component]) => {
         newMap[key] = (props: any) => {
-          // Replace \n with <br />
-          const children = props?.children?.map((child: any) => {
-            if (child === '\n') return <br />;
-            if (typeof child == 'string') {
-              return child.split('\n').map((str) => {
-                if (str === '') return <br />;
-                return str;
-              });
-            }
-            return child;
-          });
+          // Replace \n with <br /> for paragraphs
+          const children =
+            key === 'p'
+              ? props?.children?.map((child: any, i: number) => {
+                  if (child === '\n') return <br key={i} />;
+                  if (typeof child == 'string') {
+                    const lines = child.split('\n');
+                    return lines.map((str, i) => (
+                      <React.Fragment key={i}>
+                        {str}
+                        {i !== lines.length - 1 && <br />}
+                      </React.Fragment>
+                    ));
+                  }
+                  return child;
+                })
+              : props.children;
           return (
             <Component {...props} {...(componentProps || {})}>
               {children}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -119,9 +119,23 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
       const componentMapWithPassedThroughProps = Object.entries(
         componentMap
       ).reduce((newMap, [key, Component]) => {
-        newMap[key] = (props: any) => (
-          <Component {...props} {...(componentProps || {})} />
-        );
+        newMap[key] = (props: any) => {
+          const children = props?.children?.map((child: any) => {
+            if (child === '\n') return <br />;
+            if (typeof child == 'string') {
+              return child.split('\n').map((str) => {
+                if (str === '') return <br />;
+                return str;
+              });
+            }
+            return child;
+          });
+          return (
+            <Component {...props} {...(componentProps || {})}>
+              {children}
+            </Component>
+          );
+        };
         return newMap;
       }, {} as any);
 


### PR DESCRIPTION
### Description

Speculate was ignoring soft line returns for inline paragraph styles in slides created via markdown. Now the markdown slides accurately reflect each line break.

**Before:**
![Before (1)](https://user-images.githubusercontent.com/20046764/170104464-6cc39be5-7737-49c3-9e92-fcbeafdfd3f2.png)

**After:**
![After (1)](https://user-images.githubusercontent.com/20046764/170104484-316e0fa9-e4f7-485a-b2eb-eeb84b7ec9fa.png)

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

A unit test in `markdown.test.ts` checks that line breaks are correctly added for inline elements

