### PR TITLE
Feat: Persist deck template between slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Persist deck template between slides in default mode [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
+- Fix deck level templates not displayed in presenter, print and export modes
+- Persist deck template between slides in default and presenter modes [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
 
 ## 9.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Persist deck template between slides in default mode [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
+
 ## 9.1.1
 
 - Newlines in markdown slides correctly render line breaks [#1114](https://github.com/FormidableLabs/spectacle/pull/1114)

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -28,7 +28,6 @@
         FullScreen,
         Progress,
         Appear,
-        Stepper,
         Slide,
         Deck,
         Text,
@@ -166,7 +165,7 @@
                 <${Text}>Double-size Grid Item</${Text}>
               </${Box}>
             </${Grid}>
-            <${Grid} gridTemplateColumns="1fr 1fr 1fr" gridTemplateRows="1fr 1fr 1fr" alignItems="center" justifyContent="center" gridRowGap=${1}>
+            <${Grid} gridTemplateColumns="1fr 1fr 1fr" gridTemplateRows="1fr 1fr 1fr" gridRowGap=${1}>
               ${Array(9).fill('').map((_, index) => html`<${FlexBox} paddingTop=${0} key=${`formidable-logo-${index}`} flex=${1}>
                 <${Image} src=${formidableLogo} width=${100} />
               </${FlexBox}>`)}
@@ -225,7 +224,7 @@
               `}
           </${MarkdownSlide}>
           <${Slide}>
-            <${Grid} flex=${1} gridTemplateColumns="50% 50%" gridTemplateRows="50% 50%" height="100%">
+            <${Grid} gridTemplateColumns="50% 50%" gridTemplateRows="50% 50%" height="100%">
               <${FlexBox} alignItems="center" justifyContent="center">
                 <${Heading}>This is a 4x4 Grid</${Heading}>
               </${FlexBox}>

--- a/src/components/deck/deck.tsx
+++ b/src/components/deck/deck.tsx
@@ -390,7 +390,7 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
 
     const templateElement: ReactNode =
       typeof template === 'function'
-        ? template?.({
+        ? template({
             slideNumber: activeView.slideIndex + 1,
             numberOfSlides: slideIds.length
           })

--- a/src/components/deck/deck.tsx
+++ b/src/components/deck/deck.tsx
@@ -73,6 +73,8 @@ export type DeckContextType = {
   template: TemplateFn | ReactNode;
   transition: SlideTransition;
   backgroundImage?: string;
+  inOverviewMode: boolean;
+  inPrintMode: boolean;
 };
 
 export const DeckContext = createContext<DeckContextType>(null as any);
@@ -443,7 +445,9 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
               cancelTransition,
               transition,
               template,
-              backgroundImage
+              backgroundImage,
+              inOverviewMode: overviewMode,
+              inPrintMode: printMode
             }}
           >
             <Portal
@@ -452,19 +456,21 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
               printMode={printMode}
               fitAspectRatioStyle={fitAspectRatioStyle}
             >
-              {!doesCurrentSlideHaveItsOwnTemplate && !overviewMode && (
-                <TemplateWrapper
-                  style={{
-                    ...wrapperStyle,
-                    // Slides are appended to the parent as they are portaled in and end up later in
-                    // the source order. Adding zIndex to the template to overlay the sibling slides
-                    // once they have been portaled in.
-                    zIndex: 1
-                  }}
-                >
-                  {templateElement}
-                </TemplateWrapper>
-              )}
+              {!doesCurrentSlideHaveItsOwnTemplate &&
+                !overviewMode &&
+                !printMode && (
+                  <TemplateWrapper
+                    style={{
+                      ...wrapperStyle,
+                      // Slides are appended to the parent as they are portaled in and end up later in
+                      // the source order. Adding zIndex to the template to overlay the sibling slides
+                      // once they have been portaled in.
+                      zIndex: 1
+                    }}
+                  >
+                    {templateElement}
+                  </TemplateWrapper>
+                )}
             </Portal>
             <div ref={setPlaceholderContainer} style={{ display: 'none' }}>
               {children}

--- a/src/components/deck/deck.tsx
+++ b/src/components/deck/deck.tsx
@@ -386,7 +386,7 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
     }
 
     const doesCurrentSlideHaveItsOwnTemplate =
-      slideIdsWithTemplates.includes(activeSlideId);
+      slideIdsWithTemplates.has(activeSlideId);
 
     const templateElement: ReactNode =
       typeof template === 'function'

--- a/src/components/presenter-mode/index.tsx
+++ b/src/components/presenter-mode/index.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useState, useEffect, ReactNode } from 'react';
 import styled from 'styled-components';
-import { DeckInternal, DeckRef } from '../deck/deck';
+import { DeckInternal, DeckRef, TemplateFn } from '../deck/deck';
 import { Text, SpectacleLogo } from '../../index';
 import {
   PresenterDeckContainer,
@@ -30,7 +30,7 @@ const PreviewSlideWrapper = styled.div<{ visible?: boolean }>(
 );
 
 const PresenterMode = (props: PresenterModeProps): JSX.Element => {
-  const { children, theme, backgroundImage } = props;
+  const { children, theme, backgroundImage, template } = props;
   const deck = useRef<DeckRef>(null);
   const previewDeck = useRef<DeckRef>(null);
   const [notePortalNode, setNotePortalNode] = useState<HTMLDivElement | null>();
@@ -113,6 +113,7 @@ const PresenterMode = (props: PresenterModeProps): JSX.Element => {
           ref={deck}
           theme={theme}
           backgroundImage={backgroundImage}
+          template={template}
         >
           {children}
         </DeckInternal>
@@ -124,6 +125,7 @@ const PresenterMode = (props: PresenterModeProps): JSX.Element => {
             ref={previewDeck}
             theme={theme}
             backgroundImage={backgroundImage}
+            template={template}
           >
             {children}
           </DeckInternal>
@@ -139,4 +141,5 @@ type PresenterModeProps = {
   theme?: SpectacleThemeOverrides;
   children: ReactNode;
   backgroundImage?: string;
+  template?: TemplateFn | ReactNode;
 };

--- a/src/components/print-mode/index.tsx
+++ b/src/components/print-mode/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
-import { DeckInternal } from '../deck/deck';
+import { DeckInternal, TemplateFn } from '../deck/deck';
 import { AnimatedDiv } from '../slide/slide';
 import defaultTheme, {
   SpectacleThemeOverrides
@@ -34,7 +34,8 @@ export default function PrintMode({
   exportMode,
   pageSize,
   pageOrientation = '',
-  backgroundImage
+  backgroundImage,
+  template
 }: PrintModeProps) {
   const width = theme?.size?.width || defaultTheme.size.width;
   const height = theme?.size?.height || defaultTheme.size.height;
@@ -51,6 +52,7 @@ export default function PrintMode({
         disableInteractivity
         theme={{ ...theme, Backdrop, backdropStyle: {} }}
         backgroundImage={backgroundImage}
+        template={template}
       >
         {children}
       </DeckInternal>
@@ -65,4 +67,5 @@ type PrintModeProps = {
   pageSize?: string;
   pageOrientation?: '' | 'landscape' | 'portrait';
   backgroundImage?: string;
+  template?: TemplateFn | ReactNode;
 };

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -108,7 +108,7 @@ const Slide = (props: SlideProps): JSX.Element => {
     throw new Error(`Slide components may not be nested within each other.`);
   }
 
-  const hasTemplate = Boolean(template);
+  const hasTemplate = template !== undefined;
   const { slideId, placeholder } = useSlide(hasTemplate, userProvidedId);
   const { setStepContainer, activationThresholds, finalStepIndex } =
     useCollectSteps();
@@ -368,14 +368,9 @@ const Slide = (props: SlideProps): JSX.Element => {
                 color={textColor}
                 {...swipeHandler}
               >
-                {isActive && hasTemplate && (
+                {((isActive && hasTemplate) || inOverviewMode) && (
                   <TemplateWrapper style={wrapperOverrideStyle}>
-                    {slideTemplateElement}
-                  </TemplateWrapper>
-                )}
-                {inOverviewMode && (
-                  <TemplateWrapper style={wrapperOverrideStyle}>
-                    {deckTemplateElement}
+                    {hasTemplate ? slideTemplateElement : deckTemplateElement}
                   </TemplateWrapper>
                 )}
                 <SlideWrapper

--- a/src/components/template-wrapper.tsx
+++ b/src/components/template-wrapper.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const TemplateWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+`;
+
+export default TemplateWrapper;

--- a/src/hooks/use-slides.tsx
+++ b/src/hooks/use-slides.tsx
@@ -25,9 +25,11 @@ export function useCollectSlides() {
     const nextSlideIdsOfSlidesWithTemplates: Set<SlideId> = new Set();
     for (const placeholderNode of slides) {
       const { slideId, slideHasTemplate } = placeholderNode.dataset;
-      nextSlideIds.push(slideId!);
-      if (slideHasTemplate === 'true') {
-        nextSlideIdsOfSlidesWithTemplates.add(slideId!);
+      if (slideId !== undefined) {
+        nextSlideIds.push(slideId);
+        if (slideHasTemplate === 'true') {
+          nextSlideIdsOfSlidesWithTemplates.add(slideId);
+        }
       }
     }
     setSlideIds(nextSlideIds);

--- a/src/hooks/use-slides.tsx
+++ b/src/hooks/use-slides.tsx
@@ -12,6 +12,8 @@ export function useCollectSlides() {
   const [initialized, setInitialized] = useState(false);
   const [slideContainer, setSlideContainer] = useState<HTMLElement | null>();
   const [slideIds, setSlideIds] = useState<SlideId[]>([]);
+  const [slideIdsOfSlidesWithTemplates, setSlideIdsOfSlidesWithTemplates] =
+    useState<SlideId[]>([]);
 
   useEffect(() => {
     if (!slideContainer) return;
@@ -20,23 +22,40 @@ export function useCollectSlides() {
     ) as unknown as Iterable<HTMLElement>;
 
     const nextSlideIds: SlideId[] = [];
+    const nextSlideIdsOfSlidesWithTemplates: SlideId[] = [];
     for (const placeholderNode of slides) {
-      const { slideId } = placeholderNode.dataset;
+      const { slideId, slideHasTemplate } = placeholderNode.dataset;
       nextSlideIds.push(slideId!);
+      if (slideHasTemplate === 'true') {
+        nextSlideIdsOfSlidesWithTemplates.push(slideId!);
+      }
     }
     setSlideIds(nextSlideIds);
+    setSlideIdsOfSlidesWithTemplates(nextSlideIdsOfSlidesWithTemplates);
     setInitialized(true);
   }, [slideContainer]);
 
-  return [setSlideContainer, slideIds, initialized] as const;
+  return [
+    setSlideContainer,
+    slideIds,
+    slideIdsOfSlidesWithTemplates,
+    initialized
+  ] as const;
 }
 
-export function useSlide(userProvidedId?: SlideId) {
+export function useSlide(
+  doesSlideHaveTemplate: boolean,
+  userProvidedId?: SlideId
+) {
   const [slideId] = useState<SlideId>(userProvidedId || ulid);
   return {
     slideId,
     placeholder: (
-      <div className={PLACEHOLDER_CLASS_NAME} data-slide-id={slideId} />
+      <div
+        className={PLACEHOLDER_CLASS_NAME}
+        data-slide-id={slideId}
+        data-slide-has-template={doesSlideHaveTemplate}
+      />
     )
   };
 }

--- a/src/hooks/use-slides.tsx
+++ b/src/hooks/use-slides.tsx
@@ -13,7 +13,7 @@ export function useCollectSlides() {
   const [slideContainer, setSlideContainer] = useState<HTMLElement | null>();
   const [slideIds, setSlideIds] = useState<SlideId[]>([]);
   const [slideIdsOfSlidesWithTemplates, setSlideIdsOfSlidesWithTemplates] =
-    useState<SlideId[]>([]);
+    useState<Set<SlideId>>(new Set());
 
   useEffect(() => {
     if (!slideContainer) return;
@@ -22,12 +22,12 @@ export function useCollectSlides() {
     ) as unknown as Iterable<HTMLElement>;
 
     const nextSlideIds: SlideId[] = [];
-    const nextSlideIdsOfSlidesWithTemplates: SlideId[] = [];
+    const nextSlideIdsOfSlidesWithTemplates: Set<SlideId> = new Set();
     for (const placeholderNode of slides) {
       const { slideId, slideHasTemplate } = placeholderNode.dataset;
       nextSlideIds.push(slideId!);
       if (slideHasTemplate === 'true') {
-        nextSlideIdsOfSlidesWithTemplates.push(slideId!);
+        nextSlideIdsOfSlidesWithTemplates.add(slideId!);
       }
     }
     setSlideIds(nextSlideIds);


### PR DESCRIPTION
### Description

- Moved the deck-wide template up to deck level in default mode so that it persists between slides.
- Fixed deck level templates not being displayed in presenter, print and export modes.

Completes #1106 and paves the way for #1105.

To persist deck-wide templates between slides, I needed to move the rendering of the deck template up to deck level. If the slide has a slide-specific template however, we should not render the deck template, but render the slide template instead. For this, I needed to know whether the active slide had a slide-specific template at deck level. I added a `data-slide-has-template` attribute to the slides placeholder and extended the existing `useCollectSlides` hook, which we use to to surface slide ids to the deck, to also contain information about which slides have slide-specific templates. With the list of slides ids that have their own templates to hand, we can decide whether or not to show the deck template at deck level.

#### In default and presenter modes:
- If there is no slide specific template, the deck template will render at deck level and persist between slides.
- If there is a slide specific template, the deck template will not be diplayed and the slide template will be rendered at slide level.

Demo (with a transparent deck level template and blue slide template on the third slide):

https://user-images.githubusercontent.com/8139746/171488523-0b45687a-f2f0-41ce-8b0a-a0b2f31e6fd1.mov

#### In overview and print / export modes:
- For slides without a slide template, the deck template will be rendered at slide level.
- For slides with a slide template, the slide specific template will be rendered at slide level.

<img width="1113" alt="Screenshot 2022-06-01 at 17 08 19" src="https://user-images.githubusercontent.com/8139746/171450102-1eabaa40-58de-496f-a884-85739abf1229.png">

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

No new functionality to add to docs - perhaps I should have categorised this one as a chore instead of a feature.