### PR TITLE
Fix error on start up in SSR environment

### DIFF
--- a/src/hooks/use-broadcast-channel.ts
+++ b/src/hooks/use-broadcast-channel.ts
@@ -4,7 +4,9 @@ import { BroadcastChannel as BroadcastChannelPolyfill } from 'broadcast-channel'
 import { DeckView } from './use-deck-state';
 
 const noop = () => {};
-const BroadcastChannel = window.BroadcastChannel || BroadcastChannelPolyfill;
+const BroadcastChannel =
+  (typeof window !== 'undefined' ? window.BroadcastChannel : undefined) ||
+  BroadcastChannelPolyfill;
 
 type MessageCallback = (message: MessageTypes) => void;
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Current code crashes when loaded in an environment without window global - eg. in node. It crashes even without actually rendering the code, so standard workaround of delaying render until client-side hydratation is not sufficient. This PR fixes that. To be clear: it does not enable SSR and instead only enables usage in codebase which uses SSR.

Related issue is #868 but this PR does not fix it, only allows user to work around it without patching the package.

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I ran `yarn check-ci`. Also this is based on a patch that I apply to my local spectacle installation.

### Checklist

- [ ] I did not add tests that prove my fix is effective or that my feature works, given that it is a one line change. Should I?
