### PR TITLE
Add AnimatedProgress component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 - Fix deck level templates not displayed in presenter, print and export modes
 - Persist deck template between slides in default and presenter modes [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
-- Update to react 18
-- Replace enzyme tests with react-testing-library tests
-- Add AnimatedProgress component
+- Upgrade dependencies to be React 18-friendly, removing Enzyme in favor of RTL via [#1119](https://github.com/FormidableLabs/spectacle/pull/1119)
+- Add AnimatedProgress component [#1105](https://github.com/FormidableLabs/spectacle/issues/1105)
 
 ## 9.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix deck level templates not displayed in presenter, print and export modes
 - Persist deck template between slides in default and presenter modes [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
+- Update to react 18
+- Replace enzyme tests with react-testing-library tests
+- Add AnimatedProgress component
 
 ## 9.1.1
 

--- a/docs/content/api-reference.md
+++ b/docs/content/api-reference.md
@@ -342,10 +342,21 @@ Notes is a component that only renders in Presenter mode as presenter notes. It 
 
 ## Progress
 
-Progress is a component with no children that just shows dots for each slide in your deck. Visited and current slides are represented by a filled circle and future slides with just a stroke. The size and color are customizable.
+Progress is a component with no children that just shows dots for each slide in your deck. The current slide is represented by a filled circle. Visited and future slides are represented by a transparent, outlined circle. The size and color are customizable.
 
 | Props                              | Type             | Example   |
 | ---------------------------------- | ---------------- | --------- |
 | `size`                             | PropTypes.number | `23`      |
 | `color`                            | PropTypes.string | `#abc123` |
+| [**`Position`**](./props#position) |                  |           |
+
+## AnimatedProgress
+
+AnimatedProgress is similar to the Progress component, with an additional Pacman character that moves when the current slide changes. It looks like the Pacman is eating all of the circles that represent slides up to, and including, the new current slide. The size and color of the circles are customizable, as is the color of the Pacman.
+
+| Props                              | Type             | Example   |
+| ---------------------------------- | ---------------- | --------- |
+| `size`                             | PropTypes.number | `23`      |
+| `color`                            | PropTypes.string | `#abc123` |
+| `pacmanColor`                      | PropTypes.string | `#abc123` |
 | [**`Position`**](./props#position) |                  |           |

--- a/docs/content/props.md
+++ b/docs/content/props.md
@@ -141,7 +141,7 @@ const transition = {
 
 ## Position
 
-**Position** props are used by [`Box`](./api-reference#box), [`FlexBox`](./api-reference#flex-box), [`Grid`](./api-reference#grid), [`CodePane`](./api-reference#code-pane), [`FullScreen`](./api-reference#fullscreen), [`Progress`](./api-reference#progress), and [`Markdown`](./api-reference#markdown-components).
+**Position** props are used by [`Box`](./api-reference#box), [`FlexBox`](./api-reference#flex-box), [`Grid`](./api-reference#grid), [`CodePane`](./api-reference#code-pane), [`FullScreen`](./api-reference#fullscreen), [`Progress`](./api-reference#progress), [`AnimatedProgress`](./api-reference#animated-progress), and [`Markdown`](./api-reference#markdown-components).
 
 | Name       | PropType         | Description              | Example    |
 | ---------- | ---------------- | ------------------------ | ---------- |

--- a/docs/content/props.md
+++ b/docs/content/props.md
@@ -141,7 +141,7 @@ const transition = {
 
 ## Position
 
-**Position** props are used by [`Box`](./api-reference#box), [`FlexBox`](./api-reference#flex-box), [`Grid`](./api-reference#grid), [`CodePane`](./api-reference#code-pane), [`FullScreen`](./api-reference#fullscreen), [`Progress`](./api-reference#progress), [`AnimatedProgress`](./api-reference#animated-progress), and [`Markdown`](./api-reference#markdown-components).
+**Position** props are used by [`Box`](./api-reference#box), [`FlexBox`](./api-reference#flex-box), [`Grid`](./api-reference#grid), [`CodePane`](./api-reference#code-pane), [`FullScreen`](./api-reference#fullscreen), [`Progress`](./api-reference#progress), [`AnimatedProgress`](./api-reference#animatedprogress), and [`Markdown`](./api-reference#markdown-components).
 
 | Name       | PropType         | Description              | Example    |
 | ---------- | ---------------- | ------------------------ | ---------- |

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -8,7 +8,7 @@ import {
   OrderedList,
   ListItem,
   FullScreen,
-  Progress,
+  AnimatedProgress,
   Appear,
   Slide,
   Deck,
@@ -47,7 +47,7 @@ const template = () => (
       <FullScreen />
     </Box>
     <Box padding="1em">
-      <Progress />
+      <AnimatedProgress />
     </Box>
   </FlexBox>
 );

--- a/examples/md/index.js
+++ b/examples/md/index.js
@@ -6,7 +6,7 @@ import {
   Deck,
   FlexBox,
   FullScreen,
-  Progress,
+  AnimatedProgress,
   MarkdownSlideSet
 } from 'spectacle';
 
@@ -30,7 +30,7 @@ const template = () => (
       <FullScreen />
     </Box>
     <Box padding="1em">
-      <Progress />
+      <AnimatedProgress />
     </Box>
   </FlexBox>
 );

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -26,7 +26,7 @@
         OrderedList,
         ListItem,
         FullScreen,
-        Progress,
+        AnimatedProgress,
         Appear,
         Slide,
         Deck,
@@ -60,7 +60,7 @@
             <${FullScreen} />
           </${Box}>
           <${Box} padding="1em">
-            <${Progress} />
+            <${AnimatedProgress} />
           </${Box}>
         </${FlexBox}>
       `;

--- a/examples/typescript/index.tsx
+++ b/examples/typescript/index.tsx
@@ -8,7 +8,7 @@ import {
   OrderedList,
   ListItem,
   FullScreen,
-  Progress,
+  AnimatedProgress,
   Appear,
   Slide,
   Deck,
@@ -47,7 +47,7 @@ const template = () => (
       <FullScreen />
     </Box>
     <Box padding="1em">
-      <Progress />
+      <AnimatedProgress />
     </Box>
   </FlexBox>
 );

--- a/src/components/animated-progress.test.tsx
+++ b/src/components/animated-progress.test.tsx
@@ -1,0 +1,51 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { DeckContext, DeckContextType } from './deck/deck';
+import defaultTheme from '../theme/default-theme';
+import AnimatedProgress from './animated-progress';
+import { DeepPartial } from '../types/deep-partial';
+import { render } from '@testing-library/react';
+
+const mountWithContext = (
+  tree: ReactElement,
+  context: DeepPartial<DeckContextType>
+) => {
+  const WrappingThemeProvider = (props: PropsWithChildren<{}>) => (
+    <DeckContext.Provider
+      value={{
+        ...(context as DeckContextType),
+        skipTo: jest.fn()
+      }}
+    >
+      <ThemeProvider theme={defaultTheme}>{props.children}</ThemeProvider>
+    </DeckContext.Provider>
+  );
+  return render(tree, { wrapper: WrappingThemeProvider });
+};
+
+describe('<AnimatedProgress />', () => {
+  it('should render the right amount of circles', () => {
+    const { queryAllByTestId } = mountWithContext(<AnimatedProgress />, {
+      slideCount: 5,
+      activeView: {
+        slideIndex: 0
+      }
+    });
+
+    expect(queryAllByTestId('animated-progress-circle')).toHaveLength(5);
+  });
+
+  it('should render the right amount of circles with the current circle in the active state', () => {
+    const { queryAllByTestId } = mountWithContext(<AnimatedProgress />, {
+      slideCount: 5,
+      activeView: {
+        slideIndex: 4
+      }
+    });
+
+    expect(queryAllByTestId('animated-progress-circle')[4]).toHaveStyle({
+      background: '#fff'
+    });
+  });
+});

--- a/src/components/animated-progress.test.tsx
+++ b/src/components/animated-progress.test.tsx
@@ -35,17 +35,4 @@ describe('<AnimatedProgress />', () => {
 
     expect(queryAllByTestId('animated-progress-circle')).toHaveLength(5);
   });
-
-  it('should render the right amount of circles with the current circle in the active state', () => {
-    const { queryAllByTestId } = mountWithContext(<AnimatedProgress />, {
-      slideCount: 5,
-      activeView: {
-        slideIndex: 4
-      }
-    });
-
-    expect(queryAllByTestId('animated-progress-circle')[4]).toHaveStyle({
-      background: '#fff'
-    });
-  });
 });

--- a/src/components/animated-progress.tsx
+++ b/src/components/animated-progress.tsx
@@ -1,0 +1,186 @@
+import {
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback
+} from 'react';
+import styled, { keyframes, css } from 'styled-components';
+import { DeckContext } from './deck/deck';
+import {
+  ProgressContainer,
+  Circle,
+  PROGRESS_CIRCLE_BORDER_WIDTH
+} from './progress';
+
+interface PacmanBaseProps {
+  pacmanSize: number;
+  top: number;
+  left: number;
+}
+export const PacmanBase = styled.div<PacmanBaseProps>`
+  position: absolute;
+  top: ${({ top }) => top}px;
+  left: ${({ left }) => left}px;
+  height: ${({ pacmanSize }) => pacmanSize}px;
+  width: ${({ pacmanSize }) => pacmanSize}px;
+  transition: left 0.3s ease-in-out 0.2s;
+  transform: translate(-50%, -50%);
+`;
+
+const pacmanTopFrames = keyframes`
+  0% { transform: rotateZ(0deg) }
+  100% { transform: rotateZ(-30deg) }
+`;
+const pacmanBottomFrames = keyframes`
+  0% { transform: rotateZ(0deg) }
+  100% { transform: rotateZ(30deg) }
+`;
+// NOTE: rotateZ is 0.1 to generate two different animation names (styled components deduplication)
+const pacmanTopFramesAlternate = keyframes`
+  0% { transform: rotateZ(0.1deg) }
+  100% { transform: rotateZ(-30deg) }
+`;
+// NOTE: rotateZ is 0.1 to generate two different animation names (styled components deduplication)
+const pacmanBottomFramesAlternate = keyframes`
+  0% { transform: rotateZ(0.1deg) }
+  100% { transform: rotateZ(30deg) }
+`;
+interface PacmanBodyProps {
+  color: string;
+  pacmanSize: number;
+  alternate: boolean;
+}
+const PacmanBodyTop = styled.div<PacmanBodyProps>`
+  position: absolute;
+  top: 0;
+  height: ${({ pacmanSize }) => pacmanSize / 2}px;
+  width: ${({ pacmanSize }) => pacmanSize}px;
+  background: ${({ color }) => color};
+  border-top-left-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
+  border-top-right-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
+  // NOTE: So the top and bottom always overlap when sizes are in decimals.
+  box-shadow: 0 0 0 0.1px ${({ color }) => color};
+  animation-name: ${({ alternate }) =>
+    alternate ? pacmanTopFrames : pacmanTopFramesAlternate};
+  animation-duration: 0.12s;
+  animation-timing-function: linear;
+  animation-iteration-count: 10;
+  animation-direction: alternate;
+  animation-fill-mode: both;
+`;
+const PacmanBodyBottom = styled(PacmanBodyTop)`
+  top: 50%;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
+  border-bottom-right-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
+  animation-name: ${({ alternate }) =>
+    alternate ? pacmanBottomFrames : pacmanBottomFramesAlternate};
+`;
+
+export type AnimatedProgressProps = {
+  color?: string;
+  size?: number;
+  pacmanColor?: string;
+};
+
+const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
+  ({ color: circleColor = '#fff', size: circleSize = 7.5, ...props }, ref) => {
+    const {
+      slideCount,
+      skipTo,
+      activeView: { slideIndex }
+    } = useContext(DeckContext);
+
+    const [pacmanOffsetLeft, setPacmanOffsetLeft] = useState<number | null>(
+      null
+    );
+    const [pacmanOffsetTop, setPacmanOffsetTop] = useState<number | null>(null);
+    const [alternateAnimation, setAlternateAnimation] = useState(false);
+
+    const [activeCircleNode, setActiveCircleNode] =
+      useState<HTMLDivElement | null>(null);
+    const activeCircleCallbackRef = useCallback(
+      (activeCircleNode: HTMLDivElement) => {
+        setActiveCircleNode(activeCircleNode);
+      },
+      []
+    );
+
+    useEffect(() => {
+      if (activeCircleNode?.offsetParent) {
+        const { offsetLeft, offsetTop } = activeCircleNode;
+        const halfOfCircleOccupiedSpace =
+          circleSize / 2 + PROGRESS_CIRCLE_BORDER_WIDTH;
+        setPacmanOffsetLeft(offsetLeft + halfOfCircleOccupiedSpace);
+        setPacmanOffsetTop(offsetTop + halfOfCircleOccupiedSpace);
+        setAlternateAnimation(!alternateAnimation);
+      } else {
+        setPacmanOffsetLeft(null);
+        setPacmanOffsetTop(null);
+      }
+    }, [circleSize, activeCircleNode]);
+
+    const circleMargin = circleSize / 1.64;
+    const pacmanColor = props.pacmanColor || circleColor;
+    const pacmanSize =
+      circleSize + PROGRESS_CIRCLE_BORDER_WIDTH + circleMargin * 2;
+
+    return (
+      <ProgressContainer
+        ref={ref}
+        className="spectacle-animated-progress-indicator"
+        position="relative"
+        {...props}
+      >
+        {typeof pacmanOffsetTop === 'number' &&
+          typeof pacmanOffsetLeft === 'number' && (
+            <PacmanBase
+              pacmanSize={pacmanSize}
+              top={pacmanOffsetTop}
+              left={pacmanOffsetLeft}
+            >
+              <PacmanBodyTop
+                color={pacmanColor}
+                pacmanSize={pacmanSize}
+                alternate={alternateAnimation}
+              />
+              <PacmanBodyBottom
+                color={pacmanColor}
+                pacmanSize={pacmanSize}
+                alternate={alternateAnimation}
+              />
+            </PacmanBase>
+          )}
+        {Array(slideCount)
+          .fill(0)
+          .map((_, idx) => {
+            const isActive = slideIndex === idx;
+            return (
+              <Circle
+                key={idx}
+                ref={isActive ? activeCircleCallbackRef : null}
+                color={circleColor}
+                active={isActive}
+                size={circleSize}
+                margin={circleMargin}
+                onClick={() =>
+                  skipTo({
+                    slideIndex: idx,
+                    stepIndex: 0
+                  })
+                }
+                data-testid="animated-progress-circle"
+              />
+            );
+          })}
+      </ProgressContainer>
+    );
+  }
+);
+
+AnimatedProgress.displayName = 'AnimatedProgress';
+
+export default AnimatedProgress;

--- a/src/components/animated-progress.tsx
+++ b/src/components/animated-progress.tsx
@@ -129,12 +129,7 @@ const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
       circleSize + PROGRESS_CIRCLE_BORDER_WIDTH + circleMargin * 2;
 
     return (
-      <ProgressContainer
-        ref={ref}
-        className="spectacle-animated-progress-indicator"
-        position="relative"
-        {...props}
-      >
+      <ProgressContainer ref={ref} position="relative" {...props}>
         {typeof pacmanOffsetTop === 'number' &&
           typeof pacmanOffsetLeft === 'number' && (
             <PacmanBase

--- a/src/components/animated-progress.tsx
+++ b/src/components/animated-progress.tsx
@@ -11,7 +11,8 @@ import { DeckContext } from './deck/deck';
 import {
   ProgressContainer,
   Circle,
-  PROGRESS_CIRCLE_BORDER_WIDTH
+  PROGRESS_CIRCLE_BORDER_WIDTH,
+  DEFAULT_PROGRESS_CIRCLE_WIDTH_INCLUDING_MARGIN
 } from './progress';
 
 interface PacmanBaseProps {
@@ -80,6 +81,8 @@ const PacmanBodyBottom = styled(PacmanBodyTop)`
     alternate ? pacmanBottomFrames : pacmanBottomFramesAlternate};
 `;
 
+const DEFAULT_ANIMATED_PROGRESS_CIRCLE_SIZE = 7.5;
+
 export type AnimatedProgressProps = {
   color?: string;
   size?: number;
@@ -87,7 +90,14 @@ export type AnimatedProgressProps = {
 };
 
 const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
-  ({ color: circleColor = '#fff', size: circleSize = 7.5, ...props }, ref) => {
+  (
+    {
+      color: circleColor = '#fff',
+      size: circleSize = DEFAULT_ANIMATED_PROGRESS_CIRCLE_SIZE,
+      ...props
+    },
+    ref
+  ) => {
     const {
       slideCount,
       skipTo,
@@ -123,7 +133,11 @@ const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
       }
     }, [circleSize, activeCircleNode]);
 
-    const circleMargin = circleSize / 1.64;
+    const circleMargin =
+      (DEFAULT_PROGRESS_CIRCLE_WIDTH_INCLUDING_MARGIN -
+        DEFAULT_ANIMATED_PROGRESS_CIRCLE_SIZE -
+        PROGRESS_CIRCLE_BORDER_WIDTH * 2) /
+      2;
     const pacmanColor = props.pacmanColor || circleColor;
     const pacmanSize =
       circleSize + PROGRESS_CIRCLE_BORDER_WIDTH + circleMargin * 2;
@@ -151,26 +165,23 @@ const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
           )}
         {Array(slideCount)
           .fill(0)
-          .map((_, idx) => {
-            const isActive = slideIndex === idx;
-            return (
-              <Circle
-                key={idx}
-                ref={isActive ? activeCircleCallbackRef : null}
-                color={circleColor}
-                active={isActive}
-                size={circleSize}
-                margin={circleMargin}
-                onClick={() =>
-                  skipTo({
-                    slideIndex: idx,
-                    stepIndex: 0
-                  })
-                }
-                data-testid="animated-progress-circle"
-              />
-            );
-          })}
+          .map((_, idx) => (
+            <Circle
+              key={idx}
+              ref={slideIndex === idx ? activeCircleCallbackRef : null}
+              color={circleColor}
+              active={false}
+              size={circleSize}
+              margin={circleMargin}
+              onClick={() =>
+                skipTo({
+                  slideIndex: idx,
+                  stepIndex: 0
+                })
+              }
+              data-testid="animated-progress-circle"
+            />
+          ))}
       </ProgressContainer>
     );
   }

--- a/src/components/animated-progress.tsx
+++ b/src/components/animated-progress.tsx
@@ -116,7 +116,7 @@ const AnimatedProgress = forwardRef<HTMLDivElement, AnimatedProgressProps>(
           circleSize / 2 + PROGRESS_CIRCLE_BORDER_WIDTH;
         setPacmanOffsetLeft(offsetLeft + halfOfCircleOccupiedSpace);
         setPacmanOffsetTop(offsetTop + halfOfCircleOccupiedSpace);
-        setAlternateAnimation(!alternateAnimation);
+        setAlternateAnimation((alternateAnimation) => !alternateAnimation);
       } else {
         setPacmanOffsetLeft(null);
         setPacmanOffsetTop(null);

--- a/src/components/progress.tsx
+++ b/src/components/progress.tsx
@@ -3,7 +3,13 @@ import styled from 'styled-components';
 import { DeckContext } from './deck/deck';
 import { position, PositionProps } from 'styled-system';
 
+const DEFAULT_PROGRESS_CIRCLE_SIZE = 10;
 export const PROGRESS_CIRCLE_BORDER_WIDTH = 1;
+const DEFAULT_PROGRESS_CIRCLE_MARGIN = DEFAULT_PROGRESS_CIRCLE_SIZE / 3;
+export const DEFAULT_PROGRESS_CIRCLE_WIDTH_INCLUDING_MARGIN =
+  DEFAULT_PROGRESS_CIRCLE_SIZE +
+  (PROGRESS_CIRCLE_BORDER_WIDTH + DEFAULT_PROGRESS_CIRCLE_MARGIN) * 2;
+
 export type CircleProps = {
   size: number;
   margin: number;
@@ -36,7 +42,7 @@ export type ProgressProps = {
 };
 
 const Progress = forwardRef<HTMLDivElement, ProgressProps>(
-  ({ color = '#fff', size = 10, ...props }, ref) => {
+  ({ color = '#fff', size = DEFAULT_PROGRESS_CIRCLE_SIZE, ...props }, ref) => {
     const { slideCount, skipTo, activeView } = useContext(DeckContext);
     return (
       <ProgressContainer
@@ -52,7 +58,7 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
               color={color}
               active={activeView.slideIndex === idx}
               size={size}
-              margin={size / 3}
+              margin={DEFAULT_PROGRESS_CIRCLE_MARGIN}
               onClick={() =>
                 skipTo({
                   slideIndex: idx,

--- a/src/components/progress.tsx
+++ b/src/components/progress.tsx
@@ -5,10 +5,10 @@ import { position, PositionProps } from 'styled-system';
 
 const DEFAULT_PROGRESS_CIRCLE_SIZE = 10;
 export const PROGRESS_CIRCLE_BORDER_WIDTH = 1;
-const DEFAULT_PROGRESS_CIRCLE_MARGIN = DEFAULT_PROGRESS_CIRCLE_SIZE / 3;
+const PROGRESS_CIRCLE_MARGIN = DEFAULT_PROGRESS_CIRCLE_SIZE / 3;
 export const DEFAULT_PROGRESS_CIRCLE_WIDTH_INCLUDING_MARGIN =
   DEFAULT_PROGRESS_CIRCLE_SIZE +
-  (PROGRESS_CIRCLE_BORDER_WIDTH + DEFAULT_PROGRESS_CIRCLE_MARGIN) * 2;
+  (PROGRESS_CIRCLE_BORDER_WIDTH + PROGRESS_CIRCLE_MARGIN) * 2;
 
 export type CircleProps = {
   size: number;
@@ -58,7 +58,7 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
               color={color}
               active={activeView.slideIndex === idx}
               size={size}
-              margin={DEFAULT_PROGRESS_CIRCLE_MARGIN}
+              margin={PROGRESS_CIRCLE_MARGIN}
               onClick={() =>
                 skipTo({
                   slideIndex: idx,

--- a/src/components/progress.tsx
+++ b/src/components/progress.tsx
@@ -1,23 +1,30 @@
 import { forwardRef, useContext } from 'react';
 import styled from 'styled-components';
 import { DeckContext } from './deck/deck';
-import { position } from 'styled-system';
+import { position, PositionProps } from 'styled-system';
 
-export type CircleProps = { size: number; color: string; active: boolean };
+export const PROGRESS_CIRCLE_BORDER_WIDTH = 1;
+export type CircleProps = {
+  size: number;
+  margin: number;
+  color: string;
+  active: boolean;
+};
 export const Circle = styled.div<CircleProps>`
   width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;
-  display: inline-block;
-  border: 1px solid ${({ color }) => color};
+  border: ${PROGRESS_CIRCLE_BORDER_WIDTH}px solid ${({ color }) => color};
   background: ${({ color, active }) => (active ? color : 'transparent')};
-  margin: ${({ size }) => size / 3}px;
+  margin: ${({ margin }) => margin}px;
   border-radius: 50%;
   pointer-events: all;
   cursor: pointer;
 `;
 
-const Container = styled.div`
+export const ProgressContainer = styled.div<PositionProps>`
   ${position}
+  display: flex;
+  flex-wrap: wrap;
   @media print {
     display: none;
   }
@@ -32,7 +39,11 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
   ({ color = '#fff', size = 10, ...props }, ref) => {
     const { slideCount, skipTo, activeView } = useContext(DeckContext);
     return (
-      <Container ref={ref} className="spectacle-progress-indicator" {...props}>
+      <ProgressContainer
+        ref={ref}
+        className="spectacle-progress-indicator"
+        {...props}
+      >
         {Array(slideCount)
           .fill(0)
           .map((_, idx) => (
@@ -41,6 +52,7 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
               color={color}
               active={activeView.slideIndex === idx}
               size={size}
+              margin={size / 3}
               onClick={() =>
                 skipTo({
                   slideIndex: idx,
@@ -50,7 +62,7 @@ const Progress = forwardRef<HTMLDivElement, ProgressProps>(
               data-testid="Progress Circle"
             />
           ))}
-      </Container>
+      </ProgressContainer>
     );
   }
 );

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -342,6 +342,12 @@ const Slide = (props: SlideProps): JSX.Element => {
               style={{
                 ...(inOverviewMode || inPrintMode ? {} : springFrameStyle),
                 ...frameOverrideStyle,
+                // NOTE: React-spring will update the display value at some point in the near
+                // future rather than immediately at the time of render. In the AnimatedProgress
+                // component, we need to make DOM calculations when a new slide becomes active
+                // but are not able to if the active slide is not visible at the time of render.
+                // We toggle the display immediately once a slide becomes active to avoid the delay.
+                ...(isActive && { display: 'unset' }),
                 ...(inOverviewMode &&
                   hover && {
                     outline: '2px solid white'

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -341,13 +341,13 @@ const Slide = (props: SlideProps): JSX.Element => {
               tabIndex={inOverviewMode && isActive ? 0 : undefined}
               style={{
                 ...(inOverviewMode || inPrintMode ? {} : springFrameStyle),
-                ...frameOverrideStyle,
                 // NOTE: React-spring will update the display value at some point in the near
                 // future rather than immediately at the time of render. In the AnimatedProgress
                 // component, we need to make DOM calculations when a new slide becomes active
                 // but are not able to if the active slide is not visible at the time of render.
                 // We toggle the display immediately once a slide becomes active to avoid the delay.
                 ...(isActive && { display: 'unset' }),
+                ...frameOverrideStyle,
                 ...(inOverviewMode &&
                   hover && {
                     outline: '2px solid white'

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export { Image, FullSizeImage } from './components/image';
 export { default as Notes } from './components/notes';
 export { default as Progress } from './components/progress';
 export type { ProgressProps } from './components/progress';
+export { default as AnimatedProgress } from './components/animated-progress';
+export type { AnimatedProgressProps } from './components/animated-progress';
 export { default as FullScreen } from './components/fullscreen';
 export {
   Markdown,


### PR DESCRIPTION
### Description

- Added an `<AnimatedProgress />` component

https://user-images.githubusercontent.com/8139746/172902189-2c763576-7a96-4353-aa59-4ac517f2bd7a.mov

Has `color`, `size` and `pacmanColor` props. I didn't want to make assumptions so Pacman defaults to the `color` prop if not defined, but with `<Pacman pacmanColor="yellow" />` we can easily achieve:

https://user-images.githubusercontent.com/8139746/172902617-31f04464-2934-4b80-9a52-d70fc6e56b52.mov

The size of the circles is `7.5px` by default with a larger margin (to make space for the Pacman) vs `10px` for circles in the `Progress` component. This means the two can be swapped out easily at default sizing. One above the other for comparison:

<img width="1796" alt="compare" src="https://user-images.githubusercontent.com/8139746/172903237-da802bc7-a953-4223-9fda-0ce7667c47f1.png">

Also gracefully support presentations with a lot of slides that causes the circles to wrap:

https://user-images.githubusercontent.com/8139746/172903881-fd7f8ccc-800f-4c88-9183-aee2def760f7.mov

The way it works is by measuring where the active slides circle is in the DOM, relative to the it's internal container, then re-positions the Pacman over the top of it.

Completes #1105 and means we can close #979 and #926

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Have tested across all modes manually. Have also copied existing and equally applicable Progress component tests, that cover the number of circles and the correct circle appearing as active, but testing the existence and the position of the Pacman is going to be difficult since it relies on real DOM measurements that aren't possible in JSDOM.