### PR TITLE
fix: only the first page showing in export and print modes in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix deck level templates not displayed in presenter, print and export modes
 - Persist deck template between slides in default and presenter modes [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
+- Update to react 18
+- Replace enzyme tests with react-testing-library tests
+- Fix only the first page showing in print and export modes in Firefox
 
 ## 9.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 - Fix deck level templates not displayed in presenter, print and export modes
 - Persist deck template between slides in default and presenter modes [#1106](https://github.com/FormidableLabs/spectacle/issues/1106)
-- Update to react 18
-- Replace enzyme tests with react-testing-library tests
-- Fix only the first page showing in print and export modes in Firefox
+- Upgrade dependencies to be React 18-friendly, removing Enzyme in favor of RTL via [#1119](https://github.com/FormidableLabs/spectacle/pull/1119)
+- Fix only the first page showing in print and export modes in Firefox [#1077](https://github.com/FormidableLabs/spectacle/issues/1077)
 
 ## 9.1.1
 

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -47,7 +47,7 @@ const SlideContainer = styled.div<SlideContainerProps>`
   ${color};
   width: 100%;
   height: 100%;
-  position: absolute;
+  position: relative;
   overflow: hidden;
   display: flex;
   z-index: 0;


### PR DESCRIPTION
### Description

Before, only the first slide was displaying when performing the print / export to pdf actions in print and export modes in Firefox. After this change, all of the slides should display.

Fixes #1077 

Before:

https://user-images.githubusercontent.com/8139746/173054235-20e4f158-f674-4467-8e8a-1acbdb91006c.mov

And after:

https://user-images.githubusercontent.com/8139746/173054251-b2948960-3184-422d-a6d2-75763b78ab24.mov

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested before and after in Firefox and across all the modes in Chrome to make sure the change is O.K.