### PR TITLE
chore: remove broken size badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 <a href="https://npmjs.com/package/spectacle"><img src="https://img.shields.io/npm/dm/spectacle.svg"></a>
 <a href="https://npmjs.com/package/spectacle"><img src="https://img.shields.io/npm/v/spectacle.svg"></a>
 <img src="http://img.badgesize.io/https://unpkg.com/spectacle/dist/spectacle.min.js?compression=gzip&label=gzip%20size">
-<img src="http://img.badgesize.io/https://unpkg.com/spectacle/dist/spectacle.min.js?label=size">
 <a href="https://github.com/FormidableLabs/spectacle#maintenance-status">
   <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg" />
 </a>


### PR DESCRIPTION
### Description

In the `README.md` the un-compressed size badge appears with a 'critical error' instead of the size.

<img width="743" alt="Screenshot 2022-06-10 at 12 27 11" src="https://user-images.githubusercontent.com/8139746/173055698-821db024-8d8f-491b-afde-da453b176fe2.png">

It appears that providing an absolute URL to the `badge-size` service is currently broken for getting the non gzipped size while gzipped sizes still work. There is an an outstanding in the `badge-size` project: https://github.com/ngryman/badge-size/issues/94 but it has been open for a little while now.

I noticed other repos of ours only display the gzipped size. Removing the un-compressed size from  the `README.md` so the 'critical error' doesn't unnecessarily worry anyone.