### PR TITLE
chore: change react-dom to a global import in the js example to fix one page example

### DIFF
--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -21,7 +21,7 @@ import {
   MarkdownSlideSet,
   Notes
 } from 'spectacle';
-import { createRoot } from 'react-dom/client';
+import ReactDOM from 'react-dom';
 
 const formidableLogo =
   'https://avatars2.githubusercontent.com/u/5078602?s=280&v=4';
@@ -264,5 +264,5 @@ const Presentation = () => (
   </Deck>
 );
 
-const root = createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<Presentation />);

--- a/examples/one-page.html
+++ b/examples/one-page.html
@@ -253,7 +253,8 @@
         </${Deck}>
       `;
 
-      ReactDOM.render(html`<${Presentation}/>`, document.getElementById('root'));
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(html`<${Presentation}/>`);
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Description

Since upgrading to react 18, the one page example has unfortunately stopped working if re-built. The one page example has `react-dom` loaded as a global from a CDN, but the js example uses a named import for `createRoot`.

This leads to `import { createRoot } from 'react-dom/client';` being included in the output of the one page example which it's not able to resolve and `const root = createRoot(...);` where `createRoot` can't be found.

Changing the `react-dom` import to a default in the js example, results in the one page example omitting the default import from it's output and referencing `ReactDOM.createRoot(...)` where it's able to find `ReactDOM` in global scope, having been loaded from the CDN.