### PR TITLE
`wireit` setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
         run: pnpm install
 
       - name: Check Code ${{ matrix.node-version }}
-        run: yarn check-ci
+        run: pnpm run check-ci
 
         # NOTE! build-examples also builds the core.
         #  This dependency will be more explicit with wireit
       - name: Build Examples ${{ matrix.node-version }}
-        run: yarn build-examples
+        run: pnpm run build:examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: pnpm install
 
       - name: Check Code ${{ matrix.node-version }}
-        run: pnpm run check-ci
+        run: pnpm run check:ci
 
         # NOTE! build-examples also builds the core.
         #  This dependency will be more explicit with wireit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Wireit cache
+      - uses: google/wireit@setup-github-actions-caching/v1
+
       - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7
@@ -53,7 +56,8 @@ jobs:
       - name: Check Code ${{ matrix.node-version }}
         run: pnpm run check:ci
 
-        # NOTE! build-examples also builds the core.
-        #  This dependency will be more explicit with wireit
+      - name: Build Core ${{ matrix.node-version }}
+        run: pnpm run build:core
+
       - name: Build Examples ${{ matrix.node-version }}
         run: pnpm run build:examples

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build
 dist
 lib
 es
+.wireit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ $ pnpm run start:one-page
 
 **Note**: This file is published and used by `spectacle-cli`.
 
-**Development Note**: This JS code portion of this file is programmatically updated from the source in `examples/js/index.js` directly into `one-page.html`. Rather than editing directly, please run `pnpm run build-one-page` and verify changes look good.
+**Development Note**: This JS code portion of this file is programmatically updated from the source in `examples/js/index.js` directly into `one-page.html`. Rather than editing directly, please run `pnpm run build:one-page` and verify changes look good.
 
 ### Examples integration with `spectacle-cli`
 
@@ -166,7 +166,7 @@ Thanks for taking the time to help us make Spectacle even better! Before you go
 ahead and submit a PR, make sure that you have done the following:
 
 - Run all checks using `pnpm run check-ci`.
-- Run `pnpm run build-one-page` and check + commit changes to `examples/one-page/index.html`
+- Run `pnpm run build:one-page` and check + commit changes to `examples/one-page/index.html`
 - Check that both the core library and _all_ examples build: `pnpm run build`.
 - Everything else included in our [pull request checklist](.github/PULL_REQUEST_TEMPLATE.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,14 +141,14 @@ To check (and fix) code:
 
 ```bash
 $ pnpm run lint
-$ pnpm run lint-fix
+$ pnpm run lint:fix
 ```
 
 To check (and fix) formatting of MD, JSON, _and_ code:
 
 ```bash
-$ pnpm run prettier-check
-$ pnpm run prettier-fix
+$ pnpm run prettier:check
+$ pnpm run prettier:fix
 ```
 
 We also have a simple one-liner for running both of these fix-checks back-to-back:
@@ -165,7 +165,7 @@ but both should be harmonious and run together.
 Thanks for taking the time to help us make Spectacle even better! Before you go
 ahead and submit a PR, make sure that you have done the following:
 
-- Run all checks using `pnpm run check-ci`.
+- Run all checks using `pnpm run check:ci`.
 - Run `pnpm run build:one-page` and check + commit changes to `examples/one-page/index.html`
 - Check that both the core library and _all_ examples build: `pnpm run build`.
 - Everything else included in our [pull request checklist](.github/PULL_REQUEST_TEMPLATE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for contributing!
   <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg" />
 </a>
 
-Spectacle is actively maintained by @[carlos-kelly][] and @[kale-stew][]
+Spectacle is actively maintained by @[carlos-kelly][] and @[gksander][]
 from within [@FormidableLabs][formidable-github].
 
 ## Development
@@ -29,6 +29,7 @@ Our examples are spread out across multiple projects depending on where the core
 
 - `spectacle`
   - [`examples/js`](https://github.com/FormidableLabs/spectacle/tree/main/examples/js)
+  - [`examples/typescript`](https://github.com/FormidableLabs/spectacle/tree/main/examples/typescript)
   - [`examples/md`](https://github.com/FormidableLabs/spectacle/tree/main/examples/md)
   - [`examples/one-page`](https://github.com/FormidableLabs/spectacle/tree/main/examples/one-page.html)
 - `spectacle-mdx-loader`
@@ -41,8 +42,10 @@ Our examples are spread out across multiple projects depending on where the core
 We have various deck scenarios in `examples` in this repository that are part of the development process.
 
 We follow the convention of `start:NAME` to run an in-memory dev server for a specific
-example, but we also have a `pnpm run build-examples` script task to make sure we're actually
+example, but we also have a `pnpm run build:examples` script task to make sure we're actually
 producing non-broken sample presentations as a CI / assurance test.
+
+If you'd like to make changes to Spectacle core, and see changes reflected in the examples, run `pnpm run build:core --watch` in a terminal window, and then follow along with the following commands in a _separate_ terminal window.
 
 #### `examples/js`
 
@@ -275,7 +278,7 @@ available at [https://www.contributor-covenant.org/version/2/0][cc-latest-versio
 [cc-homepage]: http://contributor-covenant.org
 [cc-latest-version]: https://www.contributor-covenant.org/version/2/0/code_of_conduct
 [formidable-github]: https://www.github.com/FormidableLabs
-[kale-stew]: https://www.github.com/kale-stew
+[gksander]: https://www.github.com/gksander
 [mdx]: https://mdxjs.com/
 [spectacle-cli]: https://www.github.com/FormidableLabs/spectacle-cli
 [pnpm-docs]: https://pnpm.io/

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "spectacle-monorepo",
   "scripts": {
     "lint": "eslint --ext .tsx,.ts,.jsx,.js ./examples ./scripts packages/spectacle/src",
-    "lint-fix": "pnpm run lint --fix",
+    "lint:fix": "pnpm run lint --fix",
     "prettier": "prettier \"**/*.{js,json,ts,css,md}\"",
-    "prettier-check": "pnpm run prettier --check",
-    "prettier-fix": "pnpm prettier --write",
+    "prettier:check": "pnpm run prettier --check",
+    "prettier:fix": "pnpm prettier --write",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "check-ci": "wireit",
+    "check:ci": "wireit",
     "clean": "pnpm run -r clean",
 
     "build:core": "wireit",
@@ -41,10 +41,10 @@
     "wireit": "^0.7.1"
   },
   "wireit": {
-    "check-ci": {
+    "check:ci": {
       "dependencies": [
         "lint",
-        "prettier-check",
+        "prettier:check",
         "test",
         "typecheck"
       ]

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "spectacle-monorepo",
   "scripts": {
-    "lint": "eslint --ext .tsx,.ts,.jsx,.js ./examples ./scripts packages/spectacle/src",
+    "lint": "wireit",
     "lint:fix": "pnpm run lint --fix",
-    "prettier": "prettier \"**/*.{js,json,ts,css,md}\"",
-    "prettier:check": "pnpm run prettier --check",
-    "prettier:fix": "pnpm prettier --write",
-    "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test",
+    "prettier:check": "wireit",
+    "prettier:fix": "wireit",
+    "typecheck": "wireit",
+    "test": "wireit",
     "check:ci": "wireit",
     "clean": "pnpm run -r clean",
 
@@ -41,6 +40,28 @@
     "wireit": "^0.7.1"
   },
   "wireit": {
+    "lint": {
+      "files": ["./examples", "./scripts", "./packages/spectacle/src", "!**/node_modules", "!**/es", "!**/lib", "!**/dist"],
+      "command": "eslint --ext .tsx,.ts,.jsx,.js ./examples ./scripts packages/spectacle/src"
+    },
+    "lint:fix": {
+      "command": "eslint --ext .tsx,.ts,.jsx,.js ./examples ./scripts packages/spectacle/src --fix"
+    },
+    "prettier:check": {
+      "files": ["**/*.{js,json,ts,css,md}", "!**/node_modules", "!**/es", "!**/lib", "!**/dist", "!**/docs", "!.vscode", "!.idea", "!.nova"],
+      "command": "prettier \"**/*.{js,json,ts,css,md}\" --check"
+    },
+    "prettier:fix": {
+      "command": "prettier \"**/*.{js,json,ts,css,md}\" --write"
+    },
+    "typecheck": {
+      "files": ["./packages/spectacle/**/*.{ts,tsx,json}", "!**/node_modules", "!**/es", "!**/lib", "!**/dist"],
+      "dependencies": ["./packages/spectacle:typecheck"]
+    },
+    "test": {
+      "files": ["./packages/spectacle/src/**/*", "./packages/spectacle/*"],
+      "dependencies": ["./packages/spectacle:test"]
+    },
     "check:ci": {
       "dependencies": [
         "lint",
@@ -49,6 +70,7 @@
         "typecheck"
       ]
     },
+
     "build:core": {
       "files": ["./packages/spectacle/src/**/*.{ts,tsx,js}"],
       "dependencies": ["./packages/spectacle:build"]

--- a/package.json
+++ b/package.json
@@ -1,11 +1,6 @@
 {
   "name": "spectacle-monorepo",
   "scripts": {
-    "start:js": "pnpm run --filter spectacle-example-js start",
-    "start:ts": "pnpm run --filter spectacle-example-ts start",
-    "start:md": "pnpm run --filter spectacle-example-md start",
-    "start:one-page": "pnpm run --filter spectacle-example-one-page start",
-    "start:examples": "pnpm run --parallel --filter \"*example*\" start",
     "lint": "eslint --ext .tsx,.ts,.jsx,.js ./examples ./scripts packages/spectacle/src",
     "lint-fix": "pnpm run lint --fix",
     "prettier": "prettier \"**/*.{js,json,ts,css,md}\"",
@@ -13,16 +8,24 @@
     "prettier-fix": "pnpm prettier --write",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "check": "pnpm run lint && pnpm run prettier-check && pnpm run test && pnpm run typecheck",
-    "check-ci": "pnpm run check",
+    "check-ci": "wireit",
     "clean": "pnpm run -r clean",
-    "build-examples": "pnpm run --filter spectacle build && pnpm run -r --filter \"*example*\" build",
-    "build-core": "pnpm run --filter spectacle build",
-    "build": "pnpm run -r build",
-    "build-one-page": "node ./scripts/one-page.js"
+
+    "build:core": "wireit",
+    "start:js": "wireit",
+    "build:js": "wireit",
+    "start:ts": "wireit",
+    "build:ts": "wireit",
+    "start:md": "wireit",
+    "build:md": "wireit",
+    "start:one-page": "wireit",
+    "build:one-page": "wireit",
+    "start:examples": "wireit",
+    "build:examples": "wireit"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",
+    "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "babel-eslint": "^10.1.0",
@@ -35,6 +38,65 @@
     "prettier": "^2.4.1",
     "pretty": "^2.0.0",
     "typescript": "^4.5.2",
-    "@types/jest": "^27.0.2"
+    "wireit": "^0.7.1"
+  },
+  "wireit": {
+    "check-ci": {
+      "dependencies": [
+        "lint",
+        "prettier-check",
+        "test",
+        "typecheck"
+      ]
+    },
+    "build:core": {
+      "files": ["./packages/spectacle/src/**/*.{ts,tsx,js}"],
+      "dependencies": ["./packages/spectacle:build"]
+    },
+    "start:js": {
+      "dependencies": ["build:core", "./examples/js:start"]
+    },
+    "build:js": {
+      "files": ["./examples/js/*"],
+      "dependencies": ["build:core", "./examples/js:build"]
+    },
+    "start:ts": {
+      "dependencies": ["build:core", "./examples/typescript:start"]
+    },
+    "build:ts": {
+      "files": ["./examples/typescript/*"],
+      "dependencies": ["build:core", "./examples/typescript:build"]
+    },
+    "start:md": {
+      "dependencies": ["build:core", "./examples/md:start"]
+    },
+    "build:md": {
+      "files": ["./examples/md/*"],
+      "dependencies": ["build:core", "./examples/md:build"]
+    },
+    "start:one-page": {
+      "dependencies": ["build:core", "./examples/one-page:start"]
+    },
+    "build:one-page": {
+      "command": "node ./scripts/one-page.js",
+      "files": ["./examples/js/index.{html,js}"]
+    },
+    "start:examples": {
+      "dependencies": [
+        "start:js",
+        "start:ts",
+        "start:md",
+        "start:one-page"
+      ]
+    },
+    "build:examples": {
+      "dependencies": [
+        "build:core",
+        "build:js",
+        "build:ts",
+        "build:md",
+        "build:one-page"
+      ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       prettier: ^2.4.1
       pretty: ^2.0.0
       typescript: ^4.5.2
+      wireit: ^0.7.1
     devDependencies:
       '@babel/core': 7.18.6
       '@types/jest': 27.5.2
@@ -33,6 +34,7 @@ importers:
       prettier: 2.7.1
       pretty: 2.0.0
       typescript: 4.7.4
+      wireit: 0.7.1
 
   examples/js:
     specifiers:
@@ -5637,6 +5639,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonc-parser/3.0.0:
+    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
+    dev: true
+
   /jsx-ast-utils/3.3.2:
     resolution: {integrity: sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==}
     engines: {node: '>=4.0'}
@@ -6404,6 +6410,14 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  /proper-lockfile/4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+    dependencies:
+      graceful-fs: 4.2.10
+      retry: 0.12.0
+      signal-exit: 3.0.7
+    dev: true
+
   /property-information/5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
     dependencies:
@@ -6778,6 +6792,11 @@ packages:
       is-core-module: 2.9.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /retry/0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
     dev: true
 
   /retry/0.13.1:
@@ -8088,6 +8107,18 @@ packages:
 
   /wildcard/2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
+
+  /wireit/0.7.1:
+    resolution: {integrity: sha512-TwuKae0aHk06DZ2omLW6YF4Y74YxCyuRCcsjZMm+cUPRXhvxAU2JhYyuCvD9wIALWK+cQUpB9GjeRFPRAbKsdw==}
+    engines: {node: '>=14.14.0'}
+    hasBin: true
+    dependencies:
+      braces: 3.0.2
+      chokidar: 3.5.3
+      fast-glob: 3.2.11
+      jsonc-parser: 3.0.0
+      proper-lockfile: 4.1.2
     dev: true
 
   /word-wrap/1.2.3:


### PR DESCRIPTION
This PR sets up `wireit` in the repo, including:

- `wireit` setup for most root scripts.
- GH Actions setup with `wireit`, which should theoretically speed up CI runs some scenarios.

Per [this issue](https://github.com/google/wireit/issues/33), we can't _yet_ seamlessly run our example dev servers along with a core build watch with a single command. We'll have to keep our eyes on that issue, so that we can eventually have some sort of `dev` command that watches the core source files (and compiles those on change), and has example dev servers running that use the built core files.