### PR TITLE
Update demo url

### DIFF
--- a/docs/src/screens/home/_content.js
+++ b/docs/src/screens/home/_content.js
@@ -25,7 +25,7 @@ const content = {
     bgStill: require('../../assets/demo-still.png'),
     bgWebm: require('../../assets/demo-presentation.webm'),
     demoUrl:
-      'https://raw.githack.com/FormidableLabs/spectacle/main/examples/one-page.html'
+      'https://raw.githack.com/FormidableLabs/spectacle/main/examples/one-page/index.html'
   },
   getStarted: {
     description:


### PR DESCRIPTION
With pnpm restructuring, demo url broke (whoops). This PR fixes that.