### PR TITLE
Replaced 'lineNumberProps' with 'lineNumberStyle'

### DIFF
--- a/packages/spectacle/src/components/code-pane.tsx
+++ b/packages/spectacle/src/components/code-pane.tsx
@@ -112,12 +112,12 @@ const CodePane = forwardRef<HTMLDivElement, CodePaneProps>(
 
     const scrollTarget = useRef<HTMLElement>(null);
 
-    const getLineNumberProps = useCallback(
+    const getLineNumberStyle = useCallback(
       (lineNumber: number) => {
-        if (!isActive) return;
+        if (!isActive) return {};
         const range = getRangeFormat(numberOfSteps, highlightRanges, step);
         return {
-          style: getStyleForLineNumber(lineNumber, range)
+          ...getStyleForLineNumber(lineNumber, range)
         };
       },
       [isActive, highlightRanges, numberOfSteps, step]
@@ -174,7 +174,7 @@ const CodePane = forwardRef<HTMLDivElement, CodePaneProps>(
             wrapLines
             showLineNumbers={showLineNumbers}
             lineProps={getLineProps}
-            lineNumberProps={getLineNumberProps}
+            lineNumberStyle={getLineNumberStyle}
             style={syntaxTheme}
           >
             {children}

--- a/packages/spectacle/src/components/code-pane.tsx
+++ b/packages/spectacle/src/components/code-pane.tsx
@@ -116,9 +116,7 @@ const CodePane = forwardRef<HTMLDivElement, CodePaneProps>(
       (lineNumber: number) => {
         if (!isActive) return {};
         const range = getRangeFormat(numberOfSteps, highlightRanges, step);
-        return {
-          ...getStyleForLineNumber(lineNumber, range)
-        };
+        return getStyleForLineNumber(lineNumber, range);
       },
       [isActive, highlightRanges, numberOfSteps, step]
     );


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

[react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter) no longer supports `lineNumberProps` but it does support inline styles with `lineNumberStyle`.

Fixes #1137 

#### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- `example/js/index.js` to test fix
1. `pnpm run build-examples`
2. `pnpm run start:js`
- Notice the console warning `Warning: React does not recognize the 'lineNumberProps '...` is no longer present

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn format`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
