### PR TITLE
Infra: bandaid version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # Note: Our `package.json:scripts.version` currently doesn't have `--fix-lockfile` for
+          # `pnpm install` because of a PNPM bug of some kind.
+          # https://github.com/FormidableLabs/spectacle/issues/1156
           version: pnpm run version
           publish: pnpm changeset publish
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+prefer-workspace-packages=true

--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "spectacle": "workspace:spectacle@*"
+    "spectacle": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",

--- a/examples/md/package.json
+++ b/examples/md/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --config ./webpack.config.js"
   },
   "dependencies": {
-    "spectacle": "workspace:spectacle@*",
+    "spectacle": "*",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --config ./webpack.config.js"
   },
   "dependencies": {
-    "spectacle": "workspace:spectacle@*",
+    "spectacle": "*",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:one-page": "node ./scripts/one-page.js",
     "build:cli": "pnpm run --filter spectacle-cli build",
     "changeset": "changeset",
-    "version": "pnpm changeset version && pnpm install --fix-lockfile"
+    "version": "pnpm changeset version && pnpm install"
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "spectacle": "workspace:spectacle@*",
+    "spectacle": "*",
     "@types/node": "^18.0.3",
     "nodemon": "^2.0.18",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
       react: ^18.1.0
       react-dom: ^18.1.0
       rimraf: ^3.0.0
-      spectacle: workspace:spectacle@*
+      spectacle: '*'
       webpack: ^5.68.0
       webpack-cli: ^4.10.0
       webpack-dev-server: ^4.7.4
@@ -89,7 +89,7 @@ importers:
       react: ^18.1.0
       react-dom: ^18.1.0
       rimraf: ^3.0.0
-      spectacle: workspace:spectacle@*
+      spectacle: '*'
       typescript: ^4.5.2
       webpack: ^5.68.0
       webpack-cli: ^4.10.0
@@ -130,7 +130,7 @@ importers:
       react: ^18.1.0
       react-dom: ^18.1.0
       rimraf: ^3.0.0
-      spectacle: workspace:spectacle@*
+      spectacle: '*'
       typescript: ^4.5.2
       webpack: ^5.68.0
       webpack-cli: ^4.10.0
@@ -164,7 +164,7 @@ importers:
       log-update: 4.0.0
       nodemon: ^2.0.18
       rimraf: ^3.0.2
-      spectacle: workspace:spectacle@*
+      spectacle: '*'
       ts-node: ^10.8.1
       typescript: '*'
     dependencies:


### PR DESCRIPTION
I filed #1156 to track the issue with `pnpm install --fix-lockfile` and the short answer is: (1) it appears to be some bug, and (2) I don't know how to fix it easily.

Fortunately, `pnpm install` alone should generate `pnpm-lock.yaml` changes that we need to re-commit at the end of changeset version, so I've just switched to that.

Separately, I've removed all `workspace:` prefixes for cross-project `spectacle` dependencies because (1) they are not needed and (2) the complicate examples / other projects release-wise and confusion-wise because they are PNPM dependent artifacts.