### PR TITLE
fix: space between pacman sides as they move

### DIFF
--- a/packages/spectacle/src/components/animated-progress.tsx
+++ b/packages/spectacle/src/components/animated-progress.tsx
@@ -62,7 +62,7 @@ const PacmanBodyTop = styled.div<PacmanBodyProps>`
   border-top-left-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
   border-top-right-radius: ${({ pacmanSize }) => pacmanSize / 2}px;
   // NOTE: So the top and bottom always overlap when sizes are in decimals.
-  box-shadow: 0 0 0 0.1px ${({ color }) => color};
+  box-shadow: 0 0 0 0.5px ${({ color }) => color};
   animation-name: ${({ alternate }) =>
     alternate ? pacmanTopFrames : pacmanTopFramesAlternate};
   animation-duration: 0.12s;


### PR DESCRIPTION
It's very minor but noticed the the sides of the Pacman didn't overlap in the earlier presentation. Thought the 0.1px box-shadow would have be enough when I first implemented but needs to be bigger.

Before:

https://user-images.githubusercontent.com/8139746/181323673-8ba18345-1ad2-4709-ba43-db0c173f3e63.mov

After:

https://user-images.githubusercontent.com/8139746/181323885-51dc587b-a0b3-4703-98b0-9ea73ed15532.mov

#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)