### PR TITLE
[FIX] Issue-1171 Do not overwrite url derived state

### DIFF
--- a/packages/spectacle/src/hooks/use-deck-state.ts
+++ b/packages/spectacle/src/hooks/use-deck-state.ts
@@ -100,7 +100,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
 export default function useDeckState(userProvidedInitialState: DeckView) {
   const [{ initialized, pendingView, activeView }, dispatch] = useReducer(
     deckReducer,
-    initialDeckState
+    { ...initialDeckState, ...userProvidedInitialState }
   );
   const actions = useMemo(
     () => ({
@@ -119,12 +119,6 @@ export default function useDeckState(userProvidedInitialState: DeckView) {
     }),
     [dispatch]
   );
-
-  useEffect(() => {
-    if (initialized) return;
-    if (userProvidedInitialState === undefined) return;
-    actions.initializeTo(userProvidedInitialState);
-  }, [initialized, actions, userProvidedInitialState]);
 
   return {
     initialized,


### PR DESCRIPTION
### Description

I have removed an effect that seemed to be overwriting the state derived from the url. 
I understand that Spectacle's approach is to maintain its own state whereby location is superseded by app state, however, I believe in this instance on initialisation we do want location to "win".

I hope that someone with a bit more context on this effect will have input on the impacts of its removal.

As far as I can tell, we can still set initial state once upon mount by spreading the argument passed to useDeckState. The only logical part that is no longer checked is ``` if(initialized) ``` I do think at mount (when passing state to the reducer) we are not initialised so this is fine. However, something to think about for someone who has context.

Fixes #1171 

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran all current tests and manually ran each example to see if they continued to work.


<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/17838632/183662555-696d1b75-463b-4103-b1b9-ba464d522599.mov

</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/17838632/183662734-04a5be15-f29c-4eab-8590-bcaba21b5082.mov

</details>