### PR TITLE
`create-spectacle` first minor release

### DIFF
--- a/.changeset/tough-jokes-learn.md
+++ b/.changeset/tough-jokes-learn.md
@@ -1,0 +1,5 @@
+---
+'create-spectacle': minor
+---
+
+Initial release of create-spectacle

--- a/packages/create-spectacle/package.json
+++ b/packages/create-spectacle/package.json
@@ -7,9 +7,7 @@
   "files": [
     "bin/"
   ],
-  "bin": {
-    "create-spectacle": "bin/cli.js"
-  },
+  "bin": "bin/cli.js",
   "author": "Formidable Labs <hello@formidable.com>",
   "license": "MIT",
   "repository": {

--- a/packages/create-spectacle/package.json
+++ b/packages/create-spectacle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-spectacle",
   "version": "0.0.1",
-  "private": "true",
+  "private": "false",
   "description": "Project generator for Spectacle",
   "main": "bin/cli.js",
   "files": [


### PR DESCRIPTION
This PR slims up the `bin` field for `create-spectacle` (since we only have one executable), and creates a changeset for a minor release. We'll see if publishing "just works" with changesets 🤔 