### PR TITLE
`create-spectacle`: Better check for overwrite

### DIFF
--- a/.changeset/tricky-drinks-listen.md
+++ b/.changeset/tricky-drinks-listen.md
@@ -1,0 +1,5 @@
+---
+'create-spectacle': patch
+---
+
+Better overwrite logic based on whether HTML file or directory will be created

--- a/packages/create-spectacle/src/cli.ts
+++ b/packages/create-spectacle/src/cli.ts
@@ -104,7 +104,7 @@ const main = async () => {
               if (type === 'onepage') {
                 return `File ${formatProjectOutputPath(
                   name
-                )}.html already exists. Overwrite it?`;
+                )}.html already exists. Overwrite and continue?`;
               } else {
                 return `Target directory ${formatProjectOutputPath(
                   name

--- a/packages/create-spectacle/src/cli.ts
+++ b/packages/create-spectacle/src/cli.ts
@@ -76,7 +76,7 @@ const main = async () => {
           },
           /**
            * Type of deck.
-           * Needs to be first so we can determine if folder/file already exists.
+           * Needs to be before overwrite confirmation so we can determine if folder/file already exists.
            */
           {
             type: 'select',


### PR DESCRIPTION
Address #1199 

Since `onepage` generates a single HTML file, but other deck types create a directory – we need to have a bit of a logic fork for determining whether or not we'll be overwriting (and when to prompt the user to confirm an overwrite). The approach here is to just move the `type` prompt right after `name` (but before the overwrite confirmation), so we can appropriately determine _when_ we need to overwrite (based on both `type` and `name`).