### PR TITLE
feat: Add new slide layouts: section, statement, big fact, quote.

### DIFF
--- a/.changeset/little-peaches-jump.md
+++ b/.changeset/little-peaches-jump.md
@@ -1,0 +1,5 @@
+---
+'spectacle': minor
+---
+
+feat: Add new Slide Layouts: Section, Statement, Big fact, Quote to expand basic layout creation.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -444,7 +444,7 @@ A vertically-centered Quote layout for if you want to present a quote and attrib
 | Props                 | Type                            | Required |  Example               |
 |-----------------------|---------------------------------|----------|------------------------|
 | `...slideProps`       | [Slide Props](#slide)           | ❌        |                        |
-| `quote`               | `string`                        | ✅        | `To be, or not to be`  |
-| `attribution`         | `string`                        | ✅        | `William Shakespeare`  |
+| `quote`               | `string | ReactNode`                        | ✅        | `To be, or not to be`  |
+| `attribution`         | `string | ReactNode`                        | ✅        | `William Shakespeare`  |
 | `quoteProps`          | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |
 | `attributionProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -423,20 +423,21 @@ A vertically-centered center-aligned statement for if you want to make a stateme
 | Props                  | Type                            | Required |  Example                 |
 |------------------------|---------------------------------|----------|--------------------------|
 | `...slideProps`        | [Slide Props](#slide)           | ❌        |                          |
-| `statementTitle`       | `string`                        | ✅        | `Statement!`          |
+| `statementTitle`       | `string`                        | ✅        | `Statement!`             |
 | `statementProps`       | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
 
 ### `SlideLayout.BigFact`
 
 A centered Big Fact layout for if you want to present a fact in a large font.
 
-| Props                     | Type                            | Required |  Example               |
-|---------------------------|---------------------------------|----------|------------------------|
-| `...slideProps`           | [Slide Props](#slide)           | ❌        |                        |
-| `fact`                    | `string`                        | ✅        | `100%`                 |
-| `factInformation`         | `string`                        | ❌        | `Fact information`     |
-| `factProps`               | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |
-| `factInformationProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |
+| Props                     | Type                            | Required |  Example               | Default |
+|---------------------------|---------------------------------|----------|------------------------|---------|
+| `...slideProps`           | [Slide Props](#slide)           | ❌        |                        |        |
+| `fact`                    | `string`                        | ✅        | `100%`                 |        |
+| `factInformation`         | `string`                        | ❌        | `Fact information`     |        |
+| `factProps`               | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |        |
+| `factInformationProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |        |
+| `factFontSize`            | `string`                        | ❌        | `150px`                |`250px` |
 
 ### `SlideLayout.Quote`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -431,8 +431,8 @@ A centered Big Fact layout for if you want to present a fact in a large font.
 | Props                     | Type                            | Required |  Example               | Default |
 |---------------------------|---------------------------------|----------|------------------------|---------|
 | `...slideProps`           | [Slide Props](#slide)           | ❌        |                        |        |
-| `fact`                    | `string`                        | ✅        | `100%`                 |        |
-| `factInformation`         | `string`                        | ❌        | `Fact information`     |        |
+| `fact`                    | `string | ReactNode`                        | ✅        | `100%`                 |        |
+| `factInformation`         | `string | ReactNode`                        | ❌        | `Fact information`     |        |
 | `factProps`               | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |        |
 | `factInformationProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |        |
 | `factFontSize`            | `string`                        | ❌        | `150px`                |`250px` |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -404,3 +404,48 @@ A layout with a list and an optional title for if you want to quickly display a 
 | `items`            | `ReactNode[]`                       | ✅        | `['Hello', <Text>World</Text>]` |
 | `animateListItems` | `boolean`                           | ❌        | `true`                          |
 | `listProps`        | [List Props](#typography-tags)      | ❌        | `{ backgroundColor: 'purple' }` |
+
+
+### `SlideLayout.Section`
+
+A vertically-centered left-aligned section title layout for if you want title page for a new section.
+
+| Props                  | Type                            | Required |  Example                 |
+|------------------------|---------------------------------|----------|--------------------------|
+| `...slideProps`        | [Slide Props](#slide)           | ❌        |                          |
+| `sectionTitle`         | `string`                        | ✅        | `Section Title`          |
+| `sectionTitleProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
+
+### `SlideLayout.Statement`
+
+A vertically-centered center-aligned statement for if you want to make a statement.
+
+| Props                  | Type                            | Required |  Example                 |
+|------------------------|---------------------------------|----------|--------------------------|
+| `...slideProps`        | [Slide Props](#slide)           | ❌        |                          |
+| `statementTitle`       | `string`                        | ✅        | `Statement!`          |
+| `statementProps`       | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
+
+### `SlideLayout.BigFact`
+
+A centered Big Fact layout for if you want to present a fact in a large font.
+
+| Props                     | Type                            | Required |  Example               |
+|---------------------------|---------------------------------|----------|------------------------|
+| `...slideProps`           | [Slide Props](#slide)           | ❌        |                        |
+| `fact`                    | `string`                        | ✅        | `100%`                 |
+| `factInformation`         | `string`                        | ❌        | `Fact information`     |
+| `factProps`               | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |
+| `factInformationProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |
+
+### `SlideLayout.Quote`
+
+A vertically-centered Quote layout for if you want to present a quote and attribute it to someone.
+
+| Props                 | Type                            | Required |  Example               |
+|-----------------------|---------------------------------|----------|------------------------|
+| `...slideProps`       | [Slide Props](#slide)           | ❌        |                        |
+| `quote`               | `string`                        | ✅        | `To be, or not to be`  |
+| `attribution`         | `string`                        | ✅        | `William Shakespeare`  |
+| `quoteProps`          | [Text Props](#typography-tags)  | ❌        | { fontSize: "100px" }  |
+| `attributionProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }   |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -413,8 +413,7 @@ A vertically-centered left-aligned section title layout for if you want title pa
 | Props                  | Type                            | Required |  Example                 |
 |------------------------|---------------------------------|----------|--------------------------|
 | `...slideProps`        | [Slide Props](#slide)           | ❌        |                          |
-| `sectionTitle`         | `string`                        | ✅        | `Section Title`          |
-| `sectionTitleProps`    | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
+| `sectionProps`         | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
 
 ### `SlideLayout.Statement`
 
@@ -423,7 +422,6 @@ A vertically-centered center-aligned statement for if you want to make a stateme
 | Props                  | Type                            | Required |  Example                 |
 |------------------------|---------------------------------|----------|--------------------------|
 | `...slideProps`        | [Slide Props](#slide)           | ❌        |                          |
-| `statementTitle`       | `string`                        | ✅        | `Statement!`             |
 | `statementProps`       | [Text Props](#typography-tags)  | ❌        | { fontSize: "48px" }     |
 
 ### `SlideLayout.BigFact`

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -183,6 +183,20 @@ describe('SlideLayout', () => {
     expect(getByText('100%')).toHaveStyle({ fontSize: '88px' });
   });
 
+  it('SlideLayout.BigFact should render a fact with default font size', () => {
+    const { getByText } = renderInDeck(<SlideLayout.BigFact fact={'100%'} />);
+
+    expect(getByText('100%')).toHaveStyle({ fontSize: '250px' });
+  });
+
+  it('SlideLayout.BigFact should render a fact with customizable font size', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.BigFact fact={'100%'} factFontSize={'150px'} />
+    );
+
+    expect(getByText('100%')).toHaveStyle({ fontSize: '150px' });
+  });
+
   it('SlideLayout.BigFact should render a slide with fact information if it exists', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.BigFact fact={'100%'} factInformation={'We earned 100%!'} />

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -123,7 +123,7 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Section should render a section title', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section sectionTitle={'Section title'} />
+      <SlideLayout.Section>{'Section title'}</SlideLayout.Section>
     );
 
     expect(getByText('Section title')).toBeDefined();
@@ -131,13 +131,13 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Section should render a section title within a react node', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section
-        sectionTitle={
+      <SlideLayout.Section>
+        {
           <>
             Hello<em>World!</em>
           </>
         }
-      />
+      </SlideLayout.Section>
     );
 
     expect(getByText('World!')).toBeDefined();
@@ -145,10 +145,9 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Section should render a section slide with props passed through', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section
-        sectionTitle={'Section title'}
-        sectionTitleProps={{ fontSize: '68px' }}
-      />
+      <SlideLayout.Section sectionProps={{ fontSize: '68px' }}>
+        {'Section title'}
+      </SlideLayout.Section>
     );
 
     expect(getByText('Section title')).toHaveStyle({ fontSize: '68px' });
@@ -156,7 +155,7 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Section should render a section title in a left aligned flexbox', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section sectionTitle={'Section title'} />
+      <SlideLayout.Section>{'Section title'}</SlideLayout.Section>
     );
 
     expect(getByText('Section title').parentElement).toHaveStyle({
@@ -166,7 +165,7 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Statement should render statement text', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Statement statement={'Statement'} />
+      <SlideLayout.Statement>{'Statement'}</SlideLayout.Statement>
     );
 
     expect(getByText('Statement')).toBeDefined();
@@ -174,13 +173,13 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Statement should render statement text within a react node', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Statement
-        statement={
+      <SlideLayout.Statement>
+        {
           <>
             Hello<em>World!</em>
           </>
         }
-      />
+      </SlideLayout.Statement>
     );
 
     expect(getByText('World!')).toBeDefined();
@@ -188,10 +187,9 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Statement should render a statement slide with props passed through', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Statement
-        statement={'Statement'}
-        statementProps={{ fontSize: '88px' }}
-      />
+      <SlideLayout.Statement statementProps={{ fontSize: '88px' }}>
+        {'Statement'}
+      </SlideLayout.Statement>
     );
 
     expect(getByText('Statement')).toHaveStyle({ fontSize: '88px' });

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -121,12 +121,9 @@ describe('SlideLayout', () => {
     expect(queryAllByTestId('AppearElement')).toHaveLength(3);
   });
 
-
   it('SlideLayout.Section should render a section title', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section
-        sectionTitle={"Section title"}
-      />
+      <SlideLayout.Section sectionTitle={'Section title'} />
     );
 
     expect(getByText('Section title')).toBeDefined();
@@ -135,7 +132,7 @@ describe('SlideLayout', () => {
   it('SlideLayout.Section should render a section slide with props passed through', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.Section
-        sectionTitle={"Section title"}
+        sectionTitle={'Section title'}
         sectionTitleProps={{ fontSize: '68px' }}
       />
     );
@@ -145,19 +142,17 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.Section should render a section title in a left aligned flexbox', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Section
-        sectionTitle={"Section title"}
-      />
+      <SlideLayout.Section sectionTitle={'Section title'} />
     );
 
-    expect(getByText('Section title').parentElement).toHaveStyle({ justifyContent: 'flex-start'});
+    expect(getByText('Section title').parentElement).toHaveStyle({
+      justifyContent: 'flex-start'
+    });
   });
 
   it('SlideLayout.Statement should render statement text', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.Statement
-        statement={"Statement"}
-      />
+      <SlideLayout.Statement statement={'Statement'} />
     );
 
     expect(getByText('Statement')).toBeDefined();
@@ -166,7 +161,7 @@ describe('SlideLayout', () => {
   it('SlideLayout.Statement should render a statement slide with props passed through', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.Statement
-        statement={"Statement"}
+        statement={'Statement'}
         statementProps={{ fontSize: '88px' }}
       />
     );
@@ -175,21 +170,14 @@ describe('SlideLayout', () => {
   });
 
   it('SlideLayout.BigFact should render a slide with fact text', () => {
-    const { getByText } = renderInDeck(
-      <SlideLayout.BigFact
-        fact={"100%"}
-      />
-    );
+    const { getByText } = renderInDeck(<SlideLayout.BigFact fact={'100%'} />);
 
     expect(getByText('100%')).toBeDefined();
   });
 
   it('SlideLayout.BigFact should render a slide with props passed through', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.BigFact
-        fact={"100%"}
-        factProps={{ fontSize: '88px' }}
-      />
+      <SlideLayout.BigFact fact={'100%'} factProps={{ fontSize: '88px' }} />
     );
 
     expect(getByText('100%')).toHaveStyle({ fontSize: '88px' });
@@ -197,10 +185,7 @@ describe('SlideLayout', () => {
 
   it('SlideLayout.BigFact should render a slide with fact information if it exists', () => {
     const { getByText } = renderInDeck(
-      <SlideLayout.BigFact
-        fact={"100%"}
-        factInformation={'We earned 100%!'}
-      />
+      <SlideLayout.BigFact fact={'100%'} factInformation={'We earned 100%!'} />
     );
 
     expect(getByText('We earned 100%!')).toBeDefined();
@@ -221,15 +206,20 @@ describe('SlideLayout', () => {
   it('SlideLayout.Quote should render a slide with quote and attribution props passed through', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.Quote
-        quote={"I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."}
+        quote={
+          "I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."
+        }
         quoteProps={{ fontSize: '68px' }}
-        attribution={"Maya Angelou"}
+        attribution={'Maya Angelou'}
         attributionProps={{ fontSize: '48px' }}
       />
     );
 
-    expect(getByText("I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel.")).toHaveStyle({ fontSize: '68px' });
-    expect(getByText("Maya Angelou")).toHaveStyle({ fontSize: '48px' });
+    expect(
+      getByText(
+        "I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."
+      )
+    ).toHaveStyle({ fontSize: '68px' });
+    expect(getByText('Maya Angelou')).toHaveStyle({ fontSize: '48px' });
   });
-
 });

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -129,6 +129,20 @@ describe('SlideLayout', () => {
     expect(getByText('Section title')).toBeDefined();
   });
 
+  it('SlideLayout.Section should render a section title within a react node', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Section
+        sectionTitle={
+          <>
+            Hello<em>World!</em>
+          </>
+        }
+      />
+    );
+
+    expect(getByText('World!')).toBeDefined();
+  });
+
   it('SlideLayout.Section should render a section slide with props passed through', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.Section
@@ -156,6 +170,20 @@ describe('SlideLayout', () => {
     );
 
     expect(getByText('Statement')).toBeDefined();
+  });
+
+  it('SlideLayout.Statement should render statement text within a react node', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Statement
+        statement={
+          <>
+            Hello<em>World!</em>
+          </>
+        }
+      />
+    );
+
+    expect(getByText('World!')).toBeDefined();
   });
 
   it('SlideLayout.Statement should render a statement slide with props passed through', () => {
@@ -209,12 +237,12 @@ describe('SlideLayout', () => {
     const { getByText } = renderInDeck(
       <SlideLayout.Quote
         quote={'To be, or not to be...'}
-        attribution={'-William Shakespeare'}
+        attribution={'William Shakespeare'}
       />
     );
 
     expect(getByText('To be, or not to be...')).toBeDefined();
-    expect(getByText('-William Shakespeare')).toBeDefined();
+    expect(getByText('William Shakespeare', { exact: false })).toBeDefined();
   });
 
   it('SlideLayout.Quote should render a slide with quote and attribution props passed through', () => {
@@ -234,6 +262,8 @@ describe('SlideLayout', () => {
         "I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."
       )
     ).toHaveStyle({ fontSize: '68px' });
-    expect(getByText('Maya Angelou')).toHaveStyle({ fontSize: '48px' });
+    expect(getByText('Maya Angelou', { exact: false })).toHaveStyle({
+      fontSize: '48px'
+    });
   });
 });

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -120,4 +120,116 @@ describe('SlideLayout', () => {
 
     expect(queryAllByTestId('AppearElement')).toHaveLength(3);
   });
+
+
+  it('SlideLayout.Section should render a section title', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Section
+        sectionTitle={"Section title"}
+      />
+    );
+
+    expect(getByText('Section title')).toBeDefined();
+  });
+
+  it('SlideLayout.Section should render a section slide with props passed through', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Section
+        sectionTitle={"Section title"}
+        sectionTitleProps={{ fontSize: '68px' }}
+      />
+    );
+
+    expect(getByText('Section title')).toHaveStyle({ fontSize: '68px' });
+  });
+
+  it('SlideLayout.Section should render a section title in a left aligned flexbox', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Section
+        sectionTitle={"Section title"}
+      />
+    );
+
+    expect(getByText('Section title').parentElement).toHaveStyle({ justifyContent: 'flex-start'});
+  });
+
+  it('SlideLayout.Statement should render statement text', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Statement
+        statement={"Statement"}
+      />
+    );
+
+    expect(getByText('Statement')).toBeDefined();
+  });
+
+  it('SlideLayout.Statement should render a statement slide with props passed through', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Statement
+        statement={"Statement"}
+        statementProps={{ fontSize: '88px' }}
+      />
+    );
+
+    expect(getByText('Statement')).toHaveStyle({ fontSize: '88px' });
+  });
+
+  it('SlideLayout.BigFact should render a slide with fact text', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.BigFact
+        fact={"100%"}
+      />
+    );
+
+    expect(getByText('100%')).toBeDefined();
+  });
+
+  it('SlideLayout.BigFact should render a slide with props passed through', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.BigFact
+        fact={"100%"}
+        factProps={{ fontSize: '88px' }}
+      />
+    );
+
+    expect(getByText('100%')).toHaveStyle({ fontSize: '88px' });
+  });
+
+  it('SlideLayout.BigFact should render a slide with fact information if it exists', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.BigFact
+        fact={"100%"}
+        factInformation={'We earned 100%!'}
+      />
+    );
+
+    expect(getByText('We earned 100%!')).toBeDefined();
+  });
+
+  it('SlideLayout.Quote should render a slide with a quote and attribution text', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Quote
+        quote={'To be, or not to be...'}
+        attribution={'-William Shakespeare'}
+      />
+    );
+
+    expect(getByText('To be, or not to be...')).toBeDefined();
+    expect(getByText('-William Shakespeare')).toBeDefined();
+  });
+
+  it('SlideLayout.Quote should render a slide with quote and attribution props passed through', () => {
+    const { getByText } = renderInDeck(
+      <SlideLayout.Quote
+        quote={"I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."}
+        quoteProps={{ fontSize: '68px' }}
+        attribution={"Maya Angelou"}
+        attributionProps={{ fontSize: '48px' }}
+      />
+    );
+
+    expect(getByText("I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel.")).toHaveStyle({ fontSize: '68px' });
+    expect(getByText("Maya Angelou")).toHaveStyle({ fontSize: '48px' });
+  });
+
 });

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -97,7 +97,7 @@ const Header = ({
   heading,
   ...rest
 }: Omit<SlideProps, 'children'> & {
-  heading: string;
+  heading: string | ReactNode;
   flexBoxProps?: ComponentProps<typeof FlexBox>;
   headingProps?: ComponentProps<typeof Heading>;
 }) => (
@@ -116,7 +116,7 @@ const Section = ({
   sectionTitleProps,
   ...rest
 }: Omit<SlideProps, 'children'> & {
-  sectionTitle: string;
+  sectionTitle: string | ReactNode;
   sectionTitleProps?: ComponentProps<typeof Heading>;
 }) => (
   <Header
@@ -134,7 +134,7 @@ const Statement = ({
   statementProps,
   ...rest
 }: Omit<SlideProps, 'children'> & {
-  statement: string;
+  statement: string | ReactNode;
   statementProps?: ComponentProps<typeof Heading>;
 }) => <Header heading={statement} headingProps={statementProps} />;
 

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -89,6 +89,26 @@ const List = ({
 };
 
 /**
+ * Generic vertically-centered Header layout
+ */
+const Header = ({
+  flexBoxProps,
+  headingProps,
+  heading,
+  ...rest
+}: Omit<SlideProps, 'children'> & {
+  heading: string;
+  flexBoxProps?: ComponentProps<typeof FlexBox>;
+  headingProps?: ComponentProps<typeof Heading>;
+}) => (
+  <Slide {...rest}>
+    <FlexBox height="100%" {...flexBoxProps}>
+      <Heading {...headingProps}>{heading}</Heading>
+    </FlexBox>
+  </Slide>
+);
+
+/**
  * Section layout with left aligned text
  */
 const Section = ({
@@ -99,11 +119,11 @@ const Section = ({
   sectionTitle: string;
   sectionTitleProps?: ComponentProps<typeof Heading>;
 }) => (
-  <Slide {...rest}>
-    <FlexBox justifyContent="flex-start" height="100%">
-      <Heading {...sectionTitleProps}>{sectionTitle}</Heading>
-    </FlexBox>
-  </Slide>
+  <Header
+    heading={sectionTitle}
+    headingProps={sectionTitleProps}
+    flexBoxProps={{ justifyContent: 'flex-start' }}
+  />
 );
 
 /**
@@ -116,13 +136,7 @@ const Statement = ({
 }: Omit<SlideProps, 'children'> & {
   statement: string;
   statementProps?: ComponentProps<typeof Heading>;
-}) => (
-  <Slide {...rest}>
-    <FlexBox height="100%">
-      <Heading {...statementProps}>{statement}</Heading>
-    </FlexBox>
-  </Slide>
-);
+}) => <Header heading={statement} headingProps={statementProps} />;
 
 /**
  * Big Fact with optional fact information

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -94,16 +94,15 @@ const List = ({
 const Header = ({
   flexBoxProps,
   headingProps,
-  heading,
+  children,
   ...rest
-}: Omit<SlideProps, 'children'> & {
-  heading: string | ReactNode;
+}: SlideProps & {
   flexBoxProps?: ComponentProps<typeof FlexBox>;
   headingProps?: ComponentProps<typeof Heading>;
 }) => (
   <Slide {...rest}>
     <FlexBox height="100%" {...flexBoxProps}>
-      <Heading {...headingProps}>{heading}</Heading>
+      <Heading {...headingProps}>{children}</Heading>
     </FlexBox>
   </Slide>
 );
@@ -112,31 +111,30 @@ const Header = ({
  * Section layout with left aligned text
  */
 const Section = ({
-  sectionTitle,
-  sectionTitleProps,
+  sectionProps,
+  children,
   ...rest
-}: Omit<SlideProps, 'children'> & {
-  sectionTitle: string | ReactNode;
-  sectionTitleProps?: ComponentProps<typeof Heading>;
+}: SlideProps & {
+  sectionProps?: ComponentProps<typeof Heading>;
 }) => (
   <Header
-    heading={sectionTitle}
-    headingProps={sectionTitleProps}
+    headingProps={sectionProps}
     flexBoxProps={{ justifyContent: 'flex-start' }}
-  />
+  >
+    {children}
+  </Header>
 );
 
 /**
  * Statement layout with centered text
  */
 const Statement = ({
-  statement,
   statementProps,
+  children,
   ...rest
-}: Omit<SlideProps, 'children'> & {
-  statement: string | ReactNode;
+}: SlideProps & {
   statementProps?: ComponentProps<typeof Heading>;
-}) => <Header heading={statement} headingProps={statementProps} />;
+}) => <Header headingProps={statementProps}>{children}</Header>;
 
 /**
  * Big Fact with optional fact information

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -147,8 +147,8 @@ const BigFact = ({
   factInformationProps,
   ...rest
 }: Omit<SlideProps, 'children'> & {
-  fact: string;
-  factInformation?: string;
+  fact: string | ReactNode;
+  factInformation?: string | ReactNode;
   factProps?: ComponentProps<typeof Text>;
   factFontSize?: string;
   factInformationProps?: ComponentProps<typeof Text>;

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -179,9 +179,9 @@ const Quote = ({
   attributionProps,
   ...rest
 }: Omit<SlideProps, 'children'> & {
-  quote: string;
+  quote: string | ReactNode;
   quoteProps?: ComponentProps<typeof Text>;
-  attribution: string;
+  attribution: string | ReactNode;
   attributionProps?: ComponentProps<typeof Text>;
 }) => (
   <Slide {...rest}>

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -192,7 +192,7 @@ const Quote = ({
         {quote}
       </Text>
       <Text fontSize="36px" padding={'0em 0em 0em 1em'} {...attributionProps}>
-        {attribution}
+        &ndash;{attribution}
       </Text>
     </Box>
   </Slide>

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -145,18 +145,20 @@ const BigFact = ({
   fact,
   factInformation,
   factProps,
+  factFontSize = '250px',
   factInformationProps,
   ...rest
 }: Omit<SlideProps, 'children'> & {
   fact: string;
   factInformation?: string;
   factProps?: ComponentProps<typeof Text>;
+  factFontSize?: string;
   factInformationProps?: ComponentProps<typeof Text>;
 }) => (
   <Slide {...rest}>
     <FlexBox>
       <Box>
-        <Text fontSize="250px" textAlign="center" {...factProps}>
+        <Text textAlign="center" fontSize={factFontSize} {...factProps}>
           {fact}
         </Text>
         {factInformation ? (

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -1,7 +1,7 @@
 import Slide, { SlideProps } from './slide/slide';
 import { Box, FlexBox } from './layout-primitives';
 import { ComponentProps, Fragment, ReactNode } from 'react';
-import { Heading, ListItem, OrderedList, UnorderedList } from './typography';
+import { Heading, Text, ListItem, OrderedList, UnorderedList } from './typography';
 import { Appear } from './appear';
 
 /**
@@ -83,13 +83,59 @@ const List = ({
 };
 
 /**
+ * Section layout with left aligned text
+ */
+ const Section = ({ sectionTitle, sectionTitleProps, ...rest }: Omit<SlideProps, 'children'> & { sectionTitle: string; sectionTitleProps?: ComponentProps<typeof Heading>; }) => (
+  <Slide {...rest}>
+    <FlexBox justifyContent="flex-start" height="100%">
+      <Heading {...sectionTitleProps}>{sectionTitle}</Heading>
+    </FlexBox>
+  </Slide>
+);
+
+/**
+ * Statement layout with centered text
+ */
+ const Statement = ({ statement, statementProps, ...rest }: Omit<SlideProps, 'children'> & { statement: string; statementProps?: ComponentProps<typeof Heading>;}) => (
+  <Slide {...rest}>
+    <FlexBox height="100%">
+      <Heading {...statementProps}>{statement}</Heading>
+    </FlexBox>
+  </Slide>
+);
+
+/**
+ * Big Fact with optional fact information
+ */
+const BigFact = ({ fact, factInformation, factProps, factInformationProps, ...rest }: Omit<SlideProps, 'children'> & {fact: string; factInformation?: string; factProps?: ComponentProps<typeof Text>; factInformationProps?: ComponentProps<typeof Text>;}) => (
+  <Slide {...rest}>
+    <FlexBox>
+      <Box>
+        <Text fontSize="250px" textAlign="center" {...factProps}>{fact}</Text>
+          {factInformation ? 
+          <Text textAlign="center" {...factInformationProps}>{factInformation}</Text>
+          : null}
+      </Box>
+    </FlexBox>
+  </Slide>
+);
+
+/**
+ * Quote layout
+ */
+ const Quote = ({ quote, quoteProps, attribution, attributionProps, ...rest }: Omit<SlideProps, 'children'> & {quote: string; quoteProps?: ComponentProps<typeof Text>; attribution: string; attributionProps?: ComponentProps<typeof Text>}) => (
+  <Slide {...rest}>
+    <Box width="100%" margin="auto">
+        <Text fontSize="85px" {...quoteProps}>{quote}</Text>
+        <Text fontSize="36px" padding={'0em 0em 0em 1em'} {...attributionProps}>{attribution}</Text>
+    </Box>
+  </Slide>
+);
+/**
  * Layouts to consider:
  * - Image (left, right, full bleed?)
  * - Intro
- * - Quote
- * - Section
- * - Statement?
- * - Big fact?
+ * - Code Snippet (syntax highlighting)
  */
 
-export default { Full, Center, TwoColumn, List };
+export default { Full, Center, TwoColumn, List, Section, BigFact, Quote, Statement  };

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -1,7 +1,13 @@
 import Slide, { SlideProps } from './slide/slide';
 import { Box, FlexBox } from './layout-primitives';
 import { ComponentProps, Fragment, ReactNode } from 'react';
-import { Heading, Text, ListItem, OrderedList, UnorderedList } from './typography';
+import {
+  Heading,
+  Text,
+  ListItem,
+  OrderedList,
+  UnorderedList
+} from './typography';
 import { Appear } from './appear';
 
 /**
@@ -85,7 +91,14 @@ const List = ({
 /**
  * Section layout with left aligned text
  */
- const Section = ({ sectionTitle, sectionTitleProps, ...rest }: Omit<SlideProps, 'children'> & { sectionTitle: string; sectionTitleProps?: ComponentProps<typeof Heading>; }) => (
+const Section = ({
+  sectionTitle,
+  sectionTitleProps,
+  ...rest
+}: Omit<SlideProps, 'children'> & {
+  sectionTitle: string;
+  sectionTitleProps?: ComponentProps<typeof Heading>;
+}) => (
   <Slide {...rest}>
     <FlexBox justifyContent="flex-start" height="100%">
       <Heading {...sectionTitleProps}>{sectionTitle}</Heading>
@@ -96,7 +109,14 @@ const List = ({
 /**
  * Statement layout with centered text
  */
- const Statement = ({ statement, statementProps, ...rest }: Omit<SlideProps, 'children'> & { statement: string; statementProps?: ComponentProps<typeof Heading>;}) => (
+const Statement = ({
+  statement,
+  statementProps,
+  ...rest
+}: Omit<SlideProps, 'children'> & {
+  statement: string;
+  statementProps?: ComponentProps<typeof Heading>;
+}) => (
   <Slide {...rest}>
     <FlexBox height="100%">
       <Heading {...statementProps}>{statement}</Heading>
@@ -107,14 +127,29 @@ const List = ({
 /**
  * Big Fact with optional fact information
  */
-const BigFact = ({ fact, factInformation, factProps, factInformationProps, ...rest }: Omit<SlideProps, 'children'> & {fact: string; factInformation?: string; factProps?: ComponentProps<typeof Text>; factInformationProps?: ComponentProps<typeof Text>;}) => (
+const BigFact = ({
+  fact,
+  factInformation,
+  factProps,
+  factInformationProps,
+  ...rest
+}: Omit<SlideProps, 'children'> & {
+  fact: string;
+  factInformation?: string;
+  factProps?: ComponentProps<typeof Text>;
+  factInformationProps?: ComponentProps<typeof Text>;
+}) => (
   <Slide {...rest}>
     <FlexBox>
       <Box>
-        <Text fontSize="250px" textAlign="center" {...factProps}>{fact}</Text>
-          {factInformation ? 
-          <Text textAlign="center" {...factInformationProps}>{factInformation}</Text>
-          : null}
+        <Text fontSize="250px" textAlign="center" {...factProps}>
+          {fact}
+        </Text>
+        {factInformation ? (
+          <Text textAlign="center" {...factInformationProps}>
+            {factInformation}
+          </Text>
+        ) : null}
       </Box>
     </FlexBox>
   </Slide>
@@ -123,11 +158,26 @@ const BigFact = ({ fact, factInformation, factProps, factInformationProps, ...re
 /**
  * Quote layout
  */
- const Quote = ({ quote, quoteProps, attribution, attributionProps, ...rest }: Omit<SlideProps, 'children'> & {quote: string; quoteProps?: ComponentProps<typeof Text>; attribution: string; attributionProps?: ComponentProps<typeof Text>}) => (
+const Quote = ({
+  quote,
+  quoteProps,
+  attribution,
+  attributionProps,
+  ...rest
+}: Omit<SlideProps, 'children'> & {
+  quote: string;
+  quoteProps?: ComponentProps<typeof Text>;
+  attribution: string;
+  attributionProps?: ComponentProps<typeof Text>;
+}) => (
   <Slide {...rest}>
     <Box width="100%" margin="auto">
-        <Text fontSize="85px" {...quoteProps}>{quote}</Text>
-        <Text fontSize="36px" padding={'0em 0em 0em 1em'} {...attributionProps}>{attribution}</Text>
+      <Text fontSize="85px" {...quoteProps}>
+        {quote}
+      </Text>
+      <Text fontSize="36px" padding={'0em 0em 0em 1em'} {...attributionProps}>
+        {attribution}
+      </Text>
     </Box>
   </Slide>
 );
@@ -138,4 +188,13 @@ const BigFact = ({ fact, factInformation, factProps, factInformationProps, ...re
  * - Code Snippet (syntax highlighting)
  */
 
-export default { Full, Center, TwoColumn, List, Section, BigFact, Quote, Statement  };
+export default {
+  Full,
+  Center,
+  TwoColumn,
+  List,
+  Section,
+  BigFact,
+  Quote,
+  Statement
+};


### PR DESCRIPTION
Description

The changes in the PR add four new types of Slide Layouts: Section, Statement, Big fact, and Quote. These layouts were modeled after Keynote slide templates with the goal of making slide creation quicker and easier for common use cases.

Type of Change
[ x ] New feature (non-breaking change which adds functionality)
How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
The changes include adding new tests in packages/spectacle/src/components/slide-layout.test.tsx
While developing the feature, I manually consumed the layout components in the Presentation deck in index.tsx

Checklist: (Feel free to delete this section upon completion)
[ n/a ] I have included a [changeset](https://github.com/FormidableLabs/spectacle/CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
[ x ] I have performed a self-review of my own code
[ x ] I have commented my code, particularly in hard-to-understand areas
[ x ] I have made corresponding changes to the documentation
[ x ] I have run pnpm run check:ci and all checks pass
[ x ] I have added tests that prove my fix is effective or that my feature works
[ x ] My changes generate no new warnings
[ n/a ] Any dependent changes have been merged and published in downstream modules