### PR TITLE
Fix eslint integration to ensure prettier/react warnings show

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,11 +6,7 @@
     "plugin:react-hooks/recommended",
     "prettier"
   ],
-  "plugins": [
-    "react",
-    "react-hooks",
-    "@typescript-eslint"
-  ],
+  "plugins": ["prettier", "react", "react-hooks", "@typescript-eslint"],
   "env": {
     "browser": true,
     "commonjs": true,
@@ -37,7 +33,12 @@
   },
   "rules": {
     "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
+    "prettier/prettier": ["error"],
+    "quotes": ["error", "single", { "allowTemplateLiterals": true }],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error"]
   },
   "overrides": [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "printWidth": 80,
   "trailingComma": "none",
-  "endOfLine": "lf"
+  "endOfLine": "lf",
+  "semi": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "search.exclude": {
-    "**/node_modules": true,
-    "**/lib": true,
-    "**/es": true,
-    "**/dist": true
-  }
-}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "^7.27.0",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^28.1.3",

--- a/packages/create-spectacle/src/cli.ts
+++ b/packages/create-spectacle/src/cli.ts
@@ -14,7 +14,7 @@ import {
   writeOnePageHTMLFile
 } from './templates/file-writers';
 // @ts-ignore
-import { version, devDependencies } from '../package.json';
+import { devDependencies } from '../package.json';
 
 const argv = yargs(hideBin(process.argv)).argv;
 const cwd = process.cwd();

--- a/packages/create-spectacle/test/e2e.test.ts
+++ b/packages/create-spectacle/test/e2e.test.ts
@@ -16,7 +16,7 @@ describe('App.js', () => {
     await page.goto('http://localhost:3000');
 
     // TODO: GET BETTER SELECTORS
-    const sel = "div[font-family='header'][font-size='h2']";
+    const sel = `div[font-family='header'][font-size='h2']`;
     await page.waitForSelector(sel);
     const text = await page.$eval(sel, (e) => e.textContent);
     expect(text).toContain('Made with');

--- a/packages/spectacle/src/components/animated-progress.tsx
+++ b/packages/spectacle/src/components/animated-progress.tsx
@@ -2,11 +2,10 @@ import {
   forwardRef,
   useContext,
   useEffect,
-  useRef,
   useState,
   useCallback
 } from 'react';
-import styled, { keyframes, css } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { DeckContext } from './deck/deck';
 import {
   ProgressContainer,

--- a/packages/spectacle/src/components/appear.tsx
+++ b/packages/spectacle/src/components/appear.tsx
@@ -85,8 +85,6 @@ export const Stepper = (props: StepperProps): JSX.Element => {
     render: renderFn,
     children: renderChildrenFn,
     alwaysVisible = false,
-    activeStyle,
-    inactiveStyle,
     ...restProps
   } = props;
   if (renderFn !== undefined && renderChildrenFn !== undefined) {

--- a/packages/spectacle/src/components/code-pane.tsx
+++ b/packages/spectacle/src/components/code-pane.tsx
@@ -102,7 +102,7 @@ const CodePane = forwardRef<HTMLDivElement, CodePaneProps>(
     }, [highlightRanges]);
 
     const theme = useContext(ThemeContext);
-    const { stepId, isActive, step, placeholder } = useSteps(numberOfSteps, {
+    const { isActive, step, placeholder } = useSteps(numberOfSteps, {
       stepIndex
     });
 

--- a/packages/spectacle/src/components/deck/default-deck.tsx
+++ b/packages/spectacle/src/components/deck/default-deck.tsx
@@ -50,7 +50,7 @@ const DefaultDeck = (props: DefaultDeckProps): JSX.Element => {
             deck.current!.regressSlide({
               stepIndex: 0
             }),
-          [KEYBOARD_SHORTCUTS.SELECT_SLIDE_OVERVIEW_MODE]: (e) =>
+          [KEYBOARD_SHORTCUTS.SELECT_SLIDE_OVERVIEW_MODE]: () =>
             toggleMode({
               newMode: SPECTACLE_MODES.DEFAULT_MODE
             })

--- a/packages/spectacle/src/components/markdown/markdown.test.tsx
+++ b/packages/spectacle/src/components/markdown/markdown.test.tsx
@@ -137,7 +137,7 @@ describe('<MarkdownSlideSet />', () => {
   });
 
   it('Markdown should pass componentProps down to constituent components', () => {
-    const { container, queryByText } = mountInsideDeck(
+    const { queryByText } = mountInsideDeck(
       <Slide>
         <Heading>Im not styled...</Heading>
         <Markdown componentProps={{ color: 'purple' }}>{`

--- a/packages/spectacle/src/components/markdown/markdown.tsx
+++ b/packages/spectacle/src/components/markdown/markdown.tsx
@@ -123,7 +123,7 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
           // Replace \r\n and \n with <br /> for paragraphs
           const children =
             key === 'p'
-              ? props.children?.map((child: any, i: number) => {
+              ? props.children?.map((child: any) => {
                   if (typeof child == 'string') {
                     const lines = child.split(/\r\n|\n/g);
                     return lines.map((str, i) => (

--- a/packages/spectacle/src/components/slide-layout.test.tsx
+++ b/packages/spectacle/src/components/slide-layout.test.tsx
@@ -265,7 +265,7 @@ describe('SlideLayout', () => {
 
     expect(
       getByText(
-        "I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."
+        `I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel.`
       )
     ).toHaveStyle({ fontSize: '68px' });
     expect(getByText('Maya Angelou', { exact: false })).toHaveStyle({

--- a/packages/spectacle/src/components/slide-layout.tsx
+++ b/packages/spectacle/src/components/slide-layout.tsx
@@ -112,8 +112,7 @@ const Header = ({
  */
 const Section = ({
   sectionProps,
-  children,
-  ...rest
+  children
 }: SlideProps & {
   sectionProps?: ComponentProps<typeof Heading>;
 }) => (
@@ -130,8 +129,7 @@ const Section = ({
  */
 const Statement = ({
   statementProps,
-  children,
-  ...rest
+  children
 }: SlideProps & {
   statementProps?: ComponentProps<typeof Heading>;
 }) => <Header headingProps={statementProps}>{children}</Header>;

--- a/packages/spectacle/src/components/table.test.tsx
+++ b/packages/spectacle/src/components/table.test.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren, ReactElement } from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
 import { ThemeProvider } from 'styled-components';
 
 import defaultTheme from '../theme/default-theme';

--- a/packages/spectacle/src/hooks/use-deck-state.ts
+++ b/packages/spectacle/src/hooks/use-deck-state.ts
@@ -1,4 +1,4 @@
-import { useReducer, useMemo, useEffect } from 'react';
+import { useReducer, useMemo } from 'react';
 import { merge } from 'merge-anything';
 import { SlideId } from '../components/deck/deck';
 

--- a/packages/spectacle/src/hooks/use-full-screen.test.tsx
+++ b/packages/spectacle/src/hooks/use-full-screen.test.tsx
@@ -1,5 +1,5 @@
 import { useToggleFullScreen } from './use-full-screen';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 const oldDocumentFullscreenElement = document.fullscreenElement;

--- a/packages/spectacle/src/hooks/use-location-sync.ts
+++ b/packages/spectacle/src/hooks/use-location-sync.ts
@@ -61,7 +61,7 @@ export default function useLocationSync({
   // "down-sync" from location to state
   useEffect(() => {
     if (!initialized && disableInteractivity) return;
-    return history.listen((location, action) => {
+    return history.listen((location) => {
       setState(mapLocationToState(location));
     });
   }, [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,7 @@ importers:
       cross-env: ^7.0.3
       eslint: ^8.2.0
       eslint-config-prettier: ^8.3.0
+      eslint-plugin-prettier: ^3.3.1
       eslint-plugin-react: ^7.27.0
       eslint-plugin-react-hooks: ^4.3.0
       html-webpack-plugin: ^5.5.0
@@ -72,6 +73,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.21.0
       eslint-config-prettier: 8.5.0_eslint@8.21.0
+      eslint-plugin-prettier: 3.4.1_h62lvancfh4b7r6zn2dgodrh5e
       eslint-plugin-react: 7.30.1_eslint@8.21.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.21.0
       html-webpack-plugin: 5.5.0_webpack@5.74.0
@@ -7064,6 +7066,23 @@ packages:
       eslint: 8.21.0
     dev: true
 
+  /eslint-plugin-prettier/3.4.1_h62lvancfh4b7r6zn2dgodrh5e:
+    resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      eslint: '>=5.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=1.13.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.21.0
+      eslint-config-prettier: 8.5.0_eslint@8.21.0
+      prettier: 2.7.1
+      prettier-linter-helpers: 1.0.0
+    dev: true
+
   /eslint-plugin-react-hooks/4.6.0_eslint@8.21.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -7421,6 +7440,10 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
+  /fast-diff/1.2.0:
+    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
   /fast-equals/2.0.4:
@@ -11463,6 +11486,13 @@ packages:
   /prepend-http/2.0.0:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /prettier-linter-helpers/1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      fast-diff: 1.2.0
     dev: true
 
   /prettier/1.19.1:

--- a/website/src/components/global/oss-badge.tsx
+++ b/website/src/components/global/oss-badge.tsx
@@ -20,7 +20,7 @@ interface OSSBadge {
   hoverable: boolean;
 }
 
-export const OSSBadge = ({ project, hoverable }: OSSBadge) => {
+const OSSBadge = ({ project, hoverable }: OSSBadge) => {
   const projectName = project.title.toLowerCase();
   const isFeaturedProject = Boolean(
     FEATURED_PROJECTS.find((p) => p === projectName)
@@ -53,3 +53,5 @@ export const OSSBadge = ({ project, hoverable }: OSSBadge) => {
     <span className={wrapperClassName}>{children}</span>
   );
 };
+
+export { OSSBadge };


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

In our migration we dropped support for prettier eslint. This adds it back and should correctly show errors. 

**Examples of errors working in VSCode and Nova**

<img width="1093" alt="Screen Shot 2022-08-24 at 1 40 06 PM" src="https://user-images.githubusercontent.com/1738349/186504863-7f16a269-af7a-4cde-8e95-27c688e34ed3.png">
<img width="676" alt="Screen Shot 2022-08-24 at 1 40 52 PM" src="https://user-images.githubusercontent.com/1738349/186504867-387e0394-1d33-4740-8d63-875576f7a02c.png">

This PR also fixes the lint issues uncovered.

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

###