### PR TITLE
Fix Markdown rendering inside templates.

### DIFF
--- a/.changeset/tiny-buses-fold.md
+++ b/.changeset/tiny-buses-fold.md
@@ -1,0 +1,5 @@
+---
+'spectacle': patch
+---
+
+Fixed Notes node tree generation inside Markdown component.

--- a/packages/spectacle/src/components/markdown/markdown.tsx
+++ b/packages/spectacle/src/components/markdown/markdown.tsx
@@ -178,10 +178,15 @@ export const Markdown = forwardRef<HTMLDivElement, MarkdownProps>(
         });
 
       // Transform and compile the notes AST.
-      const transformedNotesAst = notesCompiler.runSync(extractedNotes);
-      const noteElements = notesCompiler.stringify(transformedNotesAst);
-
-      return [templateProps, noteElements] as const;
+      if (
+        Array.isArray(extractedNotes.children) &&
+        extractedNotes.children.length >= 1
+      ) {
+        const transformedNotesAst = notesCompiler.runSync(extractedNotes);
+        const noteElements = notesCompiler.stringify(transformedNotesAst);
+        return [templateProps, noteElements] as const;
+      }
+      return [templateProps, null] as const;
     }, [
       rawMarkdownText,
       getPropsForAST,


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Fixes a bug where a Markdown component inside a Deck template would break Spectacle. The previous implementation of Markdown always creates a Notes node tree, even with undefined children if there are no notes, which cannot exist on a template as it's not a slide. This verifies there is note content before building the Notes node tree.



#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Add a `<Markdown />` component with text content to a Deck template before this change and see Spectacle break and fail to render. Check it after and see it correctly render the Markdown component. 

Example below showing a Markdown component on the template and notes inside a Markdown slide verifying no regressions introduced.

<img width="1370" alt="Screen Shot 2022-09-10 at 4 10 19 PM" src="https://user-images.githubusercontent.com/1738349/189502016-96512523-7d45-44f0-9e54-eea973f32998.png">


