### PR TITLE
Clean up issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,29 +11,37 @@ Have you read Formidable's Code of Conduct? By filing an Issue, you are expected
 
 ### Prerequisites
 
-**Feel free to delete this section if you have checked off all of the following.**
+<!-- Feel free to delete this section if you have checked off all of the following: -->
 
-- [ ] I've searched open [issues](https://www.github.com/FormidableLabs/spectacle/issues) to make sure I'm not opening a duplicate issue
+- [ ] I have searched the open [issues](https://www.github.com/FormidableLabs/spectacle/issues) to make sure I'm not opening a duplicate issue
 - [ ] I have read through the [docs](https://www.formidable.com/open-source/spectacle/docs) before asking a question
 - [ ] I am using the latest version of Spectacle
 
 ### Describe Your Environment
 
-What version of Spectacle are you using? (can be found by running `npm list spectacle`)
+**What version of Spectacle are you using?** (can be found by running `npm list --depth 0 spectacle`)
 
-What version of React are you using? (can be found by running `npm list react`)
+**What version of React are you using?** (can be found by running `npm list --depth 0 react`)
 
-What browser are you using?
+**What browser are you using?** (e.g., Chrome 105.0.5195.102, Safari 16.0)
 
-What machine are you on?
+**What platform are you on?** (e.g., Windows, macOS, iOS, Android)
 
 ### Describe the Problem
 
+<!--
+
 It's easier to show us than tell us what's going wrong with your code. Because of this, we ask that you do one of three things to help us reproduce the bug:
 
-1.  Create a public minimal repository that we can `git clone`, with install + error reproduction steps in the README.
-2.  Fork our [simple Spectacle sample Sandbox](https://codesandbox.io/s/simple-spectacle-example-3jebu), reproduce your issue in the code, and paste the link here.
+1.  Fork one of the codesandbox examples below, reproduce your issue in the code, and paste the link in this section.
+    Simple Spectacle Example:
+    https://codesandbox.io/s/lq1tbm
+    TypeScript version:
+    https://codesandbox.io/s/kqotzi
+2.  Create a public minimal repository that we can `git clone`, with install + error reproduction steps in the README.
 3.  Open up a PR, include "WIP" and the Issue # in the title, and point us to the failing regression tests.
+
+-->
 
 **Expected behavior:** [What you expect to happen]
 
@@ -41,4 +49,4 @@ It's easier to show us than tell us what's going wrong with your code. Because o
 
 ### Additional Information
 
-Any additional information, configuration or data that might be necessary to reproduce the issue.
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,12 +11,12 @@ Have you read Formidable's Code of Conduct? By filing an Issue, you are expected
 
 ### Description
 
-Including the problem you want to address, use cases, benefits, and/or goals.
+<!-- Including the problem you want to address, use cases, benefits, and/or goals. -->
 
 ### Proposal
 
-How do you propose we implement this change?
+<!-- How do you propose we implement this change? -->
 
 ### Links / References
 
-Any resources you want to point to for reference or more information.
+<!-- Any resources you want to point to for reference or more information. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,8 +11,8 @@ Have you read Formidable's Code of Conduct? By filing an Issue, you are expected
 
 ### Question
 
-What question do you have about using Spectacle?
+<!-- What question do you have about using Spectacle? -->
 
 ### Background Info/Attempts
 
-Any background information that might help us answer your questions, or a code snippet or link to a code example if you have an implementation question.
+<!-- Any background information that might help us answer your questions, or a code snippet or link to a code example (e.g., using codesandbox.io/s/lq1tbm) if you have an implementation question. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Fixes # (issue)
 
 #### Type of Change
 
-Please delete options that are not relevant (including this descriptive text).
+<!-- Please delete options that are not relevant (including this descriptive text). -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -21,7 +21,7 @@ Please delete options that are not relevant (including this descriptive text).
 
 ### How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 ### Checklist: (Feel free to delete this section upon completion)
 


### PR DESCRIPTION
### Description

I converted most of the instructional text for each section into comments, because the ambiguity about whether people should delete them or not usually results in a lot of them ending up in issues that are submitted, adding to visual clutter and making the important information harder to find.

I also updated the codesandbox links that are referenced to a couple that have been updated to the latest dependencies, one for JS and one for TS. Those are currently under my personal codesandbox account, but we can fork them over to any other (company?) account if there are concerns about maintaining them. 

#### Type of Change

Github-facing only

### How Has This Been Tested?

N/A
