### PR TITLE
Export useSteps

### DIFF
--- a/.changeset/three-bikes-unite.md
+++ b/.changeset/three-bikes-unite.md
@@ -1,0 +1,5 @@
+---
+'spectacle': minor
+---
+
+exports the `useSteps` hook

--- a/packages/spectacle/src/index.ts
+++ b/packages/spectacle/src/index.ts
@@ -44,6 +44,7 @@ export { default as indentNormalizer } from './utils/indent-normalizer';
 export { DeckContext } from './components/deck/deck';
 export type { DeckProps, SlideId } from './components/deck/deck';
 export { default as useMousetrap } from './hooks/use-mousetrap';
+export { useSteps } from './hooks/use-steps';
 export { default as defaultTheme } from './theme/default-theme';
 export type {
   SpectacleTheme,


### PR DESCRIPTION


### Description

`useSteps`, in spite of being in [the documentation](https://formidable.com/open-source/spectacle/docs/api-reference#usesteps), is not currently exported from the library. This PR exports it.

The PR was inspired by #1019 

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

It has not been tested. The hook is used internally without issue, and the export didn't throw errors and shows its TypeScript type as expected.