### PR TITLE
Docs and PR template tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: Feature Request
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,7 @@
 ---
 name: Question
 about: Ask a question about using Spectacle.
+labels: 🤔 Question
 ---
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Have you read Formidable's Code of Conduct? By filing an Issue, you are expected
 
 ### Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
 Fixes # (issue)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Come learn more at our [docs site]!
 Have a question about Spectacle? Submit an issue in this repository using the
 ["Question" template](https://github.com/FormidableLabs/spectacle/issues/new?template=question.md).
 
-Notice something inaccurate or confusing? Feel free to [open an issue](https://github.com/FormidableLabs/spectacle/issues) or [make a pull request](https://github.com/FormidableLabs/spectacle/pulls) to help improve the documentation for everyone!
+Notice something inaccurate or confusing? Feel free to [open an issue](https://github.com/FormidableLabs/spectacle/issues/new/choose) or [make a pull request](https://github.com/FormidableLabs/spectacle/pulls) to help improve the documentation for everyone!
 
 The source for our docs site lives in this repo in the [`docs`](https://github.com/FormidableLabs/spectacle/blob/main/docs/README.md) folder.
 

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Please see our [contributing guide](CONTRIBUTING.md).
 
 **Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 
-[docs site]: https://www.formidable.com/open-source/spectacle
+[docs site]: https://www.formidable.com/open-source/spectacle/docs/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Have a question about Spectacle? Submit an issue in this repository using the
 
 Notice something inaccurate or confusing? Feel free to [open an issue](https://github.com/FormidableLabs/spectacle/issues/new/choose) or [make a pull request](https://github.com/FormidableLabs/spectacle/pulls) to help improve the documentation for everyone!
 
-The source for our docs site lives in this repo in the [`docs`](https://github.com/FormidableLabs/spectacle/blob/main/docs/README.md) folder.
+The source for our docs site lives in this repo in the [`docs`](https://github.com/FormidableLabs/spectacle/blob/main/docs) folder.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/main/website/static/img/logo_spectacle.png" width=250></p>
+<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/ac6c9266/website/static/img/logo_spectacle.png" width=250></p>
 <h2 align="center">Spectacle</h2>
 <p align="center">
 <strong>✨ A ReactJS based Presentation Library ✨</strong>

--- a/packages/spectacle/README.md
+++ b/packages/spectacle/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/main/docs/src/assets/logo_spectacle.png" width=250></p>
+<p align="center"><img src="https://raw.githubusercontent.com/FormidableLabs/spectacle/ac6c9266/website/static/img/logo_spectacle.png" width=250></p>
 <h2 align="center">Spectacle</h2>
 <p align="center">
 <strong>✨ A ReactJS based Presentation Library ✨</strong>


### PR DESCRIPTION

### Description

Fixes some broken links in the READMEs and comments out one last line in the PR request template.

More direct docs link carried over from #952 

#### Type of Change

Internal/GitHub-facing-only. The docs site is not affected because only READMEs from GitHub are touched.

### How Has This Been Tested?

N/A