### PR TITLE
Fix autoPlayLoop

### DIFF
--- a/.changeset/gentle-berries-judge.md
+++ b/.changeset/gentle-berries-judge.md
@@ -1,0 +1,5 @@
+---
+'spectacle': patch
+---
+
+autoPlayLoop now works as intended

--- a/packages/spectacle/src/components/appear.tsx
+++ b/packages/spectacle/src/components/appear.tsx
@@ -60,7 +60,9 @@ type SteppedComponentProps = {
   children: ReactNode | ((step: number, isActive: boolean) => ReactNode);
   className?: string;
   tagName?: keyof JSX.IntrinsicElements;
+  // TODO v10: change this type to React.CSSProperties
   activeStyle?: Partial<CSSStyleDeclaration>;
+  // TODO v10: change this type to React.CSSProperties
   inactiveStyle?: Partial<CSSStyleDeclaration>;
   numSteps?: number;
   alwaysAppearActive?: boolean;
@@ -117,6 +119,8 @@ type StepperProps<T extends unknown[] = unknown[]> = {
   tagName?: keyof JSX.IntrinsicElements;
   values: T;
   alwaysVisible?: boolean;
+  // TODO v10: change this type to React.CSSProperties
   activeStyle?: Partial<CSSStyleDeclaration>;
+  // TODO v10: change this type to React.CSSProperties
   inactiveStyle?: Partial<CSSStyleDeclaration>;
 };

--- a/packages/spectacle/src/components/deck/deck.test.tsx
+++ b/packages/spectacle/src/components/deck/deck.test.tsx
@@ -1,9 +1,18 @@
 import Deck from './index';
 import Slide from '../slide/slide';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { CSSObject } from 'styled-components';
+import { Stepper } from '../appear';
 
 describe('<Deck />', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should allow for backdrop color overrides from theme prop', () => {
     const deckWithStyle = (
       backdropStyle: CSSObject,
@@ -33,5 +42,107 @@ describe('<Deck />', () => {
     expect(container.querySelector('.backdrop')).not.toHaveStyle({
       backgroundColor: 'black'
     });
+  });
+
+  it('should automatically advance with autoPlay=true', () => {
+    const slideNumberTracker = jest.fn();
+    const stepperActiveTracker = jest.fn();
+    const autoPlayInterval = 5000;
+
+    const deckWithExtraProps = (
+      props: Partial<React.ComponentProps<typeof Deck>>
+    ) => (
+      <Deck
+        autoPlay
+        autoPlayInterval={autoPlayInterval}
+        {...props}
+        template={({ slideNumber }) => {
+          slideNumberTracker(slideNumber);
+          return null;
+        }}
+      >
+        <Slide>Slide 1</Slide>
+        <Slide>Slide 2</Slide>
+        <Slide>
+          Slide 3
+          <Stepper values={[1]}>
+            {(_value, _step, isActive) => {
+              stepperActiveTracker(isActive);
+              return null;
+            }}
+          </Stepper>
+        </Slide>
+      </Deck>
+    );
+
+    const { rerender } = render(deckWithExtraProps({ autoPlayLoop: false }));
+
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(1);
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(false);
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay advanced to the next slide
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(2);
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay advanced to the final slide
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(false);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(3);
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay activated the stepper on the third slide
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(true);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(3);
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay stalled at the end as there are no more steps
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(true);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(3);
+
+    // Rerender with looping activated
+    rerender(deckWithExtraProps({ autoPlayLoop: true }));
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay looped around to the first slide
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(false);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(1);
+
+    // Skipping ahead to the last step on the last slide
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay brought us to the third slide with the stepper activated
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(true);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(3);
+
+    act(() => {
+      jest.advanceTimersByTime(autoPlayInterval);
+    });
+
+    // autoPlay looped around to the first slide
+    expect(stepperActiveTracker).toHaveBeenLastCalledWith(false);
+    expect(slideNumberTracker).toHaveBeenLastCalledWith(1);
   });
 });

--- a/packages/spectacle/src/components/deck/deck.tsx
+++ b/packages/spectacle/src/components/deck/deck.tsx
@@ -174,6 +174,7 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
       initialized,
       pendingView,
       activeView,
+      navigationDirection,
 
       initializeTo,
       skipTo,
@@ -434,6 +435,7 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
               onMobileSlide: onMobileSlide,
               theme: restTheme,
               autoPlayLoop,
+              navigationDirection,
 
               frameOverrideStyle: frameStyle,
               wrapperOverrideStyle: wrapperStyle,
@@ -521,7 +523,10 @@ type BackdropOverrides = {
 
 export type DeckRef = Omit<
   DeckStateAndActions,
-  'pendingView' | 'commitTransition' | 'cancelTransition'
+  | 'cancelTransition'
+  | 'commitTransition'
+  | 'navigationDirection'
+  | 'pendingView'
 > & {
   numberOfSlides: number;
 };

--- a/packages/spectacle/src/components/deck/deck.tsx
+++ b/packages/spectacle/src/components/deck/deck.tsx
@@ -44,7 +44,10 @@ import { KEYBOARD_SHORTCUTS_IDS } from '../../utils/constants';
 export type DeckContextType = {
   deckId: string | number;
   slideCount: number;
+  slideIds: SlideId[];
   useAnimations: boolean;
+  autoPlayLoop: boolean;
+  navigationDirection: number;
   slidePortalNode: HTMLDivElement;
   onSlideClick(e: MouseEvent, slideId: SlideId): void;
   onMobileSlide(eventData: SwipeEventData): void;
@@ -54,8 +57,6 @@ export type DeckContextType = {
   backdropNode: HTMLDivElement;
   notePortalNode: HTMLDivElement;
   initialized: boolean;
-  passedSlideIds: Set<SlideId>;
-  upcomingSlideIds: Set<SlideId>;
   activeView: {
     slideId: SlideId;
     slideIndex: number;
@@ -290,11 +291,7 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
       enabled: autoPlay,
       loop: autoPlayLoop,
       interval: autoPlayInterval,
-      navigation: {
-        skipTo,
-        stepForward,
-        isFinalSlide: activeView.slideIndex === slideIds.length - 1
-      }
+      stepForward
     });
 
     const handleSlideClick = useCallback<
@@ -309,22 +306,6 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
 
     const activeSlideId = slideIds[activeView.slideIndex];
     const pendingSlideId = slideIds[pendingView.slideIndex];
-
-    const [passed, upcoming] = useMemo(() => {
-      const p = new Set<SlideId>();
-      const u = new Set<SlideId>();
-      let foundActive = false;
-      for (const slideId of slideIds) {
-        if (foundActive) {
-          u.add(slideId);
-        } else if (slideId === activeSlideId) {
-          foundActive = true;
-        } else {
-          p.add(slideId);
-        }
-      }
-      return [p, u] as const;
-    }, [slideIds, activeSlideId]);
 
     const fullyInitialized = initialized && slideIdsInitialized;
 
@@ -446,11 +427,13 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
             value={{
               deckId,
               slideCount: slideIds.length,
+              slideIds,
               useAnimations,
               slidePortalNode: slidePortalNode!,
               onSlideClick: handleSlideClick,
               onMobileSlide: onMobileSlide,
               theme: restTheme,
+              autoPlayLoop,
 
               frameOverrideStyle: frameStyle,
               wrapperOverrideStyle: wrapperStyle,
@@ -458,8 +441,6 @@ export const DeckInternal = forwardRef<DeckRef, DeckInternalProps>(
               backdropNode: backdropRef.current!,
               notePortalNode: notePortalNode!,
               initialized: fullyInitialized,
-              passedSlideIds: passed,
-              upcomingSlideIds: upcoming,
               activeView: {
                 ...activeView,
                 slideId: activeSlideId

--- a/packages/spectacle/src/components/slide/slide.tsx
+++ b/packages/spectacle/src/components/slide/slide.tsx
@@ -161,6 +161,9 @@ const Slide = (props: SlideProps): JSX.Element => {
       return [false, false];
     }
     if (slideCount === 2) {
+      // The 2-slide case results in some janky animation when wrapping from end
+      // to start, but that's the best overall behavior that could be achieved
+      // without majorly reworking the animation logic.
       if (slideIndex === activeView.slideIndex) {
         return [false, false];
       }

--- a/packages/spectacle/src/components/slide/slide.tsx
+++ b/packages/spectacle/src/components/slide/slide.tsx
@@ -117,6 +117,7 @@ const Slide = (props: SlideProps): JSX.Element => {
     onMobileSlide,
     useAnimations,
     autoPlayLoop,
+    navigationDirection,
     slidePortalNode,
     frameOverrideStyle = {},
     wrapperOverrideStyle = {},
@@ -229,19 +230,18 @@ const Slide = (props: SlideProps): JSX.Element => {
         stepIndex: finalStepIndex
       });
     } else {
-      const isSingleForwardStep =
-        activeView.stepIndex === pendingView.stepIndex - 1;
+      const isSingleForwardStep = navigationDirection > 0;
       // the step is happening within this slide
       setAnimate(isSingleForwardStep);
       commitTransition();
     }
   }, [
     activeView,
-    pendingView,
     advanceSlide,
     autoPlayLoop,
     commitTransition,
     finalStepIndex,
+    navigationDirection,
     isActive,
     pendingView,
     regressSlide,
@@ -258,15 +258,15 @@ const Slide = (props: SlideProps): JSX.Element => {
       setAnimate(false);
       cancelTransition();
     } else {
-      const isTransitionToNextSlide =
-        activeView.slideIndex === pendingView.slideIndex - 1;
-      setAnimate(isTransitionToNextSlide);
+      const isSingleForwardStep = navigationDirection > 0;
+      setAnimate(isSingleForwardStep);
     }
   }, [
     activeView.slideIndex,
     autoPlayLoop,
     cancelTransition,
     pendingView,
+    navigationDirection,
     willExit
   ]);
 
@@ -294,15 +294,16 @@ const Slide = (props: SlideProps): JSX.Element => {
         stepIndex: finalStepIndex
       });
     } else {
-      const isTransitionFromPreviousSlide =
-        activeView.slideIndex === pendingView.slideIndex - 1;
-      setAnimate(isTransitionFromPreviousSlide);
+      const isSingleForwardStep = navigationDirection > 0;
+
+      setAnimate(isSingleForwardStep);
       commitTransition();
     }
   }, [
     activeView,
     commitTransition,
     finalStepIndex,
+    navigationDirection,
     pendingView,
     willEnter
   ]);

--- a/packages/spectacle/src/hooks/use-deck-state.ts
+++ b/packages/spectacle/src/hooks/use-deck-state.ts
@@ -11,12 +11,14 @@ export type DeckView = {
 };
 export type DeckState = {
   initialized: boolean;
+  navigationDirection: number;
   activeView: DeckView;
   pendingView: DeckView;
 };
 
 const initialDeckState: DeckState = {
   initialized: false,
+  navigationDirection: 0,
   pendingView: {
     slideIndex: 0,
     stepIndex: 0
@@ -41,6 +43,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
   switch (type) {
     case 'INITIALIZE_TO':
       return {
+        navigationDirection: 0,
         activeView: merge(state.activeView, payload),
         pendingView: merge(state.pendingView, payload),
         initialized: true
@@ -53,6 +56,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
     case 'STEP_FORWARD':
       return {
         ...state,
+        navigationDirection: 1,
         pendingView: merge(state.pendingView, {
           stepIndex: state.pendingView.stepIndex + 1
         })
@@ -60,6 +64,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
     case 'STEP_BACKWARD':
       return {
         ...state,
+        navigationDirection: -1,
         pendingView: merge(state.pendingView, {
           stepIndex: state.pendingView.stepIndex - 1
         })
@@ -67,6 +72,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
     case 'ADVANCE_SLIDE':
       return {
         ...state,
+        navigationDirection: 1,
         pendingView: merge(state.pendingView, {
           stepIndex: 0,
           slideIndex: state.pendingView.slideIndex + 1
@@ -75,6 +81,7 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
     case 'REGRESS_SLIDE':
       return {
         ...state,
+        navigationDirection: -1,
         pendingView: merge(state.pendingView, {
           stepIndex: payload?.stepIndex ?? GOTO_FINAL_STEP,
           slideIndex: state.pendingView.slideIndex - 1
@@ -98,10 +105,13 @@ function deckReducer(state: DeckState, { type, payload = {} }: ReducerActions) {
 }
 
 export default function useDeckState(userProvidedInitialState: DeckView) {
-  const [{ initialized, pendingView, activeView }, dispatch] = useReducer(
-    deckReducer,
-    { ...initialDeckState, ...userProvidedInitialState }
-  );
+  const [
+    { initialized, navigationDirection, pendingView, activeView },
+    dispatch
+  ] = useReducer(deckReducer, {
+    ...initialDeckState,
+    ...userProvidedInitialState
+  });
   const actions = useMemo(
     () => ({
       initializeTo: (payload: Partial<DeckView>) =>
@@ -122,6 +132,7 @@ export default function useDeckState(userProvidedInitialState: DeckView) {
 
   return {
     initialized,
+    navigationDirection,
     pendingView,
     activeView,
     ...actions

--- a/packages/spectacle/src/utils/use-auto-play.test.ts
+++ b/packages/spectacle/src/utils/use-auto-play.test.ts
@@ -32,20 +32,30 @@ describe('useAutoPlay()', () => {
   });
 
   test('should call the skip to function on the final slide and when loop is enabled.', () => {
-    renderHook(() =>
-      useAutoPlay({
-        enabled: true,
-        interval: 1000,
-        loop: true,
-        navigation: {
-          stepForward,
-          skipTo,
-          isFinalSlide: true
-        }
-      })
+    const { rerender } = renderHook(
+      ({ isFinalSlide }) =>
+        useAutoPlay({
+          enabled: true,
+          interval: 1000,
+          loop: true,
+          navigation: {
+            stepForward,
+            skipTo,
+            isFinalSlide
+          }
+        }),
+      { initialProps: { isFinalSlide: false } }
     );
 
     jest.advanceTimersByTime(1000);
+    expect(stepForward).toBeCalledTimes(1);
+    expect(skipTo).toBeCalledTimes(0);
+
+    rerender({ isFinalSlide: true });
+
+    jest.advanceTimersByTime(1000);
+
+    expect(stepForward).toBeCalledTimes(1);
     expect(skipTo).toBeCalledTimes(1);
   });
 });

--- a/packages/spectacle/src/utils/use-auto-play.test.ts
+++ b/packages/spectacle/src/utils/use-auto-play.test.ts
@@ -3,7 +3,6 @@ import { useAutoPlay } from './use-auto-play';
 
 describe('useAutoPlay()', () => {
   const stepForward = jest.fn();
-  const skipTo = jest.fn();
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -19,43 +18,11 @@ describe('useAutoPlay()', () => {
       useAutoPlay({
         enabled: true,
         interval: 1000,
-        navigation: {
-          stepForward,
-          skipTo,
-          isFinalSlide: false
-        }
+        stepForward
       })
     );
 
     jest.advanceTimersByTime(2000);
     expect(stepForward).toBeCalledTimes(2);
-  });
-
-  test('should call the skip to function on the final slide and when loop is enabled.', () => {
-    const { rerender } = renderHook(
-      ({ isFinalSlide }) =>
-        useAutoPlay({
-          enabled: true,
-          interval: 1000,
-          loop: true,
-          navigation: {
-            stepForward,
-            skipTo,
-            isFinalSlide
-          }
-        }),
-      { initialProps: { isFinalSlide: false } }
-    );
-
-    jest.advanceTimersByTime(1000);
-    expect(stepForward).toBeCalledTimes(1);
-    expect(skipTo).toBeCalledTimes(0);
-
-    rerender({ isFinalSlide: true });
-
-    jest.advanceTimersByTime(1000);
-
-    expect(stepForward).toBeCalledTimes(1);
-    expect(skipTo).toBeCalledTimes(1);
   });
 });

--- a/packages/spectacle/src/utils/use-auto-play.ts
+++ b/packages/spectacle/src/utils/use-auto-play.ts
@@ -4,29 +4,23 @@ import { DeckStateAndActions } from '../hooks/use-deck-state';
 export type AutoPlayOptions = {
   enabled?: boolean;
   loop?: boolean;
-  navigation: Pick<DeckStateAndActions, 'skipTo' | 'stepForward'> & {
-    isFinalSlide: boolean;
-  };
+  stepForward: DeckStateAndActions['stepForward'];
   interval?: number;
 };
 
 export const useAutoPlay = ({
   enabled = false,
   loop = false,
-  navigation,
+  stepForward,
   interval = 1000
 }: AutoPlayOptions) => {
-  const navRef = useRef(navigation);
-  navRef.current = navigation;
+  const stepFn = useRef(stepForward);
+  stepFn.current = stepForward;
 
   useEffect(() => {
     if (enabled) {
       const id = setInterval(() => {
-        if (navRef.current.isFinalSlide && loop) {
-          navRef.current.skipTo({ slideIndex: 0, stepIndex: 0 });
-        } else {
-          navRef.current.stepForward();
-        }
+        stepFn.current();
       }, interval);
 
       return () => clearInterval(id);

--- a/packages/spectacle/src/utils/use-auto-play.ts
+++ b/packages/spectacle/src/utils/use-auto-play.ts
@@ -16,18 +16,20 @@ export const useAutoPlay = ({
   navigation,
   interval = 1000
 }: AutoPlayOptions) => {
-  const savedCallback = useRef(() => {
-    if (navigation.isFinalSlide && loop) {
-      navigation.skipTo({ slideIndex: 0, stepIndex: 0 });
-    } else {
-      navigation.stepForward();
-    }
-  });
+  const navRef = useRef(navigation);
+  navRef.current = navigation;
 
   useEffect(() => {
     if (enabled) {
-      const id = setInterval(savedCallback.current, interval);
+      const id = setInterval(() => {
+        if (navRef.current.isFinalSlide && loop) {
+          navRef.current.skipTo({ slideIndex: 0, stepIndex: 0 });
+        } else {
+          navRef.current.stepForward();
+        }
+      }, interval);
+
       return () => clearInterval(id);
     }
-  }, [enabled, interval]);
+  }, [enabled, interval, loop]);
 };


### PR DESCRIPTION
### Description

The `autoPlayLoop` prop did not actually make the slideshow loop when autoplaying.

The fix for that was fairly straightforward, but uncovered another bug - any `Appear` or `Stepper` components on the final slide would get skipped over when jumping from the final slide to the start. That required reworking the slide logic to wrap around to the start when the final step of the final slide was exceeded.

That again, was relatively straightforward, but uncovered another bug - animations occurring when wrapping from the end to the start of the slideshow were fairly rough, with slides coming and going seemingly randomly. A little work on existing internal logic fixed it for most cases, but due to the nature of the existing animation logic, I was unable to find a simple solution to the rough animations occurring when wrapping around with a two-slide presentation. It certainly is possible to rework the animations such that we don't need to make any compromises, but the scale of such a project went way beyond what I was prepared to do for this bugfix.

Fixes #1224

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I updated the existing `useAutoPlay` tests to account for the newer, simpler behavior of the hook, and added a new unit test to test `autoPlay`+`autoPlayLoop` behavior from the user's perspective.