### PR TITLE
Better error messages for useSteps and stepper components

### DIFF
--- a/.changeset/serious-seals-divide.md
+++ b/.changeset/serious-seals-divide.md
@@ -1,0 +1,5 @@
+---
+'spectacle': minor
+---
+
+provide better error messages when useSteps or stepper components are used in the wrong context

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,7 +89,7 @@ These tags are for adding tables with content to your slides.
 
 ## useSteps
 
-The `useSteps` hook allows a component to participate in the _slide step sequence_ for a given Slide.
+The `useSteps` hook allows a component to participate in the _slide step sequence_ for a given Slide. It must be called inside a component that sits somewhere underneath a slide component, i.e., `<Slide><MyComponentThatUsesUseStepsInside /></Slide>`, so it can access the `SlideContext` managed by the Slide component.
 
 NOTE: the vast majority of use cases are covered by the `Stepper` and `Appear` components documented below- in fact, they are implemented via this hook. The only case in which you may need to use this hook explicitly is if you need more precise control over a component in your presentation.
 

--- a/packages/spectacle/src/components/appear.tsx
+++ b/packages/spectacle/src/components/appear.tsx
@@ -16,7 +16,15 @@ const SteppedComponent = (props: SteppedComponentProps): JSX.Element => {
     activeStyle = { opacity: '1' },
     inactiveStyle = { opacity: '0' }
   } = props;
-  const { immediate } = useContext(SlideContext);
+  const slideContext = useContext(SlideContext);
+  if (slideContext === null) {
+    throw new Error(
+      'This component must be used within a SlideContext.Provider. Did you' +
+        ' put an <Appear> or <Stepper> component outside of a <Slide>?'
+    );
+  }
+
+  const { immediate } = slideContext;
 
   const { isActive, step, placeholder } = useSteps(numSteps, {
     id,

--- a/packages/spectacle/src/hooks/use-steps.tsx
+++ b/packages/spectacle/src/hooks/use-steps.tsx
@@ -22,7 +22,15 @@ export function useSteps(
 ) {
   const [stepId] = useState(userProvidedId || ulid);
 
-  const { activeStepIndex, activationThresholds } = useContext(SlideContext);
+  const slideContext = useContext(SlideContext);
+  if (slideContext === null) {
+    throw new Error(
+      '`useSteps` must be called within a SlideContext.Provider. Did you' +
+        ' call `useSteps` in a component that was not placed inside a <Slide>?'
+    );
+  }
+
+  const { activeStepIndex, activationThresholds } = slideContext;
 
   let relStep: number;
 


### PR DESCRIPTION
### Description

This change provides better error messages when useSteps or stepper components are used in the wrong context.

Fixes #1233

#### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

It hasn't been. The destructuring statements that appeared where the error throwing now occurs would throw errors anyway for the same conditions.