### PR TITLE
add a wrapper to make window safe for SSR

### DIFF
--- a/packages/spectacle/src/hooks/use-broadcast-channel.ts
+++ b/packages/spectacle/src/hooks/use-broadcast-channel.ts
@@ -4,7 +4,11 @@ import { BroadcastChannel as BroadcastChannelPolyfill } from 'broadcast-channel'
 import { DeckView } from './use-deck-state';
 
 const noop = () => {};
-const BroadcastChannel = window.BroadcastChannel || BroadcastChannelPolyfill;
+let safeWindow: any = {};
+if (typeof window !== "undefined") {
+  safeWindow = window;
+}
+const BroadcastChannel = safeWindow.BroadcastChannel || BroadcastChannelPolyfill;
 
 type MessageCallback = (message: MessageTypes) => void;
 


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

This commit wraps the window for safe usage in an SSR env (like next.js)

This should be a non functional change for any users running only in browser

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

This has been run locally using SSR

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `pnpm run check:ci` and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
