### PR TITLE
Docs: Update sidebar order and text

### DIFF
--- a/.changeset/swift-bears-grow.md
+++ b/.changeset/swift-bears-grow.md
@@ -1,0 +1,5 @@
+---
+'spectacle-docs': minor
+---
+
+Updated the order of the sidebar items.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
-order: 5
-sidebar_position: 5
+order: 4
+sidebar_position: 4
 ---
 
 # API Reference

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: Extensions
-order: 7
-sidebar_position: 7
+order: 8
+sidebar_position: 8
 ---
 
 # Third Party Extensions

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
-order: 8
-sidebar_position: 8
+order: 9
+sidebar_position: 9
 ---
 
 # Frequently Asked Questions

--- a/docs/props.md
+++ b/docs/props.md
@@ -1,7 +1,7 @@
 ---
 title: Base Props
-order: 3
-sidebar_position: 3
+order: 5
+sidebar_position: 5
 ---
 
 # Base Props

--- a/docs/slide-layouts.md
+++ b/docs/slide-layouts.md
@@ -1,5 +1,10 @@
-import Full from '../website/static/img/slide-layouts/full.png';
+---
+title: Slide Layouts
+order: 6
+sidebar_position: 6
+---
 
+import Full from '../website/static/img/slide-layouts/full.png';
 
 ## SlideLayout
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,7 +1,7 @@
 ---
 title: Themes
-order: 4
-sidebar_position: 4
+order: 7
+sidebar_position: 7
 ---
 
 # Theme System

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
-order: 6
-sidebar_position: 6
+order: 3
+sidebar_position: 3
 ---
 
 # Getting Started with Spectacle: A Tutorial

--- a/packages/spectacle/src/hooks/use-broadcast-channel.ts
+++ b/packages/spectacle/src/hooks/use-broadcast-channel.ts
@@ -5,10 +5,11 @@ import { DeckView } from './use-deck-state';
 
 const noop = () => {};
 let safeWindow: any = {};
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   safeWindow = window;
 }
-const BroadcastChannel = safeWindow.BroadcastChannel || BroadcastChannelPolyfill;
+const BroadcastChannel =
+  safeWindow.BroadcastChannel || BroadcastChannelPolyfill;
 
 type MessageCallback = (message: MessageTypes) => void;
 


### PR DESCRIPTION
### Description

Updates the order of the documentation sidebar and fixes one of the labels.

#### Type of Change

- [x] This change requires a documentation update

Previous:
<img width="295" alt="Screenshot 2023-02-25 at 9 54 32 AM" src="https://user-images.githubusercontent.com/1738349/221367142-0d278e89-5bcf-43f7-aee4-fafd18f15c31.png">

New:
<img width="386" alt="Screenshot 2023-02-25 at 9 58 59 AM" src="https://user-images.githubusercontent.com/1738349/221367145-f97fd23f-1bfb-4c0f-9e03-75d36707d770.png">
