### PR TITLE
Two minor docs fixes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -126,15 +126,15 @@ For instance, suppose we render a slide like this:
   <Stepper tagName="p" alwaysVisible values={['foo', 'bar']}>
     {(value, step, isActive) =>
       isActive
-        ? `The first stepper is not active. Step: ${step} Value: ${value}`
-        : `The first stepper is active. Step: ${step} Value: ${value}`
+        ? `The first stepper is active. Step: ${step} Value: ${value}`
+        : `The first stepper is not active. Step: ${step} Value: ${value}`
     }
   </Stepper>
   <Stepper tagName="p" alwaysVisible values={['baz', 'quux']}>
     {(value, step, isActive) =>
       isActive
-        ? `The second stepper is not active. Step: ${step} Value: ${value}`
-        : `The second stepper is active. Step: ${step} Value: ${value}`
+        ? `The second stepper is active. Step: ${step} Value: ${value}`
+        : `The second stepper is not active. Step: ${step} Value: ${value}`
     }
   </Stepper>
 </Slide>

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -70,7 +70,7 @@ Additionally, there are keys for assorted overrides for the presentation:
 A template in Spectacle is a fixed overlay of components that are presented on every slide. They are similar to masters in Keynote or PowerPoint. It’s a function prop that has a single optional config object containing the current slide and total slide count and returns a React Node.
 
 ```jsx
-<Deck template=(({ slideNumber, numberOfSlides }) => (
+<Deck template={({ slideNumber, numberOfSlides }) => (
   <FlexBox
     justifyContent="space-between"
     position="absolute"
@@ -85,7 +85,7 @@ A template in Spectacle is a fixed overlay of components that are presented on e
       Slide {slideNumber} of {numberOfSlides}
     </Box>
   </FlexBox>
-))>
+)}>
 ```
 
 ## Scaled Spacing


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Includes two fixes for minor docs issues I encountered:

- a syntax error when copying + pasting the template example in `docs/themes.md`
- a backwards ternary that just needed to be flipped (as I understand it)

I haven't created an issue but would be happy to. Thanks!

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `pnpm run check:ci` and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
