### PR TITLE
Update deployment providers

### DIFF
--- a/docs/advanced-concepts.md
+++ b/docs/advanced-concepts.md
@@ -10,7 +10,7 @@ sidebar_position: 2
 
 There are a variety of ways to host your Spectacle presentation.
 
-1. If you are integrating this lib yourself, take your build and follow the linked instructions from any of (but not limited to) the following providers: [Heroku](https://devcenter.heroku.com/articles/git#deploying-code), [Zeit](https://zeit.co/docs/v2/platform/deployments), or [Surge](https://surge.sh/help/deploying-continuously-using-git-hooks).
+1. If you are integrating this lib yourself, take your build and follow the linked instructions from any of (but not limited to) the following providers: [Netlify](https://docs.netlify.com/get-started/#deploy-a-project-to-netlify), [Vercel](https://vercel.com/docs/concepts/deployments/overview), or [Surge](https://surge.sh/help/deploying-continuously-using-git-hooks).
 
 2. If using `spectacle-cli` (either `spectacle --action build` or `spectacle-boilerplate` with `yarn clean && yarn build`) your output is `dist/` and upload that directory to any of the above static hosting providers.
 


### PR DESCRIPTION

### Description

Hi everyone, great package 🙌 
Quick PR to update the links to deployment providers (Zeit -> Vercel) and also replaced `Heroku` with `Netlify` since Heroku is not supporting free plans anymore.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Change in documentation

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have run `pnpm run check:ci` and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
