### PR TITLE
Drop wireit caching from GH Action release build

### DIFF
--- a/.changeset/silent-drinks-chew.md
+++ b/.changeset/silent-drinks-chew.md
@@ -1,0 +1,5 @@
+---
+'spectacle': patch
+---
+
+Remove GA Wireit caching from release builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           node-version: 18.x
 
-      # Wireit cache
-      - uses: google/wireit@setup-github-actions-caching/v1
-
       - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description

Having issues with Wireit cache not invalidating on changed files in GH Actions but locally, we want to avoid pushing releases with incomplete assets.