### PR TITLE
dynamic vercel env

### DIFF
--- a/website/docusaurus-vercel.config.js
+++ b/website/docusaurus-vercel.config.js
@@ -6,7 +6,7 @@ async function createConfig() {
   /** @type {import("@docusaurus/types").Config} */
   const config = {
     ...(await baseConfig()),
-    baseUrl: '/'
+    ...(process.env.VERCEL_ENV === 'preview' && { baseUrl: '/' })
   };
   return config;
 }


### PR DESCRIPTION
This PR is an attempt to: deploy docs at root for preview deploys (see below), but at the nested `/open-source/spectacle` for production deploys (which is needed when we stitch this into formidable.com). Staging/preview view shown below, serving from the root.

![image](https://github.com/FormidableLabs/spectacle/assets/12721310/3c487f0c-4434-4b00-8a5e-508e0e74a7f5)
