### PR TITLE
Fix inclusion of spectacle package.json for CLI

### DIFF
--- a/.changeset/modern-ducks-try.md
+++ b/.changeset/modern-ducks-try.md
@@ -1,0 +1,5 @@
+---
+'create-spectacle': patch
+---
+
+Fix inclusion of Spectacle library package.json

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Copy Spectacle package
+        run: pnpm run --filter ./packages/create-spectacle copy-spectacle-package
+
       - name: Build create-spectacle
         run: pnpm run --filter ./packages/create-spectacle build
 

--- a/packages/create-spectacle/.gitignore
+++ b/packages/create-spectacle/.gitignore
@@ -1,1 +1,2 @@
 tmp
+spectacle-package.json

--- a/packages/create-spectacle/package.json
+++ b/packages/create-spectacle/package.json
@@ -152,6 +152,7 @@
     },
     "test": {
       "dependencies": [
+        "copy-spectacle-package",
         "build"
       ],
       "command": "jest --testMatch=\"<rootDir>/src/*.test.ts\"",

--- a/packages/create-spectacle/package.json
+++ b/packages/create-spectacle/package.json
@@ -4,7 +4,8 @@
   "description": "Project generator for Spectacle",
   "main": "bin/cli.js",
   "files": [
-    "bin/"
+    "bin/",
+    "spectacle-package.json"
   ],
   "bin": "bin/cli.js",
   "author": "Formidable Labs <hello@formidable.com>",
@@ -26,11 +27,12 @@
   "devDependencies": {
     "@types/node": "^18.0.3",
     "@types/prompts": "^2.0.14",
+    "shx": "^0.3.4",
     "spectacle": "*"
   },
   "resolutions": {},
   "scripts": {
-    "dev": "ts-node src/cli.ts",
+    "dev": "pnpm copy-spectacle-package && ts-node src/cli.ts",
     "build": "wireit",
     "types:check": "wireit",
     "lint": "wireit",
@@ -38,6 +40,9 @@
     "prettier": "wireit",
     "prettier:fix": "wireit",
     "test": "wireit",
+    "copy-spectacle-package": "shx cp ../spectacle/package.json ./spectacle-package.json",
+    "prepack": "pnpm copy-spectacle-package",
+    "postpack": "shx rm ./spectacle-package.json",
     "examples:clean": "rimraf .examples",
     "examples:test": "nps jest",
     "examples:jsx:clean": "rimraf .examples/jsx",

--- a/packages/create-spectacle/src/generators/one-page.ts
+++ b/packages/create-spectacle/src/generators/one-page.ts
@@ -1,17 +1,12 @@
-import path from 'path';
 import { onePageTemplate } from '../templates/one-page';
 
-const SPECTACLE_PATH = path.resolve(__dirname, '../../../spectacle');
-const spectaclePackage = require(`${SPECTACLE_PATH}/package.json`);
+const spectaclePackage = require(`${__dirname}/../../spectacle-package.json`);
 const REACT_VERSION = spectaclePackage.devDependencies.react.replace('^', '');
 const ESM_SH_VERSION = 'v121';
 
 export const generateImportMap = () => {
   const importMap = new Map<string, string>();
-  const {
-    dependencies,
-    peerDependencies
-  } = require(`${SPECTACLE_PATH}/package.json`);
+  const { dependencies, peerDependencies } = spectaclePackage;
 
   importMap.set('htm', importUrl('htm', '^3'));
   importMap.set('spectacle', 'https://esm.sh/spectacle@10?bundle');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
         version: 2.4.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.0.3)
+        version: 10.9.1(@types/node@18.0.3)(typescript@4.8.4)
       yargs:
         specifier: ^17.5.1
         version: 17.5.1
@@ -242,6 +242,9 @@ importers:
       '@types/prompts':
         specifier: ^2.0.14
         version: 2.0.14
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
       spectacle:
         specifier: '*'
         version: link:../spectacle
@@ -362,7 +365,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0
+        version: 6.7.0(typescript@4.8.4)
 
   packages/spectacle-mdx-loader:
     dependencies:
@@ -383,25 +386,25 @@ importers:
     devDependencies:
       '@docusaurus/core':
         specifier: ^2.4.0
-        version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/module-type-aliases':
         specifier: ^2.4.0
-        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       '@docusaurus/plugin-client-redirects':
         specifier: ^2.4.0
-        version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/preset-classic':
         specifier: ^2.4.0
-        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/theme-live-codeblock':
         specifier: ^2.4.0
-        version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/theme-search-algolia':
         specifier: ^2.4.0
-        version: 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/types':
         specifier: ^2.4.0
-        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
+        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       '@mdx-js/react':
         specifier: ^1.6.22
         version: 1.6.22(react@17.0.2)
@@ -419,7 +422,7 @@ importers:
         version: 1.2.1
       docusaurus-plugin-sass:
         specifier: ^0.2.2
-        version: 0.2.2(@docusaurus/core@2.4.0)(sass@1.54.4)
+        version: 0.2.2(@docusaurus/core@2.4.0)(sass@1.54.4)(webpack@5.76.0)
       formidable-oss-badges:
         specifier: ^0.5.1
         version: 0.5.2(styled-components@5.3.10)
@@ -443,7 +446,7 @@ importers:
         version: 1.54.4
       sass-loader:
         specifier: ^13.0.2
-        version: 13.0.2(sass@1.54.4)
+        version: 13.0.2(sass@1.54.4)(webpack@5.76.0)
       styled-components:
         specifier: ^5.3.10
         version: 5.3.10(react-dom@17.0.2)(react@17.0.2)
@@ -636,7 +639,7 @@ packages:
       '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       lodash: 4.17.21
@@ -658,10 +661,10 @@ packages:
       '@babel/helpers': 7.19.0
       '@babel/parser': 7.19.3
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
+      '@babel/traverse': 7.19.3(supports-color@5.5.0)
       '@babel/types': 7.19.3
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.1
       semver: 6.3.0
@@ -681,10 +684,10 @@ packages:
       '@babel/helpers': 7.21.5
       '@babel/parser': 7.21.8
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -899,7 +902,7 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -915,7 +918,7 @@ packages:
       '@babel/core': 7.19.3
       '@babel/helper-compilation-targets': 7.19.3(@babel/core@7.19.3)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -931,7 +934,7 @@ packages:
       '@babel/core': 7.21.8
       '@babel/helper-compilation-targets': 7.19.3(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.2
       semver: 6.3.0
@@ -1010,7 +1013,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1025,7 +1028,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
+      '@babel/traverse': 7.19.3(supports-color@5.5.0)
       '@babel/types': 7.19.3
     transitivePeerDependencies:
       - supports-color
@@ -1041,7 +1044,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1107,7 +1110,7 @@ packages:
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1120,7 +1123,7 @@ packages:
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1180,7 +1183,7 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1191,7 +1194,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -1201,7 +1204,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.3
+      '@babel/traverse': 7.19.3(supports-color@5.5.0)
       '@babel/types': 7.19.3
     transitivePeerDependencies:
       - supports-color
@@ -1212,7 +1215,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -3211,28 +3214,10 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.8
       '@babel/types': 7.21.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/traverse@7.19.3:
-    resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.19.3
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.19.3
-      '@babel/types': 7.19.3
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/traverse@7.19.3(supports-color@5.5.0):
     resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
@@ -3247,24 +3232,6 @@ packages:
       '@babel/parser': 7.19.3
       '@babel/types': 7.19.3
       debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/traverse@7.21.5:
-    resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
-      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3285,7 +3252,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types@7.18.10:
     resolution: {integrity: sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==}
@@ -3547,7 +3513,7 @@ packages:
       - '@algolia/client-search'
     dev: true
 
-  /@docusaurus/core@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/core@2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -3564,14 +3530,14 @@ packages:
       '@babel/preset-typescript': 7.18.6(@babel/core@7.21.8)
       '@babel/runtime': 7.19.0
       '@babel/runtime-corejs3': 7.18.9
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@docusaurus/cssnano-preset': 2.4.0
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       '@docusaurus/react-loadable': 5.5.2(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@slorber/static-site-generator-webpack-plugin': 4.0.7
       '@svgr/webpack': 6.3.1
       autoprefixer: 10.4.14(postcss@8.4.23)
@@ -3606,7 +3572,7 @@ packages:
       postcss-loader: 7.0.1(postcss@8.4.23)(webpack@5.76.0)
       prompts: 2.4.2
       react: 17.0.2
-      react-dev-utils: 12.0.1(webpack@5.76.0)
+      react-dev-utils: 12.0.1(eslint@8.24.0)(typescript@4.8.4)(webpack@5.76.0)
       react-dom: 17.0.2(react@17.0.2)
       react-helmet-async: 1.3.0(react-dom@17.0.2)(react@17.0.2)
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.2)
@@ -3623,9 +3589,9 @@ packages:
       update-notifier: 5.1.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.76.0)
       wait-on: 6.0.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.5.0
-      webpack-dev-server: 4.11.1(webpack@5.76.0)
+      webpack-dev-server: 4.11.1(webpack-cli@4.10.0)(webpack@5.76.0)
       webpack-merge: 5.8.0
       webpackbar: 5.0.2(webpack@5.76.0)
     transitivePeerDependencies:
@@ -3663,7 +3629,7 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /@docusaurus/mdx-loader@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/mdx-loader@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3671,9 +3637,9 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@babel/parser': 7.21.8
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@mdx-js/mdx': 1.6.22
       escape-html: 1.0.3
       file-loader: 6.2.0(webpack@5.76.0)
@@ -3688,7 +3654,7 @@ packages:
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.76.0)
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -3698,14 +3664,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/module-type-aliases@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/module-type-aliases@2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==}
     peerDependencies:
       react: '*'
       react-dom: '*'
     dependencies:
       '@docusaurus/react-loadable': 5.5.2(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       '@types/history': 4.7.11
       '@types/react': 18.2.6
       '@types/react-router-config': 5.0.6
@@ -3721,18 +3687,18 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-client-redirects@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-client-redirects@2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       eta: 2.0.1
       fs-extra: 10.1.0
       lodash: 4.17.21
@@ -3756,20 +3722,20 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-blog@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-content-blog@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 10.1.0
@@ -3780,7 +3746,7 @@ packages:
       tslib: 2.4.0
       unist-util-visit: 2.0.3
       utility-types: 3.10.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -3797,20 +3763,20 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-docs@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-content-docs@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@types/react-router-config': 5.0.6
       combine-promises: 1.1.0
       fs-extra: 10.1.0
@@ -3821,7 +3787,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       tslib: 2.4.0
       utility-types: 3.10.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -3838,23 +3804,23 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-pages@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-content-pages@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tslib: 2.4.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -3871,16 +3837,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-debug@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-debug@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -3904,16 +3870,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-analytics@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-google-analytics@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tslib: 2.4.0
@@ -3933,16 +3899,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-gtag@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-google-gtag@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tslib: 2.4.0
@@ -3962,16 +3928,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-tag-manager@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-google-tag-manager@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tslib: 2.4.0
@@ -3991,19 +3957,19 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-sitemap@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/plugin-sitemap@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -4025,26 +3991,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/preset-classic@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/preset-classic@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-docs': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-pages': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-debug': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-google-analytics': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-google-gtag': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-google-tag-manager': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-sitemap': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-classic': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-search-algolia': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-debug': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-google-analytics': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-google-gtag': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-google-tag-manager': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-sitemap': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-classic': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-search-algolia': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -4076,25 +4042,25 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@docusaurus/theme-classic@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/theme-classic@2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-docs': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-pages': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/theme-translations': 2.4.0
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@mdx-js/react': 1.6.22(react@17.0.2)
       clsx: 1.2.1
       copy-text-to-clipboard: 3.0.1
@@ -4126,19 +4092,19 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-common@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/theme-common@2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-blog': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-docs': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/plugin-content-pages': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
       '@types/history': 4.7.11
       '@types/react': 18.2.6
@@ -4168,17 +4134,17 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-live-codeblock@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/theme-live-codeblock@2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-rg+HDWNUvcA0+8DLDJ+4TP5dv5zEgwgrmQmu4hq/sTMbTL1hUBrLCfvSRbX1NQ5zOw+jPhPi740eXwe9XIkmEQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/theme-translations': 2.4.0
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       '@philpl/buble': 0.19.7
       clsx: 1.2.1
       fs-extra: 10.1.0
@@ -4203,7 +4169,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-search-algolia@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/theme-search-algolia@2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -4211,13 +4177,13 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@docsearch/react': 3.2.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/plugin-content-docs': 2.4.0(react-dom@17.0.2)(react@17.0.2)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       '@docusaurus/theme-translations': 2.4.0
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
-      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
+      '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       algoliasearch: 4.14.2
       algoliasearch-helper: 3.11.0(algoliasearch@4.14.2)
       clsx: 1.2.1
@@ -4255,7 +4221,7 @@ packages:
       tslib: 2.4.0
     dev: true
 
-  /@docusaurus/types@2.4.0(react-dom@17.0.2)(react@17.0.2):
+  /@docusaurus/types@2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
@@ -4269,7 +4235,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-helmet-async: 1.3.0(react-dom@17.0.2)(react@17.0.2)
       utility-types: 3.10.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-merge: 5.8.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -4287,16 +4253,16 @@ packages:
       '@docusaurus/types':
         optional: true
     dependencies:
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       tslib: 2.5.0
     dev: true
 
-  /@docusaurus/utils-validation@2.4.0(@docusaurus/types@2.4.0):
+  /@docusaurus/utils-validation@2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==}
     engines: {node: '>=16.14'}
     dependencies:
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0)
       joi: 17.6.0
       js-yaml: 4.1.0
       tslib: 2.5.0
@@ -4309,7 +4275,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/utils@2.4.0(@docusaurus/types@2.4.0):
+  /@docusaurus/utils@2.4.0(@docusaurus/types@2.4.0)(webpack-cli@4.10.0):
     resolution: {integrity: sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -4319,7 +4285,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/types': 2.4.0(react-dom@17.0.2)(react@17.0.2)(webpack-cli@4.10.0)
       '@svgr/webpack': 6.3.1
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.76.0)
@@ -4334,7 +4300,7 @@ packages:
       shelljs: 0.8.5
       tslib: 2.5.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.76.0)
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -4560,7 +4526,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.0
@@ -4587,7 +4553,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5997,7 +5963,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.38.1
       '@typescript-eslint/type-utils': 5.38.1(eslint@8.24.0)(typescript@4.8.4)
       '@typescript-eslint/utils': 5.38.1(eslint@8.24.0)(typescript@4.8.4)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.24.0
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -6021,7 +5987,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.38.1
       '@typescript-eslint/types': 5.38.1
       '@typescript-eslint/typescript-estree': 5.38.1(typescript@4.8.4)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.24.0
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -6048,7 +6014,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.38.1(typescript@4.8.4)
       '@typescript-eslint/utils': 5.38.1(eslint@8.24.0)(typescript@4.8.4)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.24.0
       tsutils: 3.21.0(typescript@4.8.4)
       typescript: 4.8.4
@@ -6072,7 +6038,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.38.1
       '@typescript-eslint/visitor-keys': 5.38.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
@@ -6358,7 +6324,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6704,7 +6670,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /babel-plugin-apply-mdx-type-prop@1.6.22(@babel/core@7.12.9):
@@ -7682,7 +7648,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /core-js-compat@3.24.1:
@@ -7809,7 +7775,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.23)
       postcss-value-parser: 4.2.0
       semver: 7.3.7
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /css-minimizer-webpack-plugin@4.0.0(clean-css@5.3.1)(webpack@5.76.0):
@@ -7838,7 +7804,7 @@ packages:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
       source-map: 0.6.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /css-select@4.3.0:
@@ -8049,17 +8015,6 @@ packages:
     dependencies:
       ms: 2.0.0
     dev: true
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -8278,15 +8233,15 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /docusaurus-plugin-sass@0.2.2(@docusaurus/core@2.4.0)(sass@1.54.4):
+  /docusaurus-plugin-sass@0.2.2(@docusaurus/core@2.4.0)(sass@1.54.4)(webpack@5.76.0):
     resolution: {integrity: sha512-ZZBpj3PrhGpYE2kAnkZB9NRwy/CDi4rGun1oec6PYR8YvGzqxYGtXvLgHi6FFbu8/N483klk8udqyYMh6Ted+A==}
     peerDependencies:
       '@docusaurus/core': ^2.0.0-beta
       sass: ^1.30.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.2)(react@17.0.2)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.24.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.8.4)(webpack-cli@4.10.0)
       sass: 1.54.4
-      sass-loader: 10.3.1(sass@1.54.4)
+      sass-loader: 10.3.1(sass@1.54.4)(webpack@5.76.0)
     transitivePeerDependencies:
       - fibers
       - node-sass
@@ -8740,7 +8695,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -8974,7 +8929,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9104,7 +9059,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /filesize@8.0.7:
@@ -9169,7 +9124,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9278,7 +9233,7 @@ packages:
       for-in: 1.0.2
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.2(webpack@5.76.0):
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.24.0)(typescript@4.8.4)(webpack@5.76.0):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9298,6 +9253,7 @@ packages:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
+      eslint: 8.24.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.4.7
@@ -9305,7 +9261,8 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      webpack: 5.76.0
+      typescript: 4.8.4
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /form-data@4.0.0:
@@ -9973,7 +9930,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10013,7 +9970,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10544,7 +10501,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -10611,7 +10568,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.1.2
+      jest-config: 29.1.2(@types/node@18.7.23)
       jest-util: 29.1.2
       jest-validate: 29.1.2
       prompts: 2.4.2
@@ -10620,44 +10577,6 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config@29.1.2:
-    resolution: {integrity: sha512-EC3Zi86HJUOz+2YWQcJYQXlf0zuBhJoeyxLM6vb6qJsVmpP7KcCP1JnyF0iaqTaXdBP8Rlwsvs7hnKWQWWLwwA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.8
-      '@jest/test-sequencer': 29.1.2
-      '@jest/types': 29.1.2
-      babel-jest: 29.1.2(@babel/core@7.21.8)
-      chalk: 4.1.2
-      ci-info: 3.4.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 29.1.2
-      jest-environment-node: 29.1.2
-      jest-get-type: 29.0.0
-      jest-regex-util: 29.0.0
-      jest-resolve: 29.1.2
-      jest-runner: 29.1.2
-      jest-util: 29.1.2
-      jest-validate: 29.1.2
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.1.2
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-config@29.1.2(@types/node@18.7.23):
@@ -11009,7 +10928,7 @@ packages:
       '@babel/generator': 7.21.5
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.8)
-      '@babel/traverse': 7.21.5
+      '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       '@jest/expect-utils': 29.1.2
       '@jest/transform': 29.1.2
@@ -11814,7 +11733,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -12578,7 +12497,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.23
       semver: 7.3.7
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /postcss-merge-idents@5.1.1(postcss@8.4.23):
@@ -13112,7 +13031,7 @@ packages:
     engines: {node: '>=14.1.0'}
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       devtools-protocol: 0.0.1036444
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -13235,7 +13154,7 @@ packages:
       react: 17.0.2
     dev: true
 
-  /react-dev-utils@12.0.1(webpack@5.76.0):
+  /react-dev-utils@12.0.1(eslint@8.24.0)(typescript@4.8.4)(webpack@5.76.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -13254,7 +13173,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(webpack@5.76.0)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.24.0)(typescript@4.8.4)(webpack@5.76.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13269,7 +13188,8 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      webpack: 5.76.0
+      typescript: 4.8.4
+      webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -13376,7 +13296,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.2)
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /react-router-config@5.1.1(react-router@5.3.3)(react@17.0.2):
@@ -14000,7 +13920,7 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /sass-loader@10.3.1(sass@1.54.4):
+  /sass-loader@10.3.1(sass@1.54.4)(webpack@5.76.0):
     resolution: {integrity: sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -14022,9 +13942,10 @@ packages:
       sass: 1.54.4
       schema-utils: 3.1.1
       semver: 7.3.7
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
-  /sass-loader@13.0.2(sass@1.54.4):
+  /sass-loader@13.0.2(sass@1.54.4)(webpack@5.76.0):
     resolution: {integrity: sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14046,6 +13967,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.54.4
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /sass@1.54.4:
@@ -14326,6 +14248,15 @@ packages:
       rechoir: 0.6.2
     dev: true
 
+  /shx@0.3.4:
+    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
+      shelljs: 0.8.5
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -14508,7 +14439,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -14522,7 +14453,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -14955,7 +14886,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.2
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /terser@5.14.2:
@@ -15146,7 +15077,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.0.3):
+  /ts-node@10.9.1(@types/node@18.0.3)(typescript@4.8.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -15172,6 +15103,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
+      typescript: 4.8.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: false
@@ -15192,7 +15124,7 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /tsup@6.7.0:
+  /tsup@6.7.0(typescript@4.8.4):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -15211,7 +15143,7 @@ packages:
       bundle-require: 4.0.1(esbuild@0.17.18)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       esbuild: 0.17.18
       execa: 5.1.1
       globby: 11.1.0
@@ -15222,6 +15154,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.32.0
       tree-kill: 1.2.2
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -15325,7 +15258,6 @@ packages:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /ua-parser-js@0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -15564,7 +15496,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /url-parse-lax@3.0.0:
@@ -15893,54 +15825,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /webpack-dev-server@4.11.1(webpack@5.76.0):
-    resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.14
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.0
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.0.14
-      chokidar: 3.5.3
-      colorette: 2.0.19
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.1
-      graceful-fs: 4.2.10
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.6(@types/express@4.17.14)
-      ipaddr.js: 2.0.1
-      open: 8.4.0
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.0.0
-      selfsigned: 2.1.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack: 5.76.0
-      webpack-dev-middleware: 5.3.3(webpack@5.76.0)
-      ws: 8.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /webpack-merge@5.8.0:
     resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
     engines: {node: '>=10.0.0'}
@@ -15952,46 +15836,6 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
-
-  /webpack@5.76.0:
-    resolution: {integrity: sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 0.0.51
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.8.0
-      acorn-import-assertions: 1.8.0(acorn@8.8.0)
-      browserslist: 4.21.4
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.10.0
-      es-module-lexer: 0.9.3
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.1.1
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.3(webpack@5.76.0)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
     dev: true
 
   /webpack@5.76.0(webpack-cli@4.10.0):
@@ -16045,7 +15889,7 @@ packages:
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.2.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
     dev: true
 
   /websocket-driver@0.7.4:


### PR DESCRIPTION
The CLI requires the `package.json` to correctly load the right dependencies. Since it was outside of the main source package for the CLI, it was not getting included, but looked correct locally. This uses a build script to copy the package in for packaging then remove after. Below are screenshots showing a local `npm pack` with the file included and the CLI working from what `npm pack` generated.

<img width="1018" alt="Screenshot 2023-12-18 at 1 49 18 PM" src="https://github.com/FormidableLabs/spectacle/assets/1738349/af2ed4a6-b007-4871-bb89-5c0361c8d8a6">
<img width="1018" alt="Screenshot 2023-12-18 at 1 49 16 PM" src="https://github.com/FormidableLabs/spectacle/assets/1738349/f3b12614-5063-47e7-be74-02c72bdcbcab">
