### PR TITLE
fix: add `raw-loader` to template package closes #1316

### DIFF
--- a/packages/create-spectacle/src/templates/package.ts
+++ b/packages/create-spectacle/src/templates/package.ts
@@ -33,6 +33,7 @@ export const packageTemplate = (options: PackageTemplateOptions) =>
         'style-loader': '^3.3.1',
         'css-loader': '^5.1.3',
         'file-loader': '^6.2.0',
+        'raw-loader': '^4.0.2',
         rimraf: '^3.0.0',
         webpack: '^5.68.0',
         'webpack-cli': '^4.5.0',


### PR DESCRIPTION
**before**

<img width="1800" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/360936/8ce7b3a1-f3e1-4d2f-8cb1-f5e1758a4232">

**after**

![CleanShot 2024-02-23 at 16 51 22@2x](https://github.com/FormidableLabs/spectacle/assets/360936/f81893ff-8f85-40c6-a6c0-8775bc66aed0)
