### PR TITLE
update query-string

### DIFF
--- a/.changeset/four-trainers-fly.md
+++ b/.changeset/four-trainers-fly.md
@@ -1,0 +1,5 @@
+---
+'spectacle': patch
+---
+
+security update: update query-string to fix decode-uri-component vulnerability in 0.2.0

--- a/examples/one-page/index.html
+++ b/examples/one-page/index.html
@@ -22,7 +22,7 @@
           "mdast-zone": "https://esm.sh/v121/mdast-zone@^4.0.0?deps=react@18.2.0",
           "merge-anything": "https://esm.sh/v121/merge-anything@^3.0.3?deps=react@18.2.0",
           "mousetrap": "https://esm.sh/v121/mousetrap@^1.6.5?deps=react@18.2.0",
-          "query-string": "https://esm.sh/v121/query-string@^7.1.1?deps=react@18.2.0",
+          "query-string": "https://esm.sh/v121/query-string@^7.1.3?deps=react@18.2.0",
           "react": "https://esm.sh/v121/react@18.2.0?deps=react@18.2.0",
           "react/jsx-runtime": "https://esm.sh/v121/react@18.2.0/jsx-runtime?deps=react@18.2.0",
           "react-dom": "https://esm.sh/v121/react-dom@>=18.0.0?deps=react@18.2.0",

--- a/packages/spectacle/package.json
+++ b/packages/spectacle/package.json
@@ -24,7 +24,7 @@
     "mdast-zone": "^4.0.0",
     "merge-anything": "^3.0.3",
     "mousetrap": "^1.6.5",
-    "query-string": "^7.1.1",
+    "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.0",
     "react-is": "^18.1.0",
     "react-spring": "^9.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,8 +276,8 @@ importers:
         specifier: ^1.6.5
         version: 1.6.5
       query-string:
-        specifier: ^7.1.1
-        version: 7.1.1
+        specifier: ^7.1.3
+        version: 7.1.3
       react-fast-compare:
         specifier: ^3.2.0
         version: 3.2.0
@@ -8045,8 +8045,8 @@ packages:
     resolution: {integrity: sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==}
     dev: true
 
-  /decode-uri-component@0.2.0:
-    resolution: {integrity: sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==}
+  /decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
     dev: false
 
@@ -13059,11 +13059,11 @@ packages:
       side-channel: 1.0.4
     dev: true
 
-  /query-string@7.1.1:
-    resolution: {integrity: sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==}
+  /query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
     dependencies:
-      decode-uri-component: 0.2.0
+      decode-uri-component: 0.2.2
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0


### PR DESCRIPTION
## Description

In order to increment `decode-uri-component` to the proper version in `pnpm-lock.yaml`, I had to increment `query-string` package.

Fixes part of #1318  

[fixes dependabot security alert 171](https://github.com/FormidableLabs/spectacle/security/dependabot/171)



