### PR TITLE
stop using node 16 in pipelines / clear other pipeline warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,11 @@ jobs:
   build:
     name: Check and build codebase
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1
@@ -52,7 +49,7 @@ jobs:
       # - name: Clear all caches
       #   run: pnpm clean:cache
 
-      - name: Build Code and Examples ${{ matrix.node-version }}
+      - name: Build Code and Examples
         run: pnpm run build
 
       # We build in-source files like `examples/one-page/index.html`.
@@ -60,5 +57,5 @@ jobs:
       - name: Check generated in-source files
         run: git diff --no-ext-diff --quiet --exit-code
 
-      - name: Check Code ${{ matrix.node-version }}
+      - name: Check Code
         run: pnpm run check:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  PNPM_STORE_PATH: ''
+
 # Runs build and test on:
 #   every push that has a change in a file not in the docs folder
 #   every pull request with main branch as the base that has a change
@@ -26,17 +29,21 @@ jobs:
       - uses: google/wireit@setup-github-actions-caching/v1
 
       - uses: pnpm/action-setup@v3
+        name: Install pnpm
         with:
+          run_install: false
           version: 7
 
       - name: Get pnpm store directory
+        shell: bash
         id: pnpm-cache
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+        run: |
+          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  PNPM_STORE_PATH: ''
-
 # Runs build and test on:
 #   every push that has a change in a file not in the docs folder
 #   every pull request with main branch as the base that has a change
@@ -23,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          cache: 'pnpm'
           node-version: 18.x
 
       # Wireit cache
@@ -33,20 +31,6 @@ jobs:
         with:
           run_install: false
           version: 7
-
-      - name: Get pnpm store directory
-        shell: bash
-        id: pnpm-cache
-        run: |
-          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     name: Check and build codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v3
         with:
           version: 7
 
@@ -34,7 +34,7 @@ jobs:
         run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          run_install: false
           version: 7
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          run_install: false
+          version: 7
+
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
@@ -25,12 +31,6 @@ jobs:
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-          version: 7
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -47,7 +47,7 @@ jobs:
           echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -28,7 +28,6 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          run_install: false
           version: 7
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -25,6 +25,12 @@ jobs:
         create-type: ['tsx', 'onepage']
     steps:
       - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          run_install: false
+          version: 7
+
       - uses: actions/setup-node@v4
         with:
           cache: 'pnpm'
@@ -32,12 +38,6 @@ jobs:
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1
-
-      - uses: pnpm/action-setup@v3
-        name: Install pnpm
-        with:
-          run_install: false
-          version: 7
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -1,8 +1,5 @@
 name: create-spectacle
 
-env:
-  PNPM_STORE_PATH: ''
-
 on:
   push:
     branches:
@@ -30,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          cache: 'pnpm'
           node-version: ${{ matrix.node-version }}
 
       # Wireit cache
@@ -40,19 +38,6 @@ jobs:
         with:
           run_install: false
           version: 7
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/create-spectacle.yml
+++ b/.github/workflows/create-spectacle.yml
@@ -1,5 +1,8 @@
 name: create-spectacle
 
+env:
+  PNPM_STORE_PATH: ''
+
 on:
   push:
     branches:
@@ -24,26 +27,29 @@ jobs:
         node-version: [18.x]
         create-type: ['tsx', 'onepage']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       # Wireit cache
       - uses: google/wireit@setup-github-actions-caching/v1
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
         with:
+          run_install: false
           version: 7
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+        run: |
+          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('./pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Spectacle Release Workflow
 
+env:
+  PNPM_STORE_PATH: ''
+
 on:
   push:
     branches:
@@ -18,27 +21,29 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v3
         with:
+          run_install: false
           version: 7
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+        run: |
+          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          run_install: false
           version: 7
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Spectacle Release Workflow
 
-env:
-  PNPM_STORE_PATH: ''
-
 on:
   push:
     branches:
@@ -28,25 +25,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
+          cache: 'pnpm'
           node-version: 18.x
 
       - uses: pnpm/action-setup@v3
         with:
           run_install: false
           version: 7
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PNPM_STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          cache: 'pnpm'
-          node-version: 18.x
-
       - uses: pnpm/action-setup@v3
         with:
           run_install: false
           version: 7
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version: 18.x
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
### Description

As directed by Cb, we're no longer supporting node16, and will likely not use node matrixes anymore to build / test various node versions.

This pr removes usage of node 16 and matrix, as well as works to clean up some warnings due to using older versions of Github actions such as `setup-node` and `actions/cache` etc.

Fixes #1322 & #1323

## ci.yml

### Before updating `ci.yml` (lots of warnings):
<img width="1894" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/3632381/9364b708-59a4-43d8-a867-d0e0c5ed5b25">


### After updating `ci.yml` (no warnings):
<img width="1893" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/3632381/7852b6da-b6ed-4dbc-9481-b742a4075b3a">

## create-spectacle.yml

### before: 

<img width="1893" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/3632381/d4ee35b7-c05d-40e9-94a3-5553dae87020">

### after:

<img width="1897" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/3632381/ad8bf3bb-a721-4855-9422-d45c66ac2789">

## release.yml

### before:
<img width="1896" alt="image" src="https://github.com/FormidableLabs/spectacle/assets/3632381/8186948b-bb3d-4392-a19f-b387afdb985d">

### after:
release isn't ran until a merge / push is made to master, so I cannot obtain a screenshot of the results without doing some trickery. If needed I can do so, but the changes are essentially the same as the other two files, so seems probably unnecessary.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Chore / tech debt cleanup

### How Has This Been Tested?

1. I verified in the pipelines that the pnpm cache path is still retrieved and set correctly, and warnings were removed
2. I built and ran all the sample applications locally

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a [changeset](../CONTRIBUTING.md#changesets) if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run `pnpm run check:ci` and all checks pass
- [x] My changes generate no new warnings
