### PR TITLE
chore: clean up old spectacle mdx links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ Have you read Formidable's Code of Conduct? By filing an Issue, you are expected
 <!-- Feel free to delete this section if you have checked off all of the following: -->
 
 - [ ] I have searched the open [issues](https://www.github.com/FormidableLabs/spectacle/issues) to make sure I'm not opening a duplicate issue
-- [ ] I have read through the [docs](https://www.formidable.com/open-source/spectacle/docs) before asking a question
+- [ ] I have read through the [docs](https://commerce.nearform.com/open-source/spectacle/docs) before asking a question
 - [ ] I am using the latest version of Spectacle
 
 ### Describe Your Environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ For exceptional circumstances, here is a quick guide to manually publish from a 
    $ pnpm changeset publish --otp=<insert otp code>
    ```
 
-   Note that publishing multiple pacakges via `changeset` to npm with an OTP code can often fail with `429 Too Many Requests` rate limiting error. Take a 5+ minute coffee break, then come back and try again.
+   Note that publishing multiple packages via `changeset` to npm with an OTP code can often fail with `429 Too Many Requests` rate limiting error. Take a 5+ minute coffee break, then come back and try again.
 
    Then issue the following to also push git tags:
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Please see our [contributing guide](CONTRIBUTING.md).
 
 **Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 
-[docs site]: https://www.formidable.com/open-source/spectacle/docs/
+[docs site]: https://commerce.nearform.com/open-source/spectacle/docs/

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,4 +29,4 @@ For complete documentation of the CLI, please check out [the repository](https:/
 
 A webpack MDX loader for Spectacle presentations.
 
-See [the repository](https://www.github.com/FormidableLabs/spectacle-mdx-loader) for usage, integration, and more information.
+Check [here](../packages/spectacle-mdx-loader/) for usage, integration, and more information.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,4 +29,4 @@ For complete documentation of the CLI, please check out [the repository](https:/
 
 A webpack MDX loader for Spectacle presentations.
 
-Check [here](../packages/spectacle-mdx-loader/) for usage, integration, and more information.
+Check [the repository](https://github.com/FormidableLabs/spectacle/tree/main/packages/spectacle-mdx-loader) for usage, integration, and more information.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -82,7 +82,7 @@ Spectacle also has a presenter mode that allows you to view your slides and note
 
 ## Documentation, Contributing, and Source
 
-For more information about Spectacle and its components, check out [the docs](https://formidable.com/open-source/spectacle).
+For more information about Spectacle and its components, check out [the docs](https://commerce.nearform.com/open-source/spectacle).
 
 Interested in helping out or seeing what's happening under the hood? Spectacle is maintained [on Github](https://github.com/FormidableLabs/spectacle) and you can [start contributing here](https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md).
 

--- a/packages/spectacle-mdx-loader/README.md
+++ b/packages/spectacle-mdx-loader/README.md
@@ -68,7 +68,7 @@ render(<Deck />, document.getElementById('root'));
 [npm_site]: http://badge.fury.io/js/spectacle-mdx-loader
 [mdx]: https://mdxjs.com/
 [webpack]: https://webpack.js.org/
-[spectacle]: https://formidable.com/open-source/spectacle/
+[spectacle]: https://commerce.nearform.com/open-source/spectacle/
 [npx]: https://www.npmjs.com/package/npx
 [maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg?color=brightgreen&style=flat
 

--- a/website/src/components/index/_content.ts
+++ b/website/src/components/index/_content.ts
@@ -192,13 +192,13 @@ const content = {
         title: 'Victory',
         description:
           'An ecosystem of modular data visualization components for React. Friendly and flexible.',
-        link: 'https://formidable.com/open-source/victory'
+        link: 'https://commerce.nearform.com/open-source/victory'
       },
       {
         title: 'urql',
         description:
           'Universal React Query Library is a blazing-fast GraphQL client, exposed as a set of ReactJS components.',
-        link: 'https://formidable.com/open-source/urql/'
+        link: 'https://commerce.nearform.com/open-source/urql/'
       },
       {
         title: 'Runpkg',
@@ -210,7 +210,7 @@ const content = {
       }
     ],
     buttonText: 'View All',
-    buttonUrl: 'https://formidable.com/open-source/'
+    buttonUrl: 'https://commerce.nearform.com/open-source/'
   }
 };
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Home() {
         <meta property="og:type" content="website" />
         <meta
           property="og:url"
-          content="http://www.formidable.com/open-source/spectacle/"
+          content="http://commerce.nearform.com/open-source/spectacle/"
         />
         <meta
           property="og:description"


### PR DESCRIPTION
### Description

As part of marking spectacle-mdx-loader repository as  read-only, I went through and audited our links within spectacle monorepo which pointed to the old repo or were out of date.

I also fixed some of the formidable.com links as well.

Once we publish this, the URL shown in npm for spectacle-mdx-loader should hopefully update to point to the monorepo instead. (it currently still points to the old repo)

Fixes # (issue)

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

verified links are good
