### PR TITLE
Bug(CI): Fix missing quotes in install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Upgrade npm for OIDC
-        run: npm i -g npm@>=11.5.1
+        run: npm i -g npm@">=11.5.1"
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Missed some bash escaping for the `>=` semver range.