### PR TITLE
Fix: Add missing raw-loader dependency

### DIFF
--- a/packages/create-spectacle/src/templates/package.ts
+++ b/packages/create-spectacle/src/templates/package.ts
@@ -33,6 +33,7 @@ export const packageTemplate = (options: PackageTemplateOptions) =>
         'style-loader': '^3.3.1',
         'css-loader': '^5.1.3',
         'file-loader': '^6.2.0',
+        "raw-loader": "^4.0.2",
         rimraf: '^3.0.0',
         webpack: '^5.68.0',
         'webpack-cli': '^4.5.0',


### PR DESCRIPTION
### Description

I added a missing development dependency, `raw-loader`, to the template `package.json` that `create-spectacle` uses to generate new codebases. Without the dependency, `npm start` fails when using the code generated by `create-spectacle` for Markdown decks.

Fixes #1316 and #1309

#### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I built the `create-spectacle` package and ran the resulting `bin/cli.js`. I created a new codebase for a Markdown deck using the package. I ran the development server using `npm start`. The development server started successfully.